### PR TITLE
fixed constraints handling in the simulator

### DIFF
--- a/scientific_library/tvb/simulator/simulator.py
+++ b/scientific_library/tvb/simulator/simulator.py
@@ -207,11 +207,11 @@ class Simulator(HasTraits):
                 indices.append(self.model.state_variables.index(sv))
                 boundaries.append(sv_bounds)
             sort_inds = numpy.argsort(indices)
-            self.integrator.constraint_state_variable_indices = numpy.array(indices)[sort_inds]
-            self.integrator.constraint_state_variable_boundaries = numpy.array(boundaries)[sort_inds]
+            self.integrator.bounded_state_variable_indices = numpy.array(indices)[sort_inds]
+            self.integrator.state_variable_boundaries = numpy.array(boundaries)[sort_inds]
         else:
-            self.integrator.constraint_state_variable_indices = None
-            self.integrator.constraint_state_variable_boundaries = None
+            self.integrator.bounded_state_variable_indices = None
+            self.integrator.state_variable_boundaries = None
         # monitors needs to be a list or tuple, even if there is only one...
         if not isinstance(self.monitors, (list, tuple)):
             self.monitors = [self.monitors]


### PR DESCRIPTION
The constraints are transferred from the `Model` to the `Integrator` in the `Simulator.preconfigure` function. However, while it correctly takes the `Model.state_variable_boundaries`, it creates an incorrect attributes `Integrator.constraint_state_variable_indices` and `Integratorconstraint_state_variable_boundaries`. These are then not used in the integration. 

See the before / after time series for a variable with [0, np.inf] constraint:

![download (8)](https://user-images.githubusercontent.com/833828/68843882-23616500-06c9-11ea-9d63-129b4e2c3775.png)


![download (7)](https://user-images.githubusercontent.com/833828/68843847-16dd0c80-06c9-11ea-9aae-413c0b86fca7.png)


