### PR TITLE
WIP Test GitHub Actions for CI Docker image build

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -12,3 +12,9 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build the Docker image
       run: cd tvb_build/docker && docker build . --file Dockerfile --tag tvb
+    - name: Login to registry
+      run: docker login docker.pkg.github.com -u USERNAME -p ${{ secrets.GITHUB_TOKEN }}
+    - name: Tag new image for registry
+      run: docker tag tvb docker.pkg.github.com/the-virtual-brain/tvb-root/tvb:latest
+    - name: Push image to registry
+      run: docker push docker.pkg.github.com/the-virtual-brain/tvb-root/tvb:latest

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,14 @@
+name: Build Docker image
+
+on: [push]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build the Docker image
+      run: cd tvb_build/docker && docker build . --file Dockerfile --tag tvb


### PR DESCRIPTION
GitHub added actions which looked a lot like GitLab's CI or Jenkins in functionality.  It would be nice if only for our PR workflow to have the checks that tests pass and that the images are built.  This doesn't replace Travis/Jenkins for TVB but instead complements the Git workflow.