### PR TITLE
Correct boundaries

### DIFF
--- a/scientific_library/tvb/simulator/integrators.py
+++ b/scientific_library/tvb/simulator/integrators.py
@@ -464,17 +464,21 @@ class SciPySDE(SciPyODEBase):
             self.clamp_state(X_next)
         return X_next
 
+
 class VODE(SciPyODE, Integrator):
     _scipy_ode_integrator_name = "vode"
     _ui_name = "Variable-order Adams / BDF"
+
 
 class VODEStochastic(SciPySDE, IntegratorStochastic):
     _scipy_ode_integrator_name = "vode"
     _ui_name = "Stochastic variable-order Adams / BDF"
 
+
 class Dopri5(SciPyODE, Integrator):
     _scipy_ode_integrator_name = "dopri5"
     _ui_name = "Dormand-Prince, order (4, 5)"
+
 
 class Dopri5Stochastic(SciPySDE, IntegratorStochastic):
     _scipy_ode_integrator_name = "dopri5"

--- a/scientific_library/tvb/simulator/integrators.py
+++ b/scientific_library/tvb/simulator/integrators.py
@@ -443,6 +443,10 @@ class SciPyODEBase(object):
         return self._ode.integrate(self._ode.t + self.dt).reshape(X.shape) + self.dt * stimulus
 
 
+# TODO: Find a solution for boundary application for intermediate steps of SciPy O/SDE solvers
+# Right now they would behave differently than the TVB ones.
+
+
 class SciPyODE(SciPyODEBase):
 
     def scheme(self, X, dfun, coupling, local_coupling, stimulus):

--- a/scientific_library/tvb/simulator/models/base.py
+++ b/scientific_library/tvb/simulator/models/base.py
@@ -82,16 +82,19 @@ class Model(HasTraits):
         self._build_observer()
         # Make sure that if there are any state variable boundaries, ...
         if isinstance(self.state_variable_boundaries, dict):
-            for sv, bounds in self. state_variable_boundaries.items():
+            for sv, sv_bounds in self.state_variable_boundaries.items():
                 try:
                     # ...the boundaries correspond to model's state variables,
                     self.state_variables.index(sv)
                 except:
                     # TODO: Add the correct type of error and error message
                     raise
-                # and for every two sided constraint, the left boundary is lower than the right one
-                if bounds[0] is not None and bounds[1] is not None:
-                    assert bounds[0] <= bounds[1]
+                for i_bound, (sv_bound, inf, default) in enumerate(zip(sv_bounds,
+                                                                       [-numpy.inf, numpy.inf],
+                                                                       [numpy.finfo("single").min,
+                                                                        numpy.finfo("single").max])):
+                    if sv_bound is None or sv_bound == inf:
+                        sv_bounds[i_bound] = default
         elif self.state_variable_boundaries is not None:
             # TODO: Add here a warning or, even, error?
             self.state_variable_boundaries = None

--- a/scientific_library/tvb/simulator/simulator.py
+++ b/scientific_library/tvb/simulator/simulator.py
@@ -208,7 +208,7 @@ class Simulator(HasTraits):
                 boundaries.append(sv_bounds)
             sort_inds = numpy.argsort(indices)
             self.integrator.bounded_state_variable_indices = numpy.array(indices)[sort_inds]
-            self.integrator.state_variable_boundaries = numpy.array(boundaries)[sort_inds]
+            self.integrator.state_variable_boundaries = numpy.array(boundaries).astype("float64")[sort_inds]
         else:
             self.integrator.bounded_state_variable_indices = None
             self.integrator.state_variable_boundaries = None

--- a/scientific_library/tvb/simulator/simulator.py
+++ b/scientific_library/tvb/simulator/simulator.py
@@ -190,16 +190,7 @@ class Simulator(HasTraits):
             return True
         return False
 
-    def preconfigure(self):
-        """Configure just the basic fields, so that memory can be estimated."""
-        self.connectivity.configure()
-        if self.surface:
-            self.surface.configure()
-        if self.stimulus:
-            self.stimulus.configure()
-        self.coupling.configure()
-        self.model.configure()
-        self.integrator.configure()
+    def _configure_integrator_boundaries(self):
         if self.model.state_variable_boundaries is not None:
             indices = []
             boundaries = []
@@ -212,6 +203,18 @@ class Simulator(HasTraits):
         else:
             self.integrator.bounded_state_variable_indices = None
             self.integrator.state_variable_boundaries = None
+
+    def preconfigure(self):
+        """Configure just the basic fields, so that memory can be estimated."""
+        self.connectivity.configure()
+        if self.surface:
+            self.surface.configure()
+        if self.stimulus:
+            self.stimulus.configure()
+        self.coupling.configure()
+        self.model.configure()
+        self.integrator.configure()
+        self._configure_integrator_boundaries()
         # monitors needs to be a list or tuple, even if there is only one...
         if not isinstance(self.monitors, (list, tuple)):
             self.monitors = [self.monitors]

--- a/scientific_library/tvb/tests/library/simulator/integrators_test.py
+++ b/scientific_library/tvb/tests/library/simulator/integrators_test.py
@@ -132,9 +132,9 @@ class TestIntegrators(BaseTestCase):
     def test_scipy_dopri5(self):
         self._scipy_scheme_tester('Dopri5')
 
-    def test_bounds(self):
-        min_float = numpy.finfo("single").min
-        max_float = numpy.finfo("single").max
+    def test_boundaries(self):
+        min_float = numpy.finfo("double").min
+        max_float = numpy.finfo("double").max
         bounded_state_variable_indices = numpy.r_[0, 1, 2, 3]
         state_variable_boundaries = numpy.array([[0.0, 1.0], [min_float, 1.0],
                                                  [0.0, max_float], [min_float, max_float]], dtype=float)

--- a/scientific_library/tvb/tests/library/simulator/integrators_test.py
+++ b/scientific_library/tvb/tests/library/simulator/integrators_test.py
@@ -46,6 +46,12 @@ from tvb.simulator import noise
 dt = integrators.Integrator.dt.default
 
 
+INTEGRATORStoTEST = [integrators.HeunDeterministic, integrators.HeunStochastic,
+                     integrators.EulerDeterministic, integrators.EulerStochastic,
+                     integrators.RungeKutta4thOrderDeterministic,
+                     integrators.VODE, integrators.VODEStochastic]
+
+
 class TestIntegrators(BaseTestCase):
     """
     Define test cases for coupling:
@@ -126,32 +132,41 @@ class TestIntegrators(BaseTestCase):
     def test_scipy_dopri5(self):
         self._scipy_scheme_tester('Dopri5')
 
-    def test_bound(self):
+    def test_bounds(self):
         min_float = numpy.finfo("single").min
         max_float = numpy.finfo("single").max
-        vode = integrators.VODE(
-            bounded_state_variable_indices=numpy.r_[0, 1, 2, 3],
-            state_variable_boundaries=numpy.array([[0.0, 1.0], [min_float, 1.0],
-                                                   [0.0, max_float], [min_float, max_float]], dtype=float)
-        )
+        bounded_state_variable_indices = numpy.r_[0, 1, 2, 3]
+        state_variable_boundaries = numpy.array([[0.0, 1.0], [min_float, 1.0],
+                                                 [0.0, max_float], [min_float, max_float]], dtype=float)
         x = numpy.ones((5, 4, 2))
         x[:, 0, ] = -x[:, 0, ]
         x[:, 1, ] = 2 * x[:, 1, ]
         x0 = numpy.array(x)
-        dfun = lambda state, node_coupling, local_coupling=0.0: 0.0*state
-        x = vode.scheme(x, dfun, 0.0, 0.0, 0.0)
-        for idx, val in zip(vode.bounded_state_variable_indices, vode.state_variable_boundaries):
-            if idx == 0:
-                assert numpy.all(x[idx] >= val[0])
-                assert numpy.all(x[idx] <= val[1])
-            elif idx == 1:
-                assert numpy.all(x[idx] <= val[1])
-                assert numpy.allclose(x[idx, 0], x0[idx, 0], atol=0.2)
-            elif idx == 2:
-                assert numpy.all(x[idx] >= val[0])
-                assert numpy.all(x[idx, 1] == x0[idx, 1])
-            else:
-                assert numpy.all(x[idx] == x0[idx])
+        dfun = lambda state, node_coupling, local_coupling=0.0: 0.0 * state
+        for integrator_class in INTEGRATORStoTEST:
+            integrator = integrator_class(
+                bounded_state_variable_indices=bounded_state_variable_indices,
+                state_variable_boundaries=state_variable_boundaries)
+            integrator.dt = dt
+            try:
+                # Set noise to 0 if this is a stochastic integrator
+                integrator.noise.nsig = numpy.array([0.0])
+                integrator.noise.dt = dt
+            except:
+                pass
+            x = integrator.scheme(x, dfun, 0.0, 0.0, 0.0)
+            for idx, val in zip(integrator.bounded_state_variable_indices, integrator.state_variable_boundaries):
+                if idx == 0:
+                    assert numpy.all(x[idx] >= val[0])
+                    assert numpy.all(x[idx] <= val[1])
+                elif idx == 1:
+                    assert numpy.all(x[idx] <= val[1])
+                    assert numpy.allclose(x[idx, 0], x0[idx, 0], atol=0.2)
+                elif idx == 2:
+                    assert numpy.all(x[idx] >= val[0])
+                    assert numpy.all(x[idx, 1] == x0[idx, 1])
+                else:
+                    assert numpy.all(x[idx] == x0[idx])
 
     def test_clamp(self):
         vode = integrators.VODE(

--- a/scientific_library/tvb/tests/library/simulator/models_test.py
+++ b/scientific_library/tvb/tests/library/simulator/models_test.py
@@ -99,18 +99,19 @@ class TestModels(BaseTestCase):
         assert (len(model.variables_of_interest), 10, model.number_of_modes) == obser.shape
         return state, obser
 
-    def test_model_bounds_config(self):
+    def test_sv_boundaries_setup(self):
         model = TestBoundsModel()
         model.configure()
-        min_float = numpy.finfo("single").min
-        max_float = numpy.finfo("single").max
+        min_float = numpy.finfo("double").min
+        max_float = numpy.finfo("double").max
+        min_positive = 1.0/numpy.finfo("single").max
         state_variable_boundaries = \
             {"x1": numpy.array([0.0, 1.0]),
              "x2": numpy.array([min_float, 1.0]),
              "x3": numpy.array([0.0, max_float]),
              "x4": numpy.array([min_float, max_float])}
         for sv, sv_bounds in state_variable_boundaries.items():
-            assert numpy.all(sv_bounds == model.state_variable_boundaries[sv])
+            assert numpy.allclose(sv_bounds, model.state_variable_boundaries[sv], min_positive)
 
     def test_wilson_cowan(self):
         """

--- a/scientific_library/tvb/tests/library/simulator/models_test.py
+++ b/scientific_library/tvb/tests/library/simulator/models_test.py
@@ -36,8 +36,38 @@ Test for tvb.simulator.models module
 """
 
 from tvb.tests.library.base_testcase import BaseTestCase
+from tvb.basic.neotraits.api import NArray, Final, List, Range
 from tvb.simulator import models
+from tvb.simulator.models.base import Model
 import numpy
+
+
+class TestBoundsModel(Model):
+    # Used for phase-plane axis ranges and to bound random initial() conditions.
+    state_variable_boundaries = Final(
+        label="State Variable boundaries [lo, hi]",
+        default={"x1": numpy.array([0.0, 1.0]),
+                 "x2": numpy.array([None, 1.0]),
+                 "x3": numpy.array([0.0, None]),
+                 "x4": numpy.array([-numpy.inf, numpy.inf])
+                 },
+        doc="""The values for each state-variable should be set to encompass
+            the boundaries of the dynamic range of that state-variable. Set None for one-sided boundaries""")
+
+    variables_of_interest = List(
+        of=str,
+        label="Variables watched by Monitors",
+        choices=('x1', 'x2', 'x3', 'x4', 'x5'),
+        default=('x1', 'x2', 'x3', 'x4', 'x5'),
+        doc="""default state variables to be monitored""")
+
+    state_variables = ['x1', 'x2', 'x3', 'x4', 'x5']
+    _nvar = 5
+    cvar = numpy.array([0], dtype=numpy.int32)
+
+    def dfun(self, state, node_coupling, local_coupling=0.0):
+
+        return 0.0*state
 
 
 class TestModels(BaseTestCase):
@@ -68,6 +98,19 @@ class TestModels(BaseTestCase):
         obser = model.observe(state)
         assert (len(model.variables_of_interest), 10, model.number_of_modes) == obser.shape
         return state, obser
+
+    def test_model_bounds_config(self):
+        model = TestBoundsModel()
+        model.configure()
+        min_float = numpy.finfo("single").min
+        max_float = numpy.finfo("single").max
+        state_variable_boundaries = \
+            {"x1": numpy.array([0.0, 1.0]),
+             "x2": numpy.array([min_float, 1.0]),
+             "x3": numpy.array([0.0, max_float]),
+             "x4": numpy.array([min_float, max_float])}
+        for sv, sv_bounds in state_variable_boundaries.items():
+            assert numpy.all(sv_bounds == model.state_variable_boundaries[sv])
 
     def test_wilson_cowan(self):
         """

--- a/scientific_library/tvb/tests/library/simulator/simulator_test.py
+++ b/scientific_library/tvb/tests/library/simulator/simulator_test.py
@@ -178,3 +178,17 @@ class TestSimulator(BaseTestCase):
         result = test_simulator.run_simulation(simulation_length=2)
 
         assert len(test_simulator.monitors) == len(result)
+
+    def test_configure_integrator_boundaries(self):
+        from . models_test import TestBoundsModel
+        test_simulator = simulator.Simulator()
+        test_simulator.model = TestBoundsModel()
+        test_simulator.model.configure()
+        test_simulator.integrator.configure()
+        test_simulator._configure_integrator_boundaries()
+        assert numpy.all(test_simulator.integrator.bounded_state_variable_indices == numpy.array([0, 1, 2, 3]))
+        min_float = numpy.finfo("single").min
+        max_float = numpy.finfo("single").max
+        state_variable_boundaries = numpy.array([[0.0, 1.0], [min_float, 1.0],
+                                                 [0.0, max_float], [min_float, max_float]]).astype("float64")
+        assert numpy.all(state_variable_boundaries == test_simulator.integrator.state_variable_boundaries)

--- a/scientific_library/tvb/tests/library/simulator/simulator_test.py
+++ b/scientific_library/tvb/tests/library/simulator/simulator_test.py
@@ -179,7 +179,7 @@ class TestSimulator(BaseTestCase):
 
         assert len(test_simulator.monitors) == len(result)
 
-    def test_configure_integrator_boundaries(self):
+    def test_integrator_boundaries_config(self):
         from . models_test import TestBoundsModel
         test_simulator = simulator.Simulator()
         test_simulator.model = TestBoundsModel()
@@ -187,8 +187,10 @@ class TestSimulator(BaseTestCase):
         test_simulator.integrator.configure()
         test_simulator._configure_integrator_boundaries()
         assert numpy.all(test_simulator.integrator.bounded_state_variable_indices == numpy.array([0, 1, 2, 3]))
-        min_float = numpy.finfo("single").min
-        max_float = numpy.finfo("single").max
+        min_float = numpy.finfo("double").min
+        max_float = numpy.finfo("double").max
         state_variable_boundaries = numpy.array([[0.0, 1.0], [min_float, 1.0],
                                                  [0.0, max_float], [min_float, max_float]]).astype("float64")
-        assert numpy.all(state_variable_boundaries == test_simulator.integrator.state_variable_boundaries)
+        assert numpy.allclose(state_variable_boundaries,
+                              test_simulator.integrator.state_variable_boundaries,
+                              1.0/numpy.finfo("single").max)


### PR DESCRIPTION
I have made corrections and refactored the state boundaries handling of the simulator.

1. I have moved the user model input processing to the base Model class, and I am allowing also setting infinite boundaries.
None and infinite boundaries are set equal to the maximum "single" float value.
We can go for double as well if you wish.

2. Therefore, there is less configuration now in the Simulator. I am making sure that the resulting boundaries are of float64 format though.

3.  I have made new tests, separately for the the Model configuration of the boundaries (in models_tests), the respective simulator configuration of the integrator (in simulator_tests), and the actual bounding of the state via an integrators' test, extended to all of the available integration schemes.