### PR TITLE
TVB-2556 Fix after lazy models import changes

### DIFF
--- a/framework_tvb/tvb/adapters/simulator/model_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/model_forms.py
@@ -28,33 +28,33 @@
 #
 #
 
-from tvb.simulator.models import *
 from tvb.adapters.simulator.form_with_ranges import FormWithRanges
 from tvb.core.neotraits.forms import Form, ArrayField, MultiSelectField
+from tvb.simulator.models import ModelsEnum
 
 
 def get_model_to_form_dict():
     model_class_to_form = {
-        Generic2dOscillator: Generic2dOscillatorModelForm,
-        Kuramoto: KuramotoModelForm,
-        SupHopf: SupHopfModelForm,
-        Hopfield: HopfieldModelForm,
-        Epileptor: EpileptorModelForm,
-        Epileptor2D: Epileptor2DModelForm,
-        EpileptorCodim3: EpileptorCodim3ModelForm,
-        EpileptorCodim3SlowMod: EpileptorCodim3SlowModModelForm,
-        EpileptorRestingState: EpileptorRestingStateModelForm,
-        JansenRit: JansenRitModelForm,
-        ZetterbergJansen: ZetterbergJansenModelForm,
-        ReducedWongWang: ReducedWongWangModelForm,
-        ReducedWongWangExcInh: ReducedWongWangExcInhModelForm,
-        ReducedSetFitzHughNagumo: ReducedSetFitzHughNagumoModelForm,
-        ReducedSetHindmarshRose: ReducedSetHindmarshRoseModelForm,
-        ZerlautAdaptationFirstOrder: ZerlautAdaptationFirstOrderModelForm,
-        ZerlautAdaptationSecondOrder: ZerlautAdaptationSecondOrderModelForm,
-        Linear: LinearModelForm,
-        WilsonCowan: WilsonCowanModelForm,
-        LarterBreakspear: LarterBreakspearModelForm
+        ModelsEnum.GENERIC_2D_OSCILLATOR.get_class(): Generic2dOscillatorModelForm,
+        ModelsEnum.KURAMOTO.get_class(): KuramotoModelForm,
+        ModelsEnum.SUP_HOPF.get_class(): SupHopfModelForm,
+        ModelsEnum.HOPFIELD.get_class(): HopfieldModelForm,
+        ModelsEnum.EPILEPTOR.get_class(): EpileptorModelForm,
+        ModelsEnum.EPILEPTOR_2D.get_class(): Epileptor2DModelForm,
+        ModelsEnum.EPILEPTOR_CODIM_3.get_class(): EpileptorCodim3ModelForm,
+        ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class(): EpileptorCodim3SlowModModelForm,
+        ModelsEnum.EPILEPTOR_RS.get_class(): EpileptorRestingStateModelForm,
+        ModelsEnum.JANSEN_RIT.get_class(): JansenRitModelForm,
+        ModelsEnum.ZETTERBERG_JANSEN.get_class(): ZetterbergJansenModelForm,
+        ModelsEnum.REDUCED_WONG_WANG.get_class(): ReducedWongWangModelForm,
+        ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class(): ReducedWongWangExcInhModelForm,
+        ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class(): ReducedSetFitzHughNagumoModelForm,
+        ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class(): ReducedSetHindmarshRoseModelForm,
+        ModelsEnum.ZERLAUT_FIRST_ORDER.get_class(): ZerlautAdaptationFirstOrderModelForm,
+        ModelsEnum.ZERLAUT_SECOND_ORDER.get_class(): ZerlautAdaptationSecondOrderModelForm,
+        ModelsEnum.LINEAR.get_class(): LinearModelForm,
+        ModelsEnum.WILSON_COWAN.get_class(): WilsonCowanModelForm,
+        ModelsEnum.LARTER_BREAKSPEAR.get_class(): LarterBreakspearModelForm
     }
 
     return model_class_to_form
@@ -62,26 +62,26 @@ def get_model_to_form_dict():
 
 def get_ui_name_to_model():
     ui_name_to_model = {
-        'Generic 2d Oscillator': Generic2dOscillator,
-        'Kuramoto Oscillator': Kuramoto,
-        'supHopf': SupHopf,
-        'Hopfield': Hopfield,
-        'Epileptor': Epileptor,
-        'Epileptor2D': Epileptor2D,
-        'Epileptor codim 3': EpileptorCodim3,
-        'Epileptor codim 3 ultra-slow modulations': EpileptorCodim3SlowMod,
-        'EpileptorRestingState': EpileptorRestingState,
-        'Jansen-Rit': JansenRit,
-        'Zetterberg-Jansen': ZetterbergJansen,
-        'Reduced Wong-Wang': ReducedWongWang,
-        'Reduced Wong-Wang with Excitatory and Inhibitory Coupled Populations': ReducedWongWangExcInh,
-        'Stefanescu-Jirsa 2D': ReducedSetFitzHughNagumo,
-        'Stefanescu-Jirsa 3D': ReducedSetHindmarshRose,
-        'Zerlaut adaptation first order': ZerlautAdaptationFirstOrder,
-        'Zerlaut adaptation second order': ZerlautAdaptationSecondOrder,
-        'Linear model': Linear,
-        'Wilson-Cowan': WilsonCowan,
-        'Larter-Breakspear': LarterBreakspear
+        'Generic 2d Oscillator': ModelsEnum.GENERIC_2D_OSCILLATOR.get_class(),
+        'Kuramoto Oscillator': ModelsEnum.KURAMOTO.get_class(),
+        'supHopf': ModelsEnum.KURAMOTO.get_class(),
+        'Hopfield': ModelsEnum.HOPFIELD.get_class(),
+        'Epileptor': ModelsEnum.EPILEPTOR.get_class(),
+        'Epileptor2D': ModelsEnum.EPILEPTOR_2D.get_class(),
+        'Epileptor codim 3': ModelsEnum.EPILEPTOR_CODIM_3.get_class(),
+        'Epileptor codim 3 ultra-slow modulations': ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class(),
+        'EpileptorRestingState': ModelsEnum.EPILEPTOR_RS.get_class(),
+        'Jansen-Rit': ModelsEnum.JANSEN_RIT.get_class(),
+        'Zetterberg-Jansen': ModelsEnum.ZETTERBERG_JANSEN.get_class(),
+        'Reduced Wong-Wang': ModelsEnum.REDUCED_WONG_WANG.get_class(),
+        'Reduced Wong-Wang with Excitatory and Inhibitory Coupled Populations': ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class(),
+        'Stefanescu-Jirsa 2D': ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class(),
+        'Stefanescu-Jirsa 3D': ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class(),
+        'Zerlaut adaptation first order': ModelsEnum.ZERLAUT_FIRST_ORDER.get_class(),
+        'Zerlaut adaptation second order': ModelsEnum.ZERLAUT_SECOND_ORDER.get_class(),
+        'Linear model': ModelsEnum.LINEAR.get_class(),
+        'Wilson-Cowan': ModelsEnum.WILSON_COWAN.get_class(),
+        'Larter-Breakspear': ModelsEnum.LARTER_BREAKSPEAR.get_class()
     }
     return ui_name_to_model
 
@@ -100,19 +100,21 @@ class Generic2dOscillatorModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(Generic2dOscillatorModelForm, self).__init__(prefix)
-        self.tau = ArrayField(Generic2dOscillator.tau, self)
-        self.I = ArrayField(Generic2dOscillator.I, self)
-        self.a = ArrayField(Generic2dOscillator.a, self)
-        self.b = ArrayField(Generic2dOscillator.b, self)
-        self.c = ArrayField(Generic2dOscillator.c, self)
-        self.d = ArrayField(Generic2dOscillator.d, self)
-        self.e = ArrayField(Generic2dOscillator.e, self)
-        self.f = ArrayField(Generic2dOscillator.f, self)
-        self.g = ArrayField(Generic2dOscillator.g, self)
-        self.alpha = ArrayField(Generic2dOscillator.alpha, self)
-        self.beta = ArrayField(Generic2dOscillator.beta, self)
-        self.gamma = ArrayField(Generic2dOscillator.gamma, self)
-        self.variables_of_interest = MultiSelectField(Generic2dOscillator.variables_of_interest, self)
+        self.tau = ArrayField(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().tau, self)
+        self.I = ArrayField(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().I, self)
+        self.a = ArrayField(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().a, self)
+        self.b = ArrayField(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().b, self)
+        self.c = ArrayField(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().c, self)
+        self.d = ArrayField(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().d, self)
+        self.e = ArrayField(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().e, self)
+        self.f = ArrayField(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().f, self)
+        self.g = ArrayField(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().g, self)
+        self.alpha = ArrayField(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().alpha, self)
+        self.beta = ArrayField(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().beta, self)
+        self.gamma = ArrayField(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().gamma, self)
+        self.variables_of_interest = MultiSelectField(
+            ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().variables_of_interest,
+            self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -123,8 +125,8 @@ class KuramotoModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(KuramotoModelForm, self).__init__(prefix)
-        self.omega = ArrayField(Kuramoto.omega, self)
-        self.variables_of_interest = MultiSelectField(Kuramoto.variables_of_interest, self)
+        self.omega = ArrayField(ModelsEnum.KURAMOTO.get_class().omega, self)
+        self.variables_of_interest = MultiSelectField(ModelsEnum.KURAMOTO.get_class().variables_of_interest, self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -135,9 +137,9 @@ class SupHopfModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(SupHopfModelForm, self).__init__(prefix)
-        self.a = ArrayField(SupHopf.a, self)
-        self.omega = ArrayField(SupHopf.omega, self)
-        self.variables_of_interest = MultiSelectField(SupHopf.variables_of_interest, self)
+        self.a = ArrayField(ModelsEnum.SUP_HOPF.get_class().a, self)
+        self.omega = ArrayField(ModelsEnum.SUP_HOPF.get_class().omega, self)
+        self.variables_of_interest = MultiSelectField(ModelsEnum.SUP_HOPF.get_class().variables_of_interest, self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -148,10 +150,10 @@ class HopfieldModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(HopfieldModelForm, self).__init__(prefix)
-        self.taux = ArrayField(Hopfield.taux, self)
-        self.tauT = ArrayField(Hopfield.tauT, self)
-        self.dynamic = ArrayField(Hopfield.dynamic, self)
-        self.variables_of_interest = MultiSelectField(Hopfield.variables_of_interest, self)
+        self.taux = ArrayField(ModelsEnum.HOPFIELD.get_class().taux, self)
+        self.tauT = ArrayField(ModelsEnum.HOPFIELD.get_class().tauT, self)
+        self.dynamic = ArrayField(ModelsEnum.HOPFIELD.get_class().dynamic, self)
+        self.variables_of_interest = MultiSelectField(ModelsEnum.HOPFIELD.get_class().variables_of_interest, self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -162,25 +164,25 @@ class EpileptorModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(EpileptorModelForm, self).__init__(prefix)
-        self.a = ArrayField(Epileptor.a, self)
-        self.b = ArrayField(Epileptor.b, self)
-        self.c = ArrayField(Epileptor.c, self)
-        self.d = ArrayField(Epileptor.d, self)
-        self.r = ArrayField(Epileptor.r, self)
-        self.s = ArrayField(Epileptor.s, self)
-        self.x0 = ArrayField(Epileptor.x0, self)
-        self.Iext = ArrayField(Epileptor.Iext, self)
-        self.slope = ArrayField(Epileptor.slope, self)
-        self.Iext2 = ArrayField(Epileptor.Iext2, self)
-        self.tau = ArrayField(Epileptor.tau, self)
-        self.aa = ArrayField(Epileptor.aa, self)
-        self.bb = ArrayField(Epileptor.bb, self)
-        self.Kvf = ArrayField(Epileptor.Kvf, self)
-        self.Kf = ArrayField(Epileptor.Kf, self)
-        self.Ks = ArrayField(Epileptor.Ks, self)
-        self.tt = ArrayField(Epileptor.tt, self)
-        self.modification = ArrayField(Epileptor.modification, self)
-        self.variables_of_interest = MultiSelectField(Epileptor.variables_of_interest, self)
+        self.a = ArrayField(ModelsEnum.EPILEPTOR.get_class().a, self)
+        self.b = ArrayField(ModelsEnum.EPILEPTOR.get_class().b, self)
+        self.c = ArrayField(ModelsEnum.EPILEPTOR.get_class().c, self)
+        self.d = ArrayField(ModelsEnum.EPILEPTOR.get_class().d, self)
+        self.r = ArrayField(ModelsEnum.EPILEPTOR.get_class().r, self)
+        self.s = ArrayField(ModelsEnum.EPILEPTOR.get_class().s, self)
+        self.x0 = ArrayField(ModelsEnum.EPILEPTOR.get_class().x0, self)
+        self.Iext = ArrayField(ModelsEnum.EPILEPTOR.get_class().Iext, self)
+        self.slope = ArrayField(ModelsEnum.EPILEPTOR.get_class().slope, self)
+        self.Iext2 = ArrayField(ModelsEnum.EPILEPTOR.get_class().Iext2, self)
+        self.tau = ArrayField(ModelsEnum.EPILEPTOR.get_class().tau, self)
+        self.aa = ArrayField(ModelsEnum.EPILEPTOR.get_class().aa, self)
+        self.bb = ArrayField(ModelsEnum.EPILEPTOR.get_class().bb, self)
+        self.Kvf = ArrayField(ModelsEnum.EPILEPTOR.get_class().Kvf, self)
+        self.Kf = ArrayField(ModelsEnum.EPILEPTOR.get_class().Kf, self)
+        self.Ks = ArrayField(ModelsEnum.EPILEPTOR.get_class().Ks, self)
+        self.tt = ArrayField(ModelsEnum.EPILEPTOR.get_class().tt, self)
+        self.modification = ArrayField(ModelsEnum.EPILEPTOR.get_class().modification, self)
+        self.variables_of_interest = MultiSelectField(ModelsEnum.EPILEPTOR.get_class().variables_of_interest, self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -191,19 +193,19 @@ class Epileptor2DModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(Epileptor2DModelForm, self).__init__(prefix)
-        self.a = ArrayField(Epileptor2D.a, self)
-        self.b = ArrayField(Epileptor2D.b, self)
-        self.c = ArrayField(Epileptor2D.c, self)
-        self.d = ArrayField(Epileptor2D.d, self)
-        self.r = ArrayField(Epileptor2D.r, self)
-        self.x0 = ArrayField(Epileptor2D.x0, self)
-        self.Iext = ArrayField(Epileptor2D.Iext, self)
-        self.slope = ArrayField(Epileptor2D.slope, self)
-        self.Kvf = ArrayField(Epileptor2D.Kvf, self)
-        self.Ks = ArrayField(Epileptor2D.Ks, self)
-        self.tt = ArrayField(Epileptor2D.tt, self)
-        self.modification = ArrayField(Epileptor2D.modification, self)
-        self.variables_of_interest = MultiSelectField(Epileptor2D.variables_of_interest, self)
+        self.a = ArrayField(ModelsEnum.EPILEPTOR_2D.get_class().a, self)
+        self.b = ArrayField(ModelsEnum.EPILEPTOR_2D.get_class().b, self)
+        self.c = ArrayField(ModelsEnum.EPILEPTOR_2D.get_class().c, self)
+        self.d = ArrayField(ModelsEnum.EPILEPTOR_2D.get_class().d, self)
+        self.r = ArrayField(ModelsEnum.EPILEPTOR_2D.get_class().r, self)
+        self.x0 = ArrayField(ModelsEnum.EPILEPTOR_2D.get_class().x0, self)
+        self.Iext = ArrayField(ModelsEnum.EPILEPTOR_2D.get_class().Iext, self)
+        self.slope = ArrayField(ModelsEnum.EPILEPTOR_2D.get_class().slope, self)
+        self.Kvf = ArrayField(ModelsEnum.EPILEPTOR_2D.get_class().Kvf, self)
+        self.Ks = ArrayField(ModelsEnum.EPILEPTOR_2D.get_class().Ks, self)
+        self.tt = ArrayField(ModelsEnum.EPILEPTOR_2D.get_class().tt, self)
+        self.modification = ArrayField(ModelsEnum.EPILEPTOR_2D.get_class().modification, self)
+        self.variables_of_interest = MultiSelectField(ModelsEnum.EPILEPTOR_2D.get_class().variables_of_interest, self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -214,20 +216,21 @@ class EpileptorCodim3ModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(EpileptorCodim3ModelForm, self).__init__(prefix)
-        self.mu1_start = ArrayField(EpileptorCodim3.mu1_start, self)
-        self.mu2_start = ArrayField(EpileptorCodim3.mu2_start, self)
-        self.nu_start = ArrayField(EpileptorCodim3.nu_start, self)
-        self.mu1_stop = ArrayField(EpileptorCodim3.mu1_stop, self)
-        self.mu2_stop = ArrayField(EpileptorCodim3.mu2_stop, self)
-        self.nu_stop = ArrayField(EpileptorCodim3.nu_stop, self)
-        self.b = ArrayField(EpileptorCodim3.b, self)
-        self.R = ArrayField(EpileptorCodim3.R, self)
-        self.c = ArrayField(EpileptorCodim3.c, self)
-        self.dstar = ArrayField(EpileptorCodim3.dstar, self)
-        self.Ks = ArrayField(EpileptorCodim3.Ks, self)
-        self.N = ArrayField(EpileptorCodim3.N, self)
-        self.modification = ArrayField(EpileptorCodim3.modification, self)
-        self.variables_of_interest = MultiSelectField(EpileptorCodim3.variables_of_interest, self)
+        self.mu1_start = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3.get_class().mu1_start, self)
+        self.mu2_start = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3.get_class().mu2_start, self)
+        self.nu_start = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3.get_class().nu_start, self)
+        self.mu1_stop = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3.get_class().mu1_stop, self)
+        self.mu2_stop = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3.get_class().mu2_stop, self)
+        self.nu_stop = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3.get_class().nu_stop, self)
+        self.b = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3.get_class().b, self)
+        self.R = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3.get_class().R, self)
+        self.c = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3.get_class().c, self)
+        self.dstar = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3.get_class().dstar, self)
+        self.Ks = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3.get_class().Ks, self)
+        self.N = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3.get_class().N, self)
+        self.modification = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3.get_class().modification, self)
+        self.variables_of_interest = MultiSelectField(ModelsEnum.EPILEPTOR_CODIM_3.get_class().variables_of_interest,
+                                                      self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -239,28 +242,29 @@ class EpileptorCodim3SlowModModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(EpileptorCodim3SlowModModelForm, self).__init__(prefix)
-        self.mu1_Ain = ArrayField(EpileptorCodim3SlowMod.mu1_Ain, self)
-        self.mu2_Ain = ArrayField(EpileptorCodim3SlowMod.mu2_Ain, self)
-        self.nu_Ain = ArrayField(EpileptorCodim3SlowMod.nu_Ain, self)
-        self.mu1_Bin = ArrayField(EpileptorCodim3SlowMod.mu1_Bin, self)
-        self.mu2_Bin = ArrayField(EpileptorCodim3SlowMod.mu2_Bin, self)
-        self.nu_Bin = ArrayField(EpileptorCodim3SlowMod.nu_Bin, self)
-        self.mu1_Aend = ArrayField(EpileptorCodim3SlowMod.mu1_Aend, self)
-        self.mu2_Aend = ArrayField(EpileptorCodim3SlowMod.mu2_Aend, self)
-        self.nu_Aend = ArrayField(EpileptorCodim3SlowMod.nu_Aend, self)
-        self.mu1_Bend = ArrayField(EpileptorCodim3SlowMod.mu1_Bend, self)
-        self.mu2_Bend = ArrayField(EpileptorCodim3SlowMod.mu2_Bend, self)
-        self.nu_Bend = ArrayField(EpileptorCodim3SlowMod.nu_Bend, self)
-        self.b = ArrayField(EpileptorCodim3SlowMod.b, self)
-        self.R = ArrayField(EpileptorCodim3SlowMod.R, self)
-        self.c = ArrayField(EpileptorCodim3SlowMod.c, self)
-        self.cA = ArrayField(EpileptorCodim3SlowMod.cA, self)
-        self.cB = ArrayField(EpileptorCodim3SlowMod.cB, self)
-        self.dstar = ArrayField(EpileptorCodim3SlowMod.dstar, self)
-        self.Ks = ArrayField(EpileptorCodim3SlowMod.Ks, self)
-        self.N = ArrayField(EpileptorCodim3SlowMod.N, self)
-        self.modification = ArrayField(EpileptorCodim3SlowMod.modification, self)
-        self.variables_of_interest = ArrayField(EpileptorCodim3SlowMod.variables_of_interest, self)
+        self.mu1_Ain = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().mu1_Ain, self)
+        self.mu2_Ain = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().mu2_Ain, self)
+        self.nu_Ain = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().nu_Ain, self)
+        self.mu1_Bin = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().mu1_Bin, self)
+        self.mu2_Bin = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().mu2_Bin, self)
+        self.nu_Bin = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().nu_Bin, self)
+        self.mu1_Aend = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().mu1_Aend, self)
+        self.mu2_Aend = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().mu2_Aend, self)
+        self.nu_Aend = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().nu_Aend, self)
+        self.mu1_Bend = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().mu1_Bend, self)
+        self.mu2_Bend = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().mu2_Bend, self)
+        self.nu_Bend = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().nu_Bend, self)
+        self.b = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().b, self)
+        self.R = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().R, self)
+        self.c = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().c, self)
+        self.cA = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().cA, self)
+        self.cB = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().cB, self)
+        self.dstar = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().dstar, self)
+        self.Ks = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().Ks, self)
+        self.N = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().N, self)
+        self.modification = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().modification, self)
+        self.variables_of_interest = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().variables_of_interest,
+                                                self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -272,35 +276,36 @@ class EpileptorRestingStateModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(EpileptorRestingStateModelForm, self).__init__(prefix)
-        self.a = ArrayField(EpileptorRestingState.a, self)
-        self.b = ArrayField(EpileptorRestingState.b, self)
-        self.c = ArrayField(EpileptorRestingState.c, self)
-        self.d = ArrayField(EpileptorRestingState.d, self)
-        self.r = ArrayField(EpileptorRestingState.r, self)
-        self.s = ArrayField(EpileptorRestingState.s, self)
-        self.x0 = ArrayField(EpileptorRestingState.x0, self)
-        self.Iext = ArrayField(EpileptorRestingState.Iext, self)
-        self.slope = ArrayField(EpileptorRestingState.slope, self)
-        self.Iext2 = ArrayField(EpileptorRestingState.Iext2, self)
-        self.tau = ArrayField(EpileptorRestingState.tau, self)
-        self.aa = ArrayField(EpileptorRestingState.aa, self)
-        self.bb = ArrayField(EpileptorRestingState.bb, self)
-        self.Kvf = ArrayField(EpileptorRestingState.Kvf, self)
-        self.Kf = ArrayField(EpileptorRestingState.Kf, self)
-        self.Ks = ArrayField(EpileptorRestingState.Ks, self)
-        self.tt = ArrayField(EpileptorRestingState.tt, self)
-        self.tau_rs = ArrayField(EpileptorRestingState.tau_rs, self)
-        self.I_rs = ArrayField(EpileptorRestingState.I_rs, self)
-        self.a_rs = ArrayField(EpileptorRestingState.a_rs, self)
-        self.b_rs = ArrayField(EpileptorRestingState.b_rs, self)
-        self.d_rs = ArrayField(EpileptorRestingState.d_rs, self)
-        self.e_rs = ArrayField(EpileptorRestingState.e_rs, self)
-        self.f_rs = ArrayField(EpileptorRestingState.f_rs, self)
-        self.alpha_rs = ArrayField(EpileptorRestingState.alpha_rs, self)
-        self.beta_rs = ArrayField(EpileptorRestingState.beta_rs, self)
-        self.K_rs = ArrayField(EpileptorRestingState.K_rs, self)
-        self.p = ArrayField(EpileptorRestingState.p, self)
-        self.variables_of_interest = MultiSelectField(EpileptorRestingState.variables_of_interest, self)
+        self.a = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().a, self)
+        self.b = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().b, self)
+        self.c = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().c, self)
+        self.d = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().d, self)
+        self.r = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().r, self)
+        self.s = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().s, self)
+        self.x0 = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().x0, self)
+        self.Iext = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().Iext, self)
+        self.slope = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().slope, self)
+        self.Iext2 = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().Iext2, self)
+        self.tau = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().tau, self)
+        self.aa = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().aa, self)
+        self.bb = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().bb, self)
+        self.Kvf = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().Kvf, self)
+        self.Kf = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().Kf, self)
+        self.Ks = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().Ks, self)
+        self.tt = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().tt, self)
+        self.tau_rs = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().tau_rs, self)
+        self.I_rs = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().I_rs, self)
+        self.a_rs = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().a_rs, self)
+        self.b_rs = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().b_rs, self)
+        self.d_rs = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().d_rs, self)
+        self.e_rs = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().e_rs, self)
+        self.f_rs = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().f_rs, self)
+        self.alpha_rs = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().alpha_rs, self)
+        self.beta_rs = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().beta_rs, self)
+        self.K_rs = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().K_rs, self)
+        self.p = ArrayField(ModelsEnum.EPILEPTOR_RS.get_class().p, self)
+        self.variables_of_interest = MultiSelectField(ModelsEnum.EPILEPTOR_RS.get_class().variables_of_interest,
+                                                      self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -312,22 +317,22 @@ class JansenRitModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(JansenRitModelForm, self).__init__(prefix)
-        self.A = ArrayField(JansenRit.A, self)
-        self.B = ArrayField(JansenRit.B, self)
-        self.a = ArrayField(JansenRit.a, self)
-        self.b = ArrayField(JansenRit.b, self)
-        self.v0 = ArrayField(JansenRit.v0, self)
-        self.nu_max = ArrayField(JansenRit.nu_max, self)
-        self.r = ArrayField(JansenRit.r, self)
-        self.J = ArrayField(JansenRit.J, self)
-        self.a_1 = ArrayField(JansenRit.a_1, self)
-        self.a_2 = ArrayField(JansenRit.a_2, self)
-        self.a_3 = ArrayField(JansenRit.a_3, self)
-        self.a_4 = ArrayField(JansenRit.a_4, self)
-        self.p_min = ArrayField(JansenRit.p_min, self)
-        self.p_max = ArrayField(JansenRit.p_max, self)
-        self.mu = ArrayField(JansenRit.mu, self)
-        self.variables_of_interest = ArrayField(JansenRit.variables_of_interest, self)
+        self.A = ArrayField(ModelsEnum.JANSEN_RIT.get_class().A, self)
+        self.B = ArrayField(ModelsEnum.JANSEN_RIT.get_class().B, self)
+        self.a = ArrayField(ModelsEnum.JANSEN_RIT.get_class().a, self)
+        self.b = ArrayField(ModelsEnum.JANSEN_RIT.get_class().b, self)
+        self.v0 = ArrayField(ModelsEnum.JANSEN_RIT.get_class().v0, self)
+        self.nu_max = ArrayField(ModelsEnum.JANSEN_RIT.get_class().nu_max, self)
+        self.r = ArrayField(ModelsEnum.JANSEN_RIT.get_class().r, self)
+        self.J = ArrayField(ModelsEnum.JANSEN_RIT.get_class().J, self)
+        self.a_1 = ArrayField(ModelsEnum.JANSEN_RIT.get_class().a_1, self)
+        self.a_2 = ArrayField(ModelsEnum.JANSEN_RIT.get_class().a_2, self)
+        self.a_3 = ArrayField(ModelsEnum.JANSEN_RIT.get_class().a_3, self)
+        self.a_4 = ArrayField(ModelsEnum.JANSEN_RIT.get_class().a_4, self)
+        self.p_min = ArrayField(ModelsEnum.JANSEN_RIT.get_class().p_min, self)
+        self.p_max = ArrayField(ModelsEnum.JANSEN_RIT.get_class().p_max, self)
+        self.mu = ArrayField(ModelsEnum.JANSEN_RIT.get_class().mu, self)
+        self.variables_of_interest = ArrayField(ModelsEnum.JANSEN_RIT.get_class().variables_of_interest, self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -338,25 +343,26 @@ class ZetterbergJansenModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(ZetterbergJansenModelForm, self).__init__(prefix)
-        self.He = ArrayField(ZetterbergJansen.He, self)
-        self.Hi = ArrayField(ZetterbergJansen.Hi, self)
-        self.ke = ArrayField(ZetterbergJansen.ke, self)
-        self.ki = ArrayField(ZetterbergJansen.ki, self)
-        self.e0 = ArrayField(ZetterbergJansen.e0, self)
-        self.rho_2 = ArrayField(ZetterbergJansen.rho_2, self)
-        self.rho_1 = ArrayField(ZetterbergJansen.rho_1, self)
-        self.gamma_1 = ArrayField(ZetterbergJansen.gamma_1, self)
-        self.gamma_2 = ArrayField(ZetterbergJansen.gamma_2, self)
-        self.gamma_3 = ArrayField(ZetterbergJansen.gamma_3, self)
-        self.gamma_4 = ArrayField(ZetterbergJansen.gamma_4, self)
-        self.gamma_5 = ArrayField(ZetterbergJansen.gamma_5, self)
-        self.gamma_1T = ArrayField(ZetterbergJansen.gamma_1T, self)
-        self.gamma_2T = ArrayField(ZetterbergJansen.gamma_2T, self)
-        self.gamma_3T = ArrayField(ZetterbergJansen.gamma_3T, self)
-        self.P = ArrayField(ZetterbergJansen.P, self)
-        self.U = ArrayField(ZetterbergJansen.U, self)
-        self.Q = ArrayField(ZetterbergJansen.Q, self)
-        self.variables_of_interest = MultiSelectField(ZetterbergJansen.variables_of_interest, self)
+        self.He = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().He, self)
+        self.Hi = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().Hi, self)
+        self.ke = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().ke, self)
+        self.ki = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().ki, self)
+        self.e0 = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().e0, self)
+        self.rho_2 = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().rho_2, self)
+        self.rho_1 = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().rho_1, self)
+        self.gamma_1 = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().gamma_1, self)
+        self.gamma_2 = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().gamma_2, self)
+        self.gamma_3 = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().gamma_3, self)
+        self.gamma_4 = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().gamma_4, self)
+        self.gamma_5 = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().gamma_5, self)
+        self.gamma_1T = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().gamma_1T, self)
+        self.gamma_2T = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().gamma_2T, self)
+        self.gamma_3T = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().gamma_3T, self)
+        self.P = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().P, self)
+        self.U = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().U, self)
+        self.Q = ArrayField(ModelsEnum.ZETTERBERG_JANSEN.get_class().Q, self)
+        self.variables_of_interest = MultiSelectField(ModelsEnum.ZETTERBERG_JANSEN.get_class().variables_of_interest,
+                                                      self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -368,16 +374,17 @@ class ReducedWongWangModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(ReducedWongWangModelForm, self).__init__(prefix)
-        self.a = ArrayField(ReducedWongWang.a, self)
-        self.b = ArrayField(ReducedWongWang.b, self)
-        self.d = ArrayField(ReducedWongWang.d, self)
-        self.gamma = ArrayField(ReducedWongWang.gamma, self)
-        self.tau_s = ArrayField(ReducedWongWang.tau_s, self)
-        self.w = ArrayField(ReducedWongWang.w, self)
-        self.J_N = ArrayField(ReducedWongWang.J_N, self)
-        self.I_o = ArrayField(ReducedWongWang.I_o, self)
-        self.sigma_noise = ArrayField(ReducedWongWang.sigma_noise, self)
-        self.variables_of_interest = MultiSelectField(ReducedWongWang.variables_of_interest, self)
+        self.a = ArrayField(ModelsEnum.REDUCED_WONG_WANG.get_class().a, self)
+        self.b = ArrayField(ModelsEnum.REDUCED_WONG_WANG.get_class().b, self)
+        self.d = ArrayField(ModelsEnum.REDUCED_WONG_WANG.get_class().d, self)
+        self.gamma = ArrayField(ModelsEnum.REDUCED_WONG_WANG.get_class().gamma, self)
+        self.tau_s = ArrayField(ModelsEnum.REDUCED_WONG_WANG.get_class().tau_s, self)
+        self.w = ArrayField(ModelsEnum.REDUCED_WONG_WANG.get_class().w, self)
+        self.J_N = ArrayField(ModelsEnum.REDUCED_WONG_WANG.get_class().J_N, self)
+        self.I_o = ArrayField(ModelsEnum.REDUCED_WONG_WANG.get_class().I_o, self)
+        self.sigma_noise = ArrayField(ModelsEnum.REDUCED_WONG_WANG.get_class().sigma_noise, self)
+        self.variables_of_interest = MultiSelectField(ModelsEnum.REDUCED_WONG_WANG.get_class().variables_of_interest,
+                                                      self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -388,25 +395,27 @@ class ReducedWongWangExcInhModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(ReducedWongWangExcInhModelForm, self).__init__(prefix)
-        self.a_e = ArrayField(ReducedWongWangExcInh.a_e, self)
-        self.b_e = ArrayField(ReducedWongWangExcInh.b_e, self)
-        self.d_e = ArrayField(ReducedWongWangExcInh.d_e, self)
-        self.gamma_e = ArrayField(ReducedWongWangExcInh.gamma_e, self)
-        self.tau_e = ArrayField(ReducedWongWangExcInh.tau_e, self)
-        self.w_p = ArrayField(ReducedWongWangExcInh.w_p, self)
-        self.J_N = ArrayField(ReducedWongWangExcInh.J_N, self)
-        self.W_e = ArrayField(ReducedWongWangExcInh.W_e, self)
-        self.a_i = ArrayField(ReducedWongWangExcInh.a_i, self)
-        self.b_i = ArrayField(ReducedWongWangExcInh.b_i, self)
-        self.d_i = ArrayField(ReducedWongWangExcInh.d_i, self)
-        self.gamma_i = ArrayField(ReducedWongWangExcInh.gamma_i, self)
-        self.tau_i = ArrayField(ReducedWongWangExcInh.tau_i, self)
-        self.J_i = ArrayField(ReducedWongWangExcInh.J_i, self)
-        self.W_i = ArrayField(ReducedWongWangExcInh.W_i, self)
-        self.I_o = ArrayField(ReducedWongWangExcInh.I_o, self)
-        self.G = ArrayField(ReducedWongWangExcInh.G, self)
-        self.lamda = ArrayField(ReducedWongWangExcInh.lamda, self)
-        self.variables_of_interest = MultiSelectField(ReducedWongWangExcInh.variables_of_interest, self)
+        self.a_e = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().a_e, self)
+        self.b_e = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().b_e, self)
+        self.d_e = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().d_e, self)
+        self.gamma_e = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().gamma_e, self)
+        self.tau_e = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().tau_e, self)
+        self.w_p = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().w_p, self)
+        self.J_N = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().J_N, self)
+        self.W_e = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().W_e, self)
+        self.a_i = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().a_i, self)
+        self.b_i = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().b_i, self)
+        self.d_i = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().d_i, self)
+        self.gamma_i = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().gamma_i, self)
+        self.tau_i = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().tau_i, self)
+        self.J_i = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().J_i, self)
+        self.W_i = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().W_i, self)
+        self.I_o = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().I_o, self)
+        self.G = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().G, self)
+        self.lamda = ArrayField(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().lamda, self)
+        self.variables_of_interest = MultiSelectField(
+            ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().variables_of_interest,
+            self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -418,15 +427,16 @@ class ReducedSetFitzHughNagumoModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(ReducedSetFitzHughNagumoModelForm, self).__init__(prefix)
-        self.tau = ArrayField(ReducedSetFitzHughNagumo.tau, self)
-        self.a = ArrayField(ReducedSetFitzHughNagumo.a, self)
-        self.b = ArrayField(ReducedSetFitzHughNagumo.b, self)
-        self.K11 = ArrayField(ReducedSetFitzHughNagumo.K11, self)
-        self.K12 = ArrayField(ReducedSetFitzHughNagumo.K12, self)
-        self.K21 = ArrayField(ReducedSetFitzHughNagumo.K21, self)
-        self.sigma = ArrayField(ReducedSetFitzHughNagumo.sigma, self)
-        self.mu = ArrayField(ReducedSetFitzHughNagumo.mu, self)
-        self.variables_of_interest = MultiSelectField(ReducedSetFitzHughNagumo.variables_of_interest, self)
+        self.tau = ArrayField(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().tau, self)
+        self.a = ArrayField(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().a, self)
+        self.b = ArrayField(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().b, self)
+        self.K11 = ArrayField(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().K11, self)
+        self.K12 = ArrayField(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().K12, self)
+        self.K21 = ArrayField(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().K21, self)
+        self.sigma = ArrayField(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().sigma, self)
+        self.mu = ArrayField(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().mu, self)
+        self.variables_of_interest = MultiSelectField(
+            ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().variables_of_interest, self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -437,19 +447,20 @@ class ReducedSetHindmarshRoseModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(ReducedSetHindmarshRoseModelForm, self).__init__(prefix)
-        self.r = ArrayField(ReducedSetHindmarshRose.r, self)
-        self.a = ArrayField(ReducedSetHindmarshRose.a, self)
-        self.b = ArrayField(ReducedSetHindmarshRose.b, self)
-        self.c = ArrayField(ReducedSetHindmarshRose.c, self)
-        self.d = ArrayField(ReducedSetHindmarshRose.d, self)
-        self.s = ArrayField(ReducedSetHindmarshRose.s, self)
-        self.xo = ArrayField(ReducedSetHindmarshRose.xo, self)
-        self.K11 = ArrayField(ReducedSetHindmarshRose.K11, self)
-        self.K12 = ArrayField(ReducedSetHindmarshRose.K12, self)
-        self.K21 = ArrayField(ReducedSetHindmarshRose.K21, self)
-        self.sigma = ArrayField(ReducedSetHindmarshRose.sigma, self)
-        self.mu = ArrayField(ReducedSetHindmarshRose.mu, self)
-        self.variables_of_interest = MultiSelectField(ReducedSetHindmarshRose.variables_of_interest, self)
+        self.r = ArrayField(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().r, self)
+        self.a = ArrayField(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().a, self)
+        self.b = ArrayField(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().b, self)
+        self.c = ArrayField(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().c, self)
+        self.d = ArrayField(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().d, self)
+        self.s = ArrayField(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().s, self)
+        self.xo = ArrayField(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().xo, self)
+        self.K11 = ArrayField(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().K11, self)
+        self.K12 = ArrayField(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().K12, self)
+        self.K21 = ArrayField(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().K21, self)
+        self.sigma = ArrayField(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().sigma, self)
+        self.mu = ArrayField(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().mu, self)
+        self.variables_of_interest = MultiSelectField(
+            ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().variables_of_interest, self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -460,35 +471,36 @@ class ZerlautAdaptationFirstOrderModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(ZerlautAdaptationFirstOrderModelForm, self).__init__(prefix)
-        self.g_L = ArrayField(ZerlautAdaptationFirstOrder.g_L, self)
-        self.E_L_e = ArrayField(ZerlautAdaptationFirstOrder.E_L_e, self)
-        self.E_L_i = ArrayField(ZerlautAdaptationFirstOrder.E_L_i, self)
-        self.C_m = ArrayField(ZerlautAdaptationFirstOrder.C_m, self)
-        self.b_e = ArrayField(ZerlautAdaptationFirstOrder.b_e, self)
-        self.b_i = ArrayField(ZerlautAdaptationFirstOrder.b_i, self)
-        self.a_e = ArrayField(ZerlautAdaptationFirstOrder.a_e, self)
-        self.a_i = ArrayField(ZerlautAdaptationFirstOrder.a_i, self)
-        self.tau_w_e = ArrayField(ZerlautAdaptationFirstOrder.tau_w_e, self)
-        self.tau_w_i = ArrayField(ZerlautAdaptationFirstOrder.tau_w_i, self)
-        self.E_e = ArrayField(ZerlautAdaptationFirstOrder.E_e, self)
-        self.E_i = ArrayField(ZerlautAdaptationFirstOrder.E_i, self)
-        self.Q_e = ArrayField(ZerlautAdaptationFirstOrder.Q_e, self)
-        self.Q_i = ArrayField(ZerlautAdaptationFirstOrder.Q_i, self)
-        self.tau_e = ArrayField(ZerlautAdaptationFirstOrder.tau_e, self)
-        self.tau_i = ArrayField(ZerlautAdaptationFirstOrder.tau_i, self)
-        self.N_tot = ArrayField(ZerlautAdaptationFirstOrder.N_tot, self)
-        self.p_connect = ArrayField(ZerlautAdaptationFirstOrder.p_connect, self)
-        self.g = ArrayField(ZerlautAdaptationFirstOrder.g, self)
-        self.K_ext_e = ArrayField(ZerlautAdaptationFirstOrder.K_ext_e, self)
-        self.K_ext_i = ArrayField(ZerlautAdaptationFirstOrder.K_ext_i, self)
-        self.T = ArrayField(ZerlautAdaptationFirstOrder.T, self)
-        self.P_e = ArrayField(ZerlautAdaptationFirstOrder.P_e, self)
-        self.P_i = ArrayField(ZerlautAdaptationFirstOrder.P_i, self)
-        self.external_input_ex_ex = ArrayField(ZerlautAdaptationFirstOrder.external_input_ex_ex, self)
-        self.external_input_ex_in = ArrayField(ZerlautAdaptationFirstOrder.external_input_ex_in, self)
-        self.external_input_in_ex = ArrayField(ZerlautAdaptationFirstOrder.external_input_in_ex, self)
-        self.external_input_in_in = ArrayField(ZerlautAdaptationFirstOrder.external_input_in_in, self)
-        self.variables_of_interest = MultiSelectField(ZerlautAdaptationFirstOrder.variables_of_interest, self)
+        self.g_L = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().g_L, self)
+        self.E_L_e = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().E_L_e, self)
+        self.E_L_i = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().E_L_i, self)
+        self.C_m = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().C_m, self)
+        self.b_e = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().b_e, self)
+        self.b_i = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().b_i, self)
+        self.a_e = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().a_e, self)
+        self.a_i = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().a_i, self)
+        self.tau_w_e = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().tau_w_e, self)
+        self.tau_w_i = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().tau_w_i, self)
+        self.E_e = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().E_e, self)
+        self.E_i = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().E_i, self)
+        self.Q_e = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().Q_e, self)
+        self.Q_i = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().Q_i, self)
+        self.tau_e = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().tau_e, self)
+        self.tau_i = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().tau_i, self)
+        self.N_tot = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().N_tot, self)
+        self.p_connect = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().p_connect, self)
+        self.g = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().g, self)
+        self.K_ext_e = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().K_ext_e, self)
+        self.K_ext_i = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().K_ext_i, self)
+        self.T = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().T, self)
+        self.P_e = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().P_e, self)
+        self.P_i = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().P_i, self)
+        self.external_input_ex_ex = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().external_input_ex_ex, self)
+        self.external_input_ex_in = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().external_input_ex_in, self)
+        self.external_input_in_ex = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().external_input_in_ex, self)
+        self.external_input_in_in = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().external_input_in_in, self)
+        self.variables_of_interest = MultiSelectField(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().variables_of_interest,
+                                                      self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -497,20 +509,20 @@ class ZerlautAdaptationFirstOrderModelForm(FormWithRanges):
                 'external_input_ex_in', 'external_input_in_ex', 'external_input_in_in']
 
 
-
 class ZerlautAdaptationSecondOrderModelForm(ZerlautAdaptationFirstOrderModelForm):
 
     def __init__(self, prefix=''):
         super(ZerlautAdaptationSecondOrderModelForm, self).__init__(prefix)
-        self.variables_of_interest = MultiSelectField(ZerlautAdaptationSecondOrder.variables_of_interest, self)
+        self.variables_of_interest = MultiSelectField(ModelsEnum.ZERLAUT_SECOND_ORDER.get_class().variables_of_interest,
+                                                      self)
 
 
 class LinearModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(LinearModelForm, self).__init__(prefix)
-        self.gamma = ArrayField(Linear.gamma, self)
-        self.variables_of_interest = MultiSelectField(Linear.variables_of_interest, self)
+        self.gamma = ArrayField(ModelsEnum.LINEAR.get_class().gamma, self)
+        self.variables_of_interest = MultiSelectField(ModelsEnum.LINEAR.get_class().variables_of_interest, self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -521,29 +533,29 @@ class WilsonCowanModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(WilsonCowanModelForm, self).__init__(prefix)
-        self.c_ee = ArrayField(WilsonCowan.c_ee, self)
-        self.c_ie = ArrayField(WilsonCowan.c_ie, self)
-        self.c_ei = ArrayField(WilsonCowan.c_ei, self)
-        self.c_ii = ArrayField(WilsonCowan.c_ii, self)
-        self.tau_e = ArrayField(WilsonCowan.tau_e, self)
-        self.tau_i = ArrayField(WilsonCowan.tau_i, self)
-        self.a_e = ArrayField(WilsonCowan.a_e, self)
-        self.b_e = ArrayField(WilsonCowan.b_e, self)
-        self.c_e = ArrayField(WilsonCowan.c_e, self)
-        self.theta_e = ArrayField(WilsonCowan.theta_e, self)
-        self.a_i = ArrayField(WilsonCowan.a_i, self)
-        self.b_i = ArrayField(WilsonCowan.b_i, self)
-        self.theta_i = ArrayField(WilsonCowan.theta_i, self)
-        self.c_i = ArrayField(WilsonCowan.c_i, self)
-        self.r_e = ArrayField(WilsonCowan.r_e, self)
-        self.r_i = ArrayField(WilsonCowan.r_i, self)
-        self.k_e = ArrayField(WilsonCowan.k_e, self)
-        self.k_i = ArrayField(WilsonCowan.k_i, self)
-        self.P = ArrayField(WilsonCowan.P, self)
-        self.Q = ArrayField(WilsonCowan.Q, self)
-        self.alpha_e = ArrayField(WilsonCowan.alpha_e, self)
-        self.alpha_i = ArrayField(WilsonCowan.alpha_i, self)
-        self.variables_of_interest = MultiSelectField(WilsonCowan.variables_of_interest, self)
+        self.c_ee = ArrayField(ModelsEnum.WILSON_COWAN.get_class().c_ee, self)
+        self.c_ie = ArrayField(ModelsEnum.WILSON_COWAN.get_class().c_ie, self)
+        self.c_ei = ArrayField(ModelsEnum.WILSON_COWAN.get_class().c_ei, self)
+        self.c_ii = ArrayField(ModelsEnum.WILSON_COWAN.get_class().c_ii, self)
+        self.tau_e = ArrayField(ModelsEnum.WILSON_COWAN.get_class().tau_e, self)
+        self.tau_i = ArrayField(ModelsEnum.WILSON_COWAN.get_class().tau_i, self)
+        self.a_e = ArrayField(ModelsEnum.WILSON_COWAN.get_class().a_e, self)
+        self.b_e = ArrayField(ModelsEnum.WILSON_COWAN.get_class().b_e, self)
+        self.c_e = ArrayField(ModelsEnum.WILSON_COWAN.get_class().c_e, self)
+        self.theta_e = ArrayField(ModelsEnum.WILSON_COWAN.get_class().theta_e, self)
+        self.a_i = ArrayField(ModelsEnum.WILSON_COWAN.get_class().a_i, self)
+        self.b_i = ArrayField(ModelsEnum.WILSON_COWAN.get_class().b_i, self)
+        self.theta_i = ArrayField(ModelsEnum.WILSON_COWAN.get_class().theta_i, self)
+        self.c_i = ArrayField(ModelsEnum.WILSON_COWAN.get_class().c_i, self)
+        self.r_e = ArrayField(ModelsEnum.WILSON_COWAN.get_class().r_e, self)
+        self.r_i = ArrayField(ModelsEnum.WILSON_COWAN.get_class().r_i, self)
+        self.k_e = ArrayField(ModelsEnum.WILSON_COWAN.get_class().k_e, self)
+        self.k_i = ArrayField(ModelsEnum.WILSON_COWAN.get_class().k_i, self)
+        self.P = ArrayField(ModelsEnum.WILSON_COWAN.get_class().P, self)
+        self.Q = ArrayField(ModelsEnum.WILSON_COWAN.get_class().Q, self)
+        self.alpha_e = ArrayField(ModelsEnum.WILSON_COWAN.get_class().alpha_e, self)
+        self.alpha_i = ArrayField(ModelsEnum.WILSON_COWAN.get_class().alpha_i, self)
+        self.variables_of_interest = MultiSelectField(ModelsEnum.WILSON_COWAN.get_class().variables_of_interest, self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():
@@ -555,39 +567,40 @@ class LarterBreakspearModelForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(LarterBreakspearModelForm, self).__init__(prefix)
-        self.gCa = ArrayField(LarterBreakspear.gCa, self)
-        self.gK = ArrayField(LarterBreakspear.gK, self)
-        self.gL = ArrayField(LarterBreakspear.gL, self)
-        self.phi = ArrayField(LarterBreakspear.phi, self)
-        self.gNa = ArrayField(LarterBreakspear.gNa, self)
-        self.TK = ArrayField(LarterBreakspear.TK, self)
-        self.TCa = ArrayField(LarterBreakspear.TCa, self)
-        self.TNa = ArrayField(LarterBreakspear.TNa, self)
-        self.VCa = ArrayField(LarterBreakspear.VCa, self)
-        self.VK = ArrayField(LarterBreakspear.VK, self)
-        self.VL = ArrayField(LarterBreakspear.VL, self)
-        self.VNa = ArrayField(LarterBreakspear.VNa, self)
-        self.d_K = ArrayField(LarterBreakspear.d_K, self)
-        self.tau_K = ArrayField(LarterBreakspear.tau_K, self)
-        self.d_Na = ArrayField(LarterBreakspear.d_Na, self)
-        self.d_Ca = ArrayField(LarterBreakspear.d_Ca, self)
-        self.aei = ArrayField(LarterBreakspear.aei, self)
-        self.aie = ArrayField(LarterBreakspear.aie, self)
-        self.b = ArrayField(LarterBreakspear.b, self)
-        self.C = ArrayField(LarterBreakspear.C, self)
-        self.ane = ArrayField(LarterBreakspear.ane, self)
-        self.ani = ArrayField(LarterBreakspear.ani, self)
-        self.aee = ArrayField(LarterBreakspear.aee, self)
-        self.Iext = ArrayField(LarterBreakspear.Iext, self)
-        self.rNMDA = ArrayField(LarterBreakspear.rNMDA, self)
-        self.VT = ArrayField(LarterBreakspear.VT, self)
-        self.d_V = ArrayField(LarterBreakspear.d_V, self)
-        self.ZT = ArrayField(LarterBreakspear.ZT, self)
-        self.d_Z = ArrayField(LarterBreakspear.d_Z, self)
-        self.QV_max = ArrayField(LarterBreakspear.QV_max, self)
-        self.QZ_max = ArrayField(LarterBreakspear.QZ_max, self)
-        self.t_scale = ArrayField(LarterBreakspear.t_scale, self)
-        self.variables_of_interest = MultiSelectField(LarterBreakspear.variables_of_interest, self)
+        self.gCa = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().gCa, self)
+        self.gK = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().gK, self)
+        self.gL = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().gL, self)
+        self.phi = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().phi, self)
+        self.gNa = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().gNa, self)
+        self.TK = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().TK, self)
+        self.TCa = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().TCa, self)
+        self.TNa = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().TNa, self)
+        self.VCa = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().VCa, self)
+        self.VK = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().VK, self)
+        self.VL = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().VL, self)
+        self.VNa = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().VNa, self)
+        self.d_K = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().d_K, self)
+        self.tau_K = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().tau_K, self)
+        self.d_Na = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().d_Na, self)
+        self.d_Ca = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().d_Ca, self)
+        self.aei = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().aei, self)
+        self.aie = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().aie, self)
+        self.b = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().b, self)
+        self.C = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().C, self)
+        self.ane = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().ane, self)
+        self.ani = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().ani, self)
+        self.aee = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().aee, self)
+        self.Iext = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().Iext, self)
+        self.rNMDA = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().rNMDA, self)
+        self.VT = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().VT, self)
+        self.d_V = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().d_V, self)
+        self.ZT = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().ZT, self)
+        self.d_Z = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().d_Z, self)
+        self.QV_max = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().QV_max, self)
+        self.QZ_max = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().QZ_max, self)
+        self.t_scale = ArrayField(ModelsEnum.LARTER_BREAKSPEAR.get_class().t_scale, self)
+        self.variables_of_interest = MultiSelectField(ModelsEnum.LARTER_BREAKSPEAR.get_class().variables_of_interest,
+                                                      self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():

--- a/framework_tvb/tvb/core/entities/file/simulator/h5_factory.py
+++ b/framework_tvb/tvb/core/entities/file/simulator/h5_factory.py
@@ -30,7 +30,7 @@
 from tvb.datatypes.cortex import Cortex
 from tvb.simulator.coupling import Coupling
 from tvb.simulator.integrators import *
-from tvb.simulator.models import Model
+from tvb.simulator.models import ModelsEnum
 from tvb.simulator.monitors import Monitor, SubSample, GlobalAverage, TemporalAverage
 from tvb.simulator.noise import Additive, Multiplicative, Noise
 
@@ -45,7 +45,7 @@ def config_h5_factory(config_class):
         return integrator_h5_factory(config_class)
     if issubclass(config_class, Coupling):
         return coupling_h5_factory(config_class)
-    if issubclass(config_class, Model):
+    if issubclass(config_class, ModelsEnum.BASE_MODEL.get_class()):
         return model_h5_factory(config_class)
     if issubclass(config_class, Monitor):
         return monitor_h5_factory(config_class)
@@ -107,36 +107,33 @@ def coupling_h5_factory(coupling_class):
 
 
 def model_h5_factory(model_class):
-    from tvb.simulator.models import Epileptor, Epileptor2D, EpileptorCodim3, EpileptorCodim3SlowMod, Hopfield, \
-        JansenRit, ZetterbergJansen, EpileptorRestingState, LarterBreakspear, Generic2dOscillator, \
-        ReducedSetFitzHughNagumo, ReducedSetHindmarshRose, WilsonCowan, ReducedWongWang, ReducedWongWangExcInh, \
-        ZerlautAdaptationFirstOrder, ZerlautAdaptationSecondOrder, SupHopf, Linear, Kuramoto
     from tvb.core.entities.file.simulator.model_h5 import EpileptorH5, Epileptor2DH5, EpileptorCodim3H5, \
         EpileptorCodim3SlowModH5, HopfieldH5, JansenRitH5, ZetterbergJansenH5, EpileptorRestingStateH5, \
         LarterBreakspearH5, LinearH5, Generic2dOscillatorH5, KuramotoH5, ReducedSetFitzHughNagumoH5, \
-        ReducedSetHindmarshRoseH5, WilsonCowanH5, ReducedWongWangH5, ReducedWongWangExcInhH5, ZerlautAdaptationFirstOrderH5, \
+        ReducedSetHindmarshRoseH5, WilsonCowanH5, ReducedWongWangH5, ReducedWongWangExcInhH5, \
+        ZerlautAdaptationFirstOrderH5, \
         ZerlautAdaptationSecondOrderH5, SupHopfH5
     model_class_to_h5 = {
-        Epileptor: EpileptorH5,
-        Epileptor2D: Epileptor2DH5,
-        EpileptorCodim3: EpileptorCodim3H5,
-        EpileptorCodim3SlowMod: EpileptorCodim3SlowModH5,
-        Hopfield: HopfieldH5,
-        JansenRit: JansenRitH5,
-        ZetterbergJansen: ZetterbergJansenH5,
-        EpileptorRestingState: EpileptorRestingStateH5,
-        LarterBreakspear: LarterBreakspearH5,
-        Linear: LinearH5,
-        Generic2dOscillator: Generic2dOscillatorH5,
-        Kuramoto: KuramotoH5,
-        ReducedSetFitzHughNagumo: ReducedSetFitzHughNagumoH5,
-        ReducedSetHindmarshRose: ReducedSetHindmarshRoseH5,
-        WilsonCowan: WilsonCowanH5,
-        ReducedWongWang: ReducedWongWangH5,
-        ReducedWongWangExcInh: ReducedWongWangExcInhH5,
-        ZerlautAdaptationFirstOrder: ZerlautAdaptationFirstOrderH5,
-        ZerlautAdaptationSecondOrder: ZerlautAdaptationSecondOrderH5,
-        SupHopf: SupHopfH5
+        ModelsEnum.EPILEPTOR.get_class(): EpileptorH5,
+        ModelsEnum.EPILEPTOR_2D.get_class(): Epileptor2DH5,
+        ModelsEnum.EPILEPTOR_CODIM_3.get_class(): EpileptorCodim3H5,
+        ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class(): EpileptorCodim3SlowModH5,
+        ModelsEnum.HOPFIELD.get_class(): HopfieldH5,
+        ModelsEnum.JANSEN_RIT.get_class(): JansenRitH5,
+        ModelsEnum.ZETTERBERG_JANSEN.get_class(): ZetterbergJansenH5,
+        ModelsEnum.EPILEPTOR_RS.get_class(): EpileptorRestingStateH5,
+        ModelsEnum.LARTER_BREAKSPEAR.get_class(): LarterBreakspearH5,
+        ModelsEnum.LINEAR.get_class(): LinearH5,
+        ModelsEnum.GENERIC_2D_OSCILLATOR.get_class(): Generic2dOscillatorH5,
+        ModelsEnum.KURAMOTO.get_class(): KuramotoH5,
+        ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class(): ReducedSetFitzHughNagumoH5,
+        ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class(): ReducedSetHindmarshRoseH5,
+        ModelsEnum.WILSON_COWAN.get_class(): WilsonCowanH5,
+        ModelsEnum.REDUCED_WONG_WANG.get_class(): ReducedWongWangH5,
+        ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class(): ReducedWongWangExcInhH5,
+        ModelsEnum.ZERLAUT_FIRST_ORDER.get_class(): ZerlautAdaptationFirstOrderH5,
+        ModelsEnum.ZERLAUT_SECOND_ORDER.get_class(): ZerlautAdaptationSecondOrderH5,
+        ModelsEnum.SUP_HOPF.get_class(): SupHopfH5
     }
 
     return model_class_to_h5.get(model_class)

--- a/framework_tvb/tvb/core/entities/file/simulator/model_h5.py
+++ b/framework_tvb/tvb/core/entities/file/simulator/model_h5.py
@@ -29,7 +29,7 @@
 #
 import json
 import numpy
-from tvb.simulator.models import *
+from tvb.simulator.models import ModelsEnum
 from tvb.core.entities.file.simulator.configurations_h5 import SimulatorConfigurationH5
 from tvb.core.neotraits.h5 import DataSet, Json, JsonFinal
 
@@ -57,27 +57,28 @@ class EpileptorH5(SimulatorConfigurationH5):
     def __init__(self, path):
         super(EpileptorH5, self).__init__(path)
 
-        self.a = DataSet(Epileptor.a, self)
-        self.b = DataSet(Epileptor.b, self)
-        self.c = DataSet(Epileptor.c, self)
-        self.d = DataSet(Epileptor.d, self)
-        self.r = DataSet(Epileptor.r, self)
-        self.s = DataSet(Epileptor.s, self)
-        self.x0 = DataSet(Epileptor.x0, self)
-        self.Iext = DataSet(Epileptor.Iext, self)
-        self.slope = DataSet(Epileptor.slope, self)
-        self.Iext2 = DataSet(Epileptor.Iext2, self)
-        self.tau = DataSet(Epileptor.tau, self)
-        self.aa = DataSet(Epileptor.aa, self)
-        self.bb = DataSet(Epileptor.bb, self)
-        self.Kvf = DataSet(Epileptor.Kvf, self)
-        self.Kf = DataSet(Epileptor.Kf, self)
-        self.Ks = DataSet(Epileptor.Ks, self)
-        self.tt = DataSet(Epileptor.tt, self)
-        self.modification = DataSet(Epileptor.modification, self)
-        self.state_variable_range = JsonFinal(Epileptor.state_variable_range, self, json_encoder=StateVariablesEncoder,
+        self.a = DataSet(ModelsEnum.EPILEPTOR.get_class().a, self)
+        self.b = DataSet(ModelsEnum.EPILEPTOR.get_class().b, self)
+        self.c = DataSet(ModelsEnum.EPILEPTOR.get_class().c, self)
+        self.d = DataSet(ModelsEnum.EPILEPTOR.get_class().d, self)
+        self.r = DataSet(ModelsEnum.EPILEPTOR.get_class().r, self)
+        self.s = DataSet(ModelsEnum.EPILEPTOR.get_class().s, self)
+        self.x0 = DataSet(ModelsEnum.EPILEPTOR.get_class().x0, self)
+        self.Iext = DataSet(ModelsEnum.EPILEPTOR.get_class().Iext, self)
+        self.slope = DataSet(ModelsEnum.EPILEPTOR.get_class().slope, self)
+        self.Iext2 = DataSet(ModelsEnum.EPILEPTOR.get_class().Iext2, self)
+        self.tau = DataSet(ModelsEnum.EPILEPTOR.get_class().tau, self)
+        self.aa = DataSet(ModelsEnum.EPILEPTOR.get_class().aa, self)
+        self.bb = DataSet(ModelsEnum.EPILEPTOR.get_class().bb, self)
+        self.Kvf = DataSet(ModelsEnum.EPILEPTOR.get_class().Kvf, self)
+        self.Kf = DataSet(ModelsEnum.EPILEPTOR.get_class().Kf, self)
+        self.Ks = DataSet(ModelsEnum.EPILEPTOR.get_class().Ks, self)
+        self.tt = DataSet(ModelsEnum.EPILEPTOR.get_class().tt, self)
+        self.modification = DataSet(ModelsEnum.EPILEPTOR.get_class().modification, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.EPILEPTOR.get_class().state_variable_range, self,
+                                              json_encoder=StateVariablesEncoder,
                                               json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(Epileptor.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.EPILEPTOR.get_class().variables_of_interest, self)
 
 
 class Epileptor2DH5(SimulatorConfigurationH5):
@@ -85,214 +86,216 @@ class Epileptor2DH5(SimulatorConfigurationH5):
     def __init__(self, path):
         super(Epileptor2DH5, self).__init__(path)
 
-        self.a = DataSet(Epileptor2D.a, self)
-        self.b = DataSet(Epileptor2D.b, self)
-        self.c = DataSet(Epileptor2D.c, self)
-        self.d = DataSet(Epileptor2D.d, self)
-        self.r = DataSet(Epileptor2D.r, self)
-        self.x0 = DataSet(Epileptor2D.x0, self)
-        self.Iext = DataSet(Epileptor2D.Iext, self)
-        self.slope = DataSet(Epileptor2D.slope, self)
-        self.Kvf = DataSet(Epileptor2D.Kvf, self)
-        self.Ks = DataSet(Epileptor2D.Ks, self)
-        self.tt = DataSet(Epileptor2D.tt, self)
-        self.modification = DataSet(Epileptor2D.modification, self)
-        self.state_variable_range = JsonFinal(Epileptor2D.state_variable_range, self,
+        self.a = DataSet(ModelsEnum.EPILEPTOR_2D.get_class().a, self)
+        self.b = DataSet(ModelsEnum.EPILEPTOR_2D.get_class().b, self)
+        self.c = DataSet(ModelsEnum.EPILEPTOR_2D.get_class().c, self)
+        self.d = DataSet(ModelsEnum.EPILEPTOR_2D.get_class().d, self)
+        self.r = DataSet(ModelsEnum.EPILEPTOR_2D.get_class().r, self)
+        self.x0 = DataSet(ModelsEnum.EPILEPTOR_2D.get_class().x0, self)
+        self.Iext = DataSet(ModelsEnum.EPILEPTOR_2D.get_class().Iext, self)
+        self.slope = DataSet(ModelsEnum.EPILEPTOR_2D.get_class().slope, self)
+        self.Kvf = DataSet(ModelsEnum.EPILEPTOR_2D.get_class().Kvf, self)
+        self.Ks = DataSet(ModelsEnum.EPILEPTOR_2D.get_class().Ks, self)
+        self.tt = DataSet(ModelsEnum.EPILEPTOR_2D.get_class().tt, self)
+        self.modification = DataSet(ModelsEnum.EPILEPTOR_2D.get_class().modification, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.EPILEPTOR_2D.get_class().state_variable_range, self,
                                               json_encoder=StateVariablesEncoder, json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(Epileptor2D.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.EPILEPTOR_2D.get_class().variables_of_interest, self)
 
 
 class EpileptorCodim3H5(SimulatorConfigurationH5):
 
     def __init__(self, path):
         super(EpileptorCodim3H5, self).__init__(path)
-        self.mu1_start = DataSet(EpileptorCodim3.mu1_start, self)
-        self.mu2_start = DataSet(EpileptorCodim3.mu2_start, self)
-        self.nu_start = DataSet(EpileptorCodim3.nu_start, self)
-        self.mu1_stop = DataSet(EpileptorCodim3.mu1_stop, self)
-        self.mu2_stop = DataSet(EpileptorCodim3.mu2_stop, self)
-        self.nu_stop = DataSet(EpileptorCodim3.nu_stop, self)
-        self.b = DataSet(EpileptorCodim3.b, self)
-        self.R = DataSet(EpileptorCodim3.R, self)
-        self.c = DataSet(EpileptorCodim3.c, self)
-        self.dstar = DataSet(EpileptorCodim3.dstar, self)
-        self.Ks = DataSet(EpileptorCodim3.Ks, self)
-        self.N = DataSet(EpileptorCodim3.N, self)
-        self.modification = DataSet(EpileptorCodim3.modification, self)
-        self.state_variable_range = JsonFinal(EpileptorCodim3.state_variable_range, self,
+        self.mu1_start = DataSet(ModelsEnum.EPILEPTOR_CODIM_3.get_class().mu1_start, self)
+        self.mu2_start = DataSet(ModelsEnum.EPILEPTOR_CODIM_3.get_class().mu2_start, self)
+        self.nu_start = DataSet(ModelsEnum.EPILEPTOR_CODIM_3.get_class().nu_start, self)
+        self.mu1_stop = DataSet(ModelsEnum.EPILEPTOR_CODIM_3.get_class().mu1_stop, self)
+        self.mu2_stop = DataSet(ModelsEnum.EPILEPTOR_CODIM_3.get_class().mu2_stop, self)
+        self.nu_stop = DataSet(ModelsEnum.EPILEPTOR_CODIM_3.get_class().nu_stop, self)
+        self.b = DataSet(ModelsEnum.EPILEPTOR_CODIM_3.get_class().b, self)
+        self.R = DataSet(ModelsEnum.EPILEPTOR_CODIM_3.get_class().R, self)
+        self.c = DataSet(ModelsEnum.EPILEPTOR_CODIM_3.get_class().c, self)
+        self.dstar = DataSet(ModelsEnum.EPILEPTOR_CODIM_3.get_class().dstar, self)
+        self.Ks = DataSet(ModelsEnum.EPILEPTOR_CODIM_3.get_class().Ks, self)
+        self.N = DataSet(ModelsEnum.EPILEPTOR_CODIM_3.get_class().N, self)
+        self.modification = DataSet(ModelsEnum.EPILEPTOR_CODIM_3.get_class().modification, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.EPILEPTOR_CODIM_3.get_class().state_variable_range, self,
                                               json_encoder=StateVariablesEncoder, json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(EpileptorCodim3.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.EPILEPTOR_CODIM_3.get_class().variables_of_interest, self)
 
 
 class EpileptorCodim3SlowModH5(SimulatorConfigurationH5):
 
     def __init__(self, path):
         super(EpileptorCodim3SlowModH5, self).__init__(path)
-        self.mu1_Ain = DataSet(EpileptorCodim3SlowMod.mu1_Ain, self)
-        self.mu2_Ain = DataSet(EpileptorCodim3SlowMod.mu2_Ain, self)
-        self.nu_Ain = DataSet(EpileptorCodim3SlowMod.nu_Ain, self)
-        self.mu1_Bin = DataSet(EpileptorCodim3SlowMod.mu1_Bin, self)
-        self.mu2_Bin = DataSet(EpileptorCodim3SlowMod.mu2_Bin, self)
-        self.nu_Bin = DataSet(EpileptorCodim3SlowMod.nu_Bin, self)
-        self.mu1_Aend = DataSet(EpileptorCodim3SlowMod.mu1_Aend, self)
-        self.mu2_Aend = DataSet(EpileptorCodim3SlowMod.mu2_Aend, self)
-        self.nu_Aend = DataSet(EpileptorCodim3SlowMod.nu_Aend, self)
-        self.mu1_Bend = DataSet(EpileptorCodim3SlowMod.mu1_Bend, self)
-        self.mu2_Bend = DataSet(EpileptorCodim3SlowMod.mu2_Bend, self)
-        self.nu_Bend = DataSet(EpileptorCodim3SlowMod.nu_Bend, self)
-        self.b = DataSet(EpileptorCodim3SlowMod.b, self)
-        self.R = DataSet(EpileptorCodim3SlowMod.R, self)
-        self.c = DataSet(EpileptorCodim3SlowMod.c, self)
-        self.cA = DataSet(EpileptorCodim3SlowMod.cA, self)
-        self.cB = DataSet(EpileptorCodim3SlowMod.cB, self)
-        self.dstar = DataSet(EpileptorCodim3SlowMod.dstar, self)
-        self.Ks = DataSet(EpileptorCodim3SlowMod.Ks, self)
-        self.N = DataSet(EpileptorCodim3SlowMod.N, self)
-        self.modification = DataSet(EpileptorCodim3SlowMod.modification, self)
-        self.state_variable_range = JsonFinal(EpileptorCodim3SlowMod.state_variable_range, self,
+        self.mu1_Ain = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().mu1_Ain, self)
+        self.mu2_Ain = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().mu2_Ain, self)
+        self.nu_Ain = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().nu_Ain, self)
+        self.mu1_Bin = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().mu1_Bin, self)
+        self.mu2_Bin = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().mu2_Bin, self)
+        self.nu_Bin = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().nu_Bin, self)
+        self.mu1_Aend = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().mu1_Aend, self)
+        self.mu2_Aend = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().mu2_Aend, self)
+        self.nu_Aend = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().nu_Aend, self)
+        self.mu1_Bend = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().mu1_Bend, self)
+        self.mu2_Bend = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().mu2_Bend, self)
+        self.nu_Bend = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().nu_Bend, self)
+        self.b = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().b, self)
+        self.R = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().R, self)
+        self.c = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().c, self)
+        self.cA = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().cA, self)
+        self.cB = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().cB, self)
+        self.dstar = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().dstar, self)
+        self.Ks = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().Ks, self)
+        self.N = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().N, self)
+        self.modification = DataSet(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().modification, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().state_variable_range, self,
                                               json_encoder=StateVariablesEncoder, json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(EpileptorCodim3SlowMod.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().variables_of_interest, self)
 
 
 class HopfieldH5(SimulatorConfigurationH5):
 
     def __init__(self, path):
         super(HopfieldH5, self).__init__(path)
-        self.taux = DataSet(Hopfield.taux, self)
-        self.tauT = DataSet(Hopfield.tauT, self)
-        self.dynamic = DataSet(Hopfield.dynamic, self)
-        self.state_variable_range = JsonFinal(Hopfield.state_variable_range, self, json_encoder=StateVariablesEncoder,
+        self.taux = DataSet(ModelsEnum.HOPFIELD.get_class().taux, self)
+        self.tauT = DataSet(ModelsEnum.HOPFIELD.get_class().tauT, self)
+        self.dynamic = DataSet(ModelsEnum.HOPFIELD.get_class().dynamic, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.HOPFIELD.get_class().state_variable_range, self,
+                                              json_encoder=StateVariablesEncoder,
                                               json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(Hopfield.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.HOPFIELD.get_class().variables_of_interest, self)
 
 
 class JansenRitH5(SimulatorConfigurationH5):
 
     def __init__(self, path):
         super(JansenRitH5, self).__init__(path)
-        self.A = DataSet(JansenRit.A, self)
-        self.B = DataSet(JansenRit.B, self)
-        self.a = DataSet(JansenRit.a, self)
-        self.b = DataSet(JansenRit.b, self)
-        self.v0 = DataSet(JansenRit.v0, self)
-        self.nu_max = DataSet(JansenRit.nu_max, self)
-        self.r = DataSet(JansenRit.r, self)
-        self.J = DataSet(JansenRit.J, self)
-        self.a_1 = DataSet(JansenRit.a_1, self)
-        self.a_2 = DataSet(JansenRit.a_2, self)
-        self.a_3 = DataSet(JansenRit.a_3, self)
-        self.a_4 = DataSet(JansenRit.a_4, self)
-        self.p_min = DataSet(JansenRit.p_min, self)
-        self.p_max = DataSet(JansenRit.p_max, self)
-        self.mu = DataSet(JansenRit.mu, self)
-        self.state_variable_range = JsonFinal(JansenRit.state_variable_range, self, json_encoder=StateVariablesEncoder,
+        self.A = DataSet(ModelsEnum.JANSEN_RIT.get_class().A, self)
+        self.B = DataSet(ModelsEnum.JANSEN_RIT.get_class().B, self)
+        self.a = DataSet(ModelsEnum.JANSEN_RIT.get_class().a, self)
+        self.b = DataSet(ModelsEnum.JANSEN_RIT.get_class().b, self)
+        self.v0 = DataSet(ModelsEnum.JANSEN_RIT.get_class().v0, self)
+        self.nu_max = DataSet(ModelsEnum.JANSEN_RIT.get_class().nu_max, self)
+        self.r = DataSet(ModelsEnum.JANSEN_RIT.get_class().r, self)
+        self.J = DataSet(ModelsEnum.JANSEN_RIT.get_class().J, self)
+        self.a_1 = DataSet(ModelsEnum.JANSEN_RIT.get_class().a_1, self)
+        self.a_2 = DataSet(ModelsEnum.JANSEN_RIT.get_class().a_2, self)
+        self.a_3 = DataSet(ModelsEnum.JANSEN_RIT.get_class().a_3, self)
+        self.a_4 = DataSet(ModelsEnum.JANSEN_RIT.get_class().a_4, self)
+        self.p_min = DataSet(ModelsEnum.JANSEN_RIT.get_class().p_min, self)
+        self.p_max = DataSet(ModelsEnum.JANSEN_RIT.get_class().p_max, self)
+        self.mu = DataSet(ModelsEnum.JANSEN_RIT.get_class().mu, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.JANSEN_RIT.get_class().state_variable_range, self,
+                                              json_encoder=StateVariablesEncoder,
                                               json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(JansenRit.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.JANSEN_RIT.get_class().variables_of_interest, self)
 
 
 class ZetterbergJansenH5(SimulatorConfigurationH5):
 
     def __init__(self, path):
         super(ZetterbergJansenH5, self).__init__(path)
-        self.He = DataSet(ZetterbergJansen.He, self)
-        self.Hi = DataSet(ZetterbergJansen.Hi, self)
-        self.ke = DataSet(ZetterbergJansen.ke, self)
-        self.ki = DataSet(ZetterbergJansen.ki, self)
-        self.e0 = DataSet(ZetterbergJansen.e0, self)
-        self.rho_2 = DataSet(ZetterbergJansen.rho_2, self)
-        self.rho_1 = DataSet(ZetterbergJansen.rho_1, self)
-        self.gamma_1 = DataSet(ZetterbergJansen.gamma_1, self)
-        self.gamma_2 = DataSet(ZetterbergJansen.gamma_2, self)
-        self.gamma_3 = DataSet(ZetterbergJansen.gamma_3, self)
-        self.gamma_4 = DataSet(ZetterbergJansen.gamma_4, self)
-        self.gamma_5 = DataSet(ZetterbergJansen.gamma_5, self)
-        self.gamma_1T = DataSet(ZetterbergJansen.gamma_1T, self)
-        self.gamma_2T = DataSet(ZetterbergJansen.gamma_2T, self)
-        self.gamma_3T = DataSet(ZetterbergJansen.gamma_3T, self)
-        self.P = DataSet(ZetterbergJansen.P, self)
-        self.U = DataSet(ZetterbergJansen.U, self)
-        self.Q = DataSet(ZetterbergJansen.Q, self)
-        self.state_variable_range = JsonFinal(ZetterbergJansen.state_variable_range, self,
+        self.He = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().He, self)
+        self.Hi = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().Hi, self)
+        self.ke = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().ke, self)
+        self.ki = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().ki, self)
+        self.e0 = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().e0, self)
+        self.rho_2 = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().rho_2, self)
+        self.rho_1 = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().rho_1, self)
+        self.gamma_1 = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().gamma_1, self)
+        self.gamma_2 = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().gamma_2, self)
+        self.gamma_3 = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().gamma_3, self)
+        self.gamma_4 = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().gamma_4, self)
+        self.gamma_5 = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().gamma_5, self)
+        self.gamma_1T = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().gamma_1T, self)
+        self.gamma_2T = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().gamma_2T, self)
+        self.gamma_3T = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().gamma_3T, self)
+        self.P = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().P, self)
+        self.U = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().U, self)
+        self.Q = DataSet(ModelsEnum.ZETTERBERG_JANSEN.get_class().Q, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.ZETTERBERG_JANSEN.get_class().state_variable_range, self,
                                               json_encoder=StateVariablesEncoder, json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(ZetterbergJansen.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.ZETTERBERG_JANSEN.get_class().variables_of_interest, self)
 
 
 class EpileptorRestingStateH5(SimulatorConfigurationH5):
 
     def __init__(self, path):
         super(EpileptorRestingStateH5, self).__init__(path)
-        self.a = DataSet(EpileptorRestingState.a, self)
-        self.b = DataSet(EpileptorRestingState.b, self)
-        self.c = DataSet(EpileptorRestingState.c, self)
-        self.d = DataSet(EpileptorRestingState.d, self)
-        self.r = DataSet(EpileptorRestingState.r, self)
-        self.s = DataSet(EpileptorRestingState.s, self)
-        self.x0 = DataSet(EpileptorRestingState.x0, self)
-        self.Iext = DataSet(EpileptorRestingState.Iext, self)
-        self.slope = DataSet(EpileptorRestingState.slope, self)
-        self.Iext2 = DataSet(EpileptorRestingState.Iext2, self)
-        self.tau = DataSet(EpileptorRestingState.tau, self)
-        self.aa = DataSet(EpileptorRestingState.aa, self)
-        self.bb = DataSet(EpileptorRestingState.bb, self)
-        self.Kvf = DataSet(EpileptorRestingState.Kvf, self)
-        self.Kf = DataSet(EpileptorRestingState.Kf, self)
-        self.Ks = DataSet(EpileptorRestingState.Ks, self)
-        self.tt = DataSet(EpileptorRestingState.tt, self)
-        self.tau_rs = DataSet(EpileptorRestingState.tau_rs, self)
-        self.I_rs = DataSet(EpileptorRestingState.I_rs, self)
-        self.a_rs = DataSet(EpileptorRestingState.a_rs, self)
-        self.b_rs = DataSet(EpileptorRestingState.b_rs, self)
-        self.d_rs = DataSet(EpileptorRestingState.d_rs, self)
-        self.e_rs = DataSet(EpileptorRestingState.e_rs, self)
-        self.f_rs = DataSet(EpileptorRestingState.f_rs, self)
-        self.alpha_rs = DataSet(EpileptorRestingState.alpha_rs, self)
-        self.beta_rs = DataSet(EpileptorRestingState.beta_rs, self)
-        self.gamma_rs = DataSet(EpileptorRestingState.gamma_rs, self)
-        self.K_rs = DataSet(EpileptorRestingState.K_rs, self)
-        self.p = DataSet(EpileptorRestingState.p, self)
-        self.state_variable_range = JsonFinal(EpileptorRestingState.state_variable_range, self,
+        self.a = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().a, self)
+        self.b = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().b, self)
+        self.c = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().c, self)
+        self.d = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().d, self)
+        self.r = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().r, self)
+        self.s = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().s, self)
+        self.x0 = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().x0, self)
+        self.Iext = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().Iext, self)
+        self.slope = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().slope, self)
+        self.Iext2 = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().Iext2, self)
+        self.tau = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().tau, self)
+        self.aa = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().aa, self)
+        self.bb = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().bb, self)
+        self.Kvf = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().Kvf, self)
+        self.Kf = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().Kf, self)
+        self.Ks = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().Ks, self)
+        self.tt = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().tt, self)
+        self.tau_rs = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().tau_rs, self)
+        self.I_rs = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().I_rs, self)
+        self.a_rs = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().a_rs, self)
+        self.b_rs = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().b_rs, self)
+        self.d_rs = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().d_rs, self)
+        self.e_rs = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().e_rs, self)
+        self.f_rs = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().f_rs, self)
+        self.alpha_rs = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().alpha_rs, self)
+        self.beta_rs = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().beta_rs, self)
+        self.gamma_rs = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().gamma_rs, self)
+        self.K_rs = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().K_rs, self)
+        self.p = DataSet(ModelsEnum.EPILEPTOR_RS.get_class().p, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.EPILEPTOR_RS.get_class().state_variable_range, self,
                                               json_encoder=StateVariablesEncoder, json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(EpileptorRestingState.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.EPILEPTOR_RS.get_class().variables_of_interest, self)
 
 
 class LarterBreakspearH5(SimulatorConfigurationH5):
 
     def __init__(self, path):
         super(LarterBreakspearH5, self).__init__(path)
-        self.gCa = DataSet(LarterBreakspear.gCa, self)
-        self.gK = DataSet(LarterBreakspear.gK, self)
-        self.gL = DataSet(LarterBreakspear.gL, self)
-        self.phi = DataSet(LarterBreakspear.phi, self)
-        self.gNa = DataSet(LarterBreakspear.gNa, self)
-        self.TK = DataSet(LarterBreakspear.TK, self)
-        self.TCa = DataSet(LarterBreakspear.TCa, self)
-        self.TNa = DataSet(LarterBreakspear.TNa, self)
-        self.VCa = DataSet(LarterBreakspear.VCa, self)
-        self.VK = DataSet(LarterBreakspear.VK, self)
-        self.VL = DataSet(LarterBreakspear.VL, self)
-        self.VNa = DataSet(LarterBreakspear.VNa, self)
-        self.d_K = DataSet(LarterBreakspear.d_K, self)
-        self.tau_K = DataSet(LarterBreakspear.tau_K, self)
-        self.d_Na = DataSet(LarterBreakspear.d_Na, self)
-        self.d_Ca = DataSet(LarterBreakspear.d_Ca, self)
-        self.aei = DataSet(LarterBreakspear.aei, self)
-        self.aie = DataSet(LarterBreakspear.aie, self)
-        self.b = DataSet(LarterBreakspear.b, self)
-        self.C = DataSet(LarterBreakspear.C, self)
-        self.ane = DataSet(LarterBreakspear.ane, self)
-        self.ani = DataSet(LarterBreakspear.ani, self)
-        self.aee = DataSet(LarterBreakspear.aee, self)
-        self.Iext = DataSet(LarterBreakspear.Iext, self)
-        self.rNMDA = DataSet(LarterBreakspear.rNMDA, self)
-        self.VT = DataSet(LarterBreakspear.VT, self)
-        self.d_V = DataSet(LarterBreakspear.d_V, self)
-        self.ZT = DataSet(LarterBreakspear.ZT, self)
-        self.d_Z = DataSet(LarterBreakspear.d_Z, self)
-        self.QV_max = DataSet(LarterBreakspear.QV_max, self)
-        self.QZ_max = DataSet(LarterBreakspear.QZ_max, self)
-        self.t_scale = DataSet(LarterBreakspear.t_scale, self)
-        self.variables_of_interest = Json(LarterBreakspear.variables_of_interest, self)
-        self.state_variable_range = JsonFinal(LarterBreakspear.state_variable_range, self,
+        self.gCa = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().gCa, self)
+        self.gK = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().gK, self)
+        self.gL = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().gL, self)
+        self.phi = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().phi, self)
+        self.gNa = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().gNa, self)
+        self.TK = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().TK, self)
+        self.TCa = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().TCa, self)
+        self.TNa = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().TNa, self)
+        self.VCa = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().VCa, self)
+        self.VK = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().VK, self)
+        self.VL = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().VL, self)
+        self.VNa = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().VNa, self)
+        self.d_K = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().d_K, self)
+        self.tau_K = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().tau_K, self)
+        self.d_Na = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().d_Na, self)
+        self.d_Ca = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().d_Ca, self)
+        self.aei = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().aei, self)
+        self.aie = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().aie, self)
+        self.b = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().b, self)
+        self.C = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().C, self)
+        self.ane = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().ane, self)
+        self.ani = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().ani, self)
+        self.aee = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().aee, self)
+        self.Iext = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().Iext, self)
+        self.rNMDA = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().rNMDA, self)
+        self.VT = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().VT, self)
+        self.d_V = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().d_V, self)
+        self.ZT = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().ZT, self)
+        self.d_Z = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().d_Z, self)
+        self.QV_max = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().QV_max, self)
+        self.QZ_max = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().QZ_max, self)
+        self.t_scale = DataSet(ModelsEnum.LARTER_BREAKSPEAR.get_class().t_scale, self)
+        self.variables_of_interest = Json(ModelsEnum.LARTER_BREAKSPEAR.get_class().variables_of_interest, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.LARTER_BREAKSPEAR.get_class().state_variable_range, self,
                                               json_encoder=StateVariablesEncoder, json_decoder=StateVariablesDecoder)
 
 
@@ -300,209 +303,216 @@ class LinearH5(SimulatorConfigurationH5):
 
     def __init__(self, path):
         super(LinearH5, self).__init__(path)
-        self.gamma = DataSet(Linear.gamma, self)
-        self.state_variable_range = JsonFinal(Linear.state_variable_range, self, json_encoder=StateVariablesEncoder,
+        self.gamma = DataSet(ModelsEnum.LINEAR.get_class().gamma, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.LINEAR.get_class().state_variable_range, self,
+                                              json_encoder=StateVariablesEncoder,
                                               json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(Linear.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.LINEAR.get_class().variables_of_interest, self)
 
 
 class Generic2dOscillatorH5(SimulatorConfigurationH5):
 
     def __init__(self, path):
         super(Generic2dOscillatorH5, self).__init__(path)
-        self.tau = DataSet(Generic2dOscillator.tau, self)
-        self.I = DataSet(Generic2dOscillator.I, self)
-        self.a = DataSet(Generic2dOscillator.a, self)
-        self.b = DataSet(Generic2dOscillator.b, self)
-        self.c = DataSet(Generic2dOscillator.c, self)
-        self.d = DataSet(Generic2dOscillator.d, self)
-        self.e = DataSet(Generic2dOscillator.e, self)
-        self.f = DataSet(Generic2dOscillator.f, self)
-        self.g = DataSet(Generic2dOscillator.g, self)
-        self.alpha = DataSet(Generic2dOscillator.alpha, self)
-        self.beta = DataSet(Generic2dOscillator.beta, self)
-        self.gamma = DataSet(Generic2dOscillator.gamma, self)
-        self.state_variable_range = JsonFinal(Generic2dOscillator.state_variable_range, self,
+        self.tau = DataSet(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().tau, self)
+        self.I = DataSet(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().I, self)
+        self.a = DataSet(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().a, self)
+        self.b = DataSet(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().b, self)
+        self.c = DataSet(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().c, self)
+        self.d = DataSet(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().d, self)
+        self.e = DataSet(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().e, self)
+        self.f = DataSet(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().f, self)
+        self.g = DataSet(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().g, self)
+        self.alpha = DataSet(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().alpha, self)
+        self.beta = DataSet(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().beta, self)
+        self.gamma = DataSet(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().gamma, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().state_variable_range, self,
                                               json_encoder=StateVariablesEncoder, json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(Generic2dOscillator.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().variables_of_interest, self)
 
 
 class KuramotoH5(SimulatorConfigurationH5):
 
     def __init__(self, path):
         super(KuramotoH5, self).__init__(path)
-        self.omega = DataSet(Kuramoto.omega, self)
-        self.state_variable_range = JsonFinal(Kuramoto.state_variable_range, self, json_encoder=StateVariablesEncoder,
+        self.omega = DataSet(ModelsEnum.KURAMOTO.get_class().omega, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.KURAMOTO.get_class().state_variable_range, self,
+                                              json_encoder=StateVariablesEncoder,
                                               json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(Kuramoto.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.KURAMOTO.get_class().variables_of_interest, self)
 
 
 class SupHopfH5(SimulatorConfigurationH5):
 
     def __init__(self, path):
         super(SupHopfH5, self).__init__(path)
-        self.a = DataSet(SupHopf.a, self)
-        self.omega = DataSet(SupHopf.omega, self)
-        self.state_variable_range = JsonFinal(SupHopf.state_variable_range, self, json_encoder=StateVariablesEncoder,
+        self.a = DataSet(ModelsEnum.SUP_HOPF.get_class().a, self)
+        self.omega = DataSet(ModelsEnum.SUP_HOPF.get_class().omega, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.SUP_HOPF.get_class().state_variable_range, self,
+                                              json_encoder=StateVariablesEncoder,
                                               json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(SupHopf.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.SUP_HOPF.get_class().variables_of_interest, self)
 
 
 class ReducedSetFitzHughNagumoH5(SimulatorConfigurationH5):
 
     def __init__(self, path):
         super(ReducedSetFitzHughNagumoH5, self).__init__(path)
-        self.tau = DataSet(ReducedSetFitzHughNagumo.tau, self)
-        self.a = DataSet(ReducedSetFitzHughNagumo.a, self)
-        self.b = DataSet(ReducedSetFitzHughNagumo.b, self)
-        self.K11 = DataSet(ReducedSetFitzHughNagumo.K11, self)
-        self.K12 = DataSet(ReducedSetFitzHughNagumo.K12, self)
-        self.K21 = DataSet(ReducedSetFitzHughNagumo.K21, self)
-        self.sigma = DataSet(ReducedSetFitzHughNagumo.sigma, self)
-        self.mu = DataSet(ReducedSetFitzHughNagumo.mu, self)
-        self.state_variable_range = JsonFinal(ReducedSetFitzHughNagumo.state_variable_range, self,
+        self.tau = DataSet(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().tau, self)
+        self.a = DataSet(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().a, self)
+        self.b = DataSet(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().b, self)
+        self.K11 = DataSet(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().K11, self)
+        self.K12 = DataSet(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().K12, self)
+        self.K21 = DataSet(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().K21, self)
+        self.sigma = DataSet(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().sigma, self)
+        self.mu = DataSet(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().mu, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().state_variable_range,
+                                              self,
                                               json_encoder=StateVariablesEncoder, json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(ReducedSetFitzHughNagumo.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO.get_class().variables_of_interest,
+                                          self)
 
 
 class ReducedSetHindmarshRoseH5(SimulatorConfigurationH5):
 
     def __init__(self, path):
         super(ReducedSetHindmarshRoseH5, self).__init__(path)
-        self.r = DataSet(ReducedSetHindmarshRose.r, self)
-        self.a = DataSet(ReducedSetHindmarshRose.a, self)
-        self.b = DataSet(ReducedSetHindmarshRose.b, self)
-        self.c = DataSet(ReducedSetHindmarshRose.c, self)
-        self.d = DataSet(ReducedSetHindmarshRose.d, self)
-        self.s = DataSet(ReducedSetHindmarshRose.s, self)
-        self.xo = DataSet(ReducedSetHindmarshRose.xo, self)
-        self.K11 = DataSet(ReducedSetHindmarshRose.K11, self)
-        self.K12 = DataSet(ReducedSetHindmarshRose.K12, self)
-        self.K21 = DataSet(ReducedSetHindmarshRose.K21, self)
-        self.sigma = DataSet(ReducedSetHindmarshRose.sigma, self)
-        self.mu = DataSet(ReducedSetHindmarshRose.mu, self)
-        self.state_variable_range = JsonFinal(ReducedSetHindmarshRose.state_variable_range, self,
+        self.r = DataSet(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().r, self)
+        self.a = DataSet(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().a, self)
+        self.b = DataSet(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().b, self)
+        self.c = DataSet(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().c, self)
+        self.d = DataSet(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().d, self)
+        self.s = DataSet(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().s, self)
+        self.xo = DataSet(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().xo, self)
+        self.K11 = DataSet(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().K11, self)
+        self.K12 = DataSet(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().K12, self)
+        self.K21 = DataSet(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().K21, self)
+        self.sigma = DataSet(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().sigma, self)
+        self.mu = DataSet(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().mu, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().state_variable_range,
+                                              self,
                                               json_encoder=StateVariablesEncoder, json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(ReducedSetHindmarshRose.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.REDUCED_SET_HINDMARSH_ROSE.get_class().variables_of_interest, self)
 
 
 class WilsonCowanH5(SimulatorConfigurationH5):
 
     def __init__(self, path):
         super(WilsonCowanH5, self).__init__(path)
-        self.c_ee = DataSet(WilsonCowan.c_ee, self)
-        self.c_ie = DataSet(WilsonCowan.c_ie, self)
-        self.c_ei = DataSet(WilsonCowan.c_ei, self)
-        self.c_ii = DataSet(WilsonCowan.c_ii, self)
-        self.tau_e = DataSet(WilsonCowan.tau_e, self)
-        self.tau_i = DataSet(WilsonCowan.tau_i, self)
-        self.a_e = DataSet(WilsonCowan.a_e, self)
-        self.b_e = DataSet(WilsonCowan.b_e, self)
-        self.c_e = DataSet(WilsonCowan.c_e, self)
-        self.theta_e = DataSet(WilsonCowan.theta_e, self)
-        self.a_i = DataSet(WilsonCowan.a_i, self)
-        self.b_i = DataSet(WilsonCowan.b_i, self)
-        self.theta_i = DataSet(WilsonCowan.theta_i, self)
-        self.c_i = DataSet(WilsonCowan.c_i, self)
-        self.r_e = DataSet(WilsonCowan.r_e, self)
-        self.r_i = DataSet(WilsonCowan.r_i, self)
-        self.k_e = DataSet(WilsonCowan.k_e, self)
-        self.k_i = DataSet(WilsonCowan.k_i, self)
-        self.P = DataSet(WilsonCowan.P, self)
-        self.Q = DataSet(WilsonCowan.Q, self)
-        self.alpha_e = DataSet(WilsonCowan.alpha_e, self)
-        self.alpha_i = DataSet(WilsonCowan.alpha_i, self)
-        self.state_variable_range = JsonFinal(WilsonCowan.state_variable_range, self,
+        self.c_ee = DataSet(ModelsEnum.WILSON_COWAN.get_class().c_ee, self)
+        self.c_ie = DataSet(ModelsEnum.WILSON_COWAN.get_class().c_ie, self)
+        self.c_ei = DataSet(ModelsEnum.WILSON_COWAN.get_class().c_ei, self)
+        self.c_ii = DataSet(ModelsEnum.WILSON_COWAN.get_class().c_ii, self)
+        self.tau_e = DataSet(ModelsEnum.WILSON_COWAN.get_class().tau_e, self)
+        self.tau_i = DataSet(ModelsEnum.WILSON_COWAN.get_class().tau_i, self)
+        self.a_e = DataSet(ModelsEnum.WILSON_COWAN.get_class().a_e, self)
+        self.b_e = DataSet(ModelsEnum.WILSON_COWAN.get_class().b_e, self)
+        self.c_e = DataSet(ModelsEnum.WILSON_COWAN.get_class().c_e, self)
+        self.theta_e = DataSet(ModelsEnum.WILSON_COWAN.get_class().theta_e, self)
+        self.a_i = DataSet(ModelsEnum.WILSON_COWAN.get_class().a_i, self)
+        self.b_i = DataSet(ModelsEnum.WILSON_COWAN.get_class().b_i, self)
+        self.theta_i = DataSet(ModelsEnum.WILSON_COWAN.get_class().theta_i, self)
+        self.c_i = DataSet(ModelsEnum.WILSON_COWAN.get_class().c_i, self)
+        self.r_e = DataSet(ModelsEnum.WILSON_COWAN.get_class().r_e, self)
+        self.r_i = DataSet(ModelsEnum.WILSON_COWAN.get_class().r_i, self)
+        self.k_e = DataSet(ModelsEnum.WILSON_COWAN.get_class().k_e, self)
+        self.k_i = DataSet(ModelsEnum.WILSON_COWAN.get_class().k_i, self)
+        self.P = DataSet(ModelsEnum.WILSON_COWAN.get_class().P, self)
+        self.Q = DataSet(ModelsEnum.WILSON_COWAN.get_class().Q, self)
+        self.alpha_e = DataSet(ModelsEnum.WILSON_COWAN.get_class().alpha_e, self)
+        self.alpha_i = DataSet(ModelsEnum.WILSON_COWAN.get_class().alpha_i, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.WILSON_COWAN.get_class().state_variable_range, self,
                                               json_encoder=StateVariablesEncoder, json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(WilsonCowan.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.WILSON_COWAN.get_class().variables_of_interest, self)
 
 
 class ReducedWongWangH5(SimulatorConfigurationH5):
 
     def __init__(self, path):
         super(ReducedWongWangH5, self).__init__(path)
-        self.a = DataSet(ReducedWongWang.a, self)
-        self.b = DataSet(ReducedWongWang.b, self)
-        self.d = DataSet(ReducedWongWang.d, self)
-        self.gamma = DataSet(ReducedWongWang.gamma, self)
-        self.tau_s = DataSet(ReducedWongWang.tau_s, self)
-        self.w = DataSet(ReducedWongWang.w, self)
-        self.J_N = DataSet(ReducedWongWang.J_N, self)
-        self.I_o = DataSet(ReducedWongWang.I_o, self)
-        self.sigma_noise = DataSet(ReducedWongWang.sigma_noise, self)
-        self.state_variable_range = JsonFinal(ReducedWongWang.state_variable_range, self,
+        self.a = DataSet(ModelsEnum.REDUCED_WONG_WANG.get_class().a, self)
+        self.b = DataSet(ModelsEnum.REDUCED_WONG_WANG.get_class().b, self)
+        self.d = DataSet(ModelsEnum.REDUCED_WONG_WANG.get_class().d, self)
+        self.gamma = DataSet(ModelsEnum.REDUCED_WONG_WANG.get_class().gamma, self)
+        self.tau_s = DataSet(ModelsEnum.REDUCED_WONG_WANG.get_class().tau_s, self)
+        self.w = DataSet(ModelsEnum.REDUCED_WONG_WANG.get_class().w, self)
+        self.J_N = DataSet(ModelsEnum.REDUCED_WONG_WANG.get_class().J_N, self)
+        self.I_o = DataSet(ModelsEnum.REDUCED_WONG_WANG.get_class().I_o, self)
+        self.sigma_noise = DataSet(ModelsEnum.REDUCED_WONG_WANG.get_class().sigma_noise, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.REDUCED_WONG_WANG.get_class().state_variable_range, self,
                                               json_encoder=StateVariablesEncoder, json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(ReducedWongWang.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.REDUCED_WONG_WANG.get_class().variables_of_interest, self)
 
 
 class ReducedWongWangExcInhH5(SimulatorConfigurationH5):
 
     def __init__(self, path):
         super(ReducedWongWangExcInhH5, self).__init__(path)
-        self.a_e = DataSet(ReducedWongWangExcInh.a_e, self)
-        self.b_e = DataSet(ReducedWongWangExcInh.b_e, self)
-        self.d_e = DataSet(ReducedWongWangExcInh.d_e, self)
-        self.gamma_e = DataSet(ReducedWongWangExcInh.gamma_e, self)
-        self.tau_e = DataSet(ReducedWongWangExcInh.tau_e, self)
-        self.w_p = DataSet(ReducedWongWangExcInh.w_p, self)
-        self.J_N = DataSet(ReducedWongWangExcInh.J_N, self)
-        self.W_e = DataSet(ReducedWongWangExcInh.W_e, self)
-        self.a_i = DataSet(ReducedWongWangExcInh.a_i, self)
-        self.b_i = DataSet(ReducedWongWangExcInh.b_i, self)
-        self.d_i = DataSet(ReducedWongWangExcInh.d_i, self)
-        self.gamma_i = DataSet(ReducedWongWangExcInh.gamma_i, self)
-        self.tau_i = DataSet(ReducedWongWangExcInh.tau_i, self)
-        self.J_i = DataSet(ReducedWongWangExcInh.J_i, self)
-        self.W_i = DataSet(ReducedWongWangExcInh.W_i, self)
-        self.I_o = DataSet(ReducedWongWangExcInh.I_o, self)
-        self.G = DataSet(ReducedWongWangExcInh.G, self)
-        self.lamda = DataSet(ReducedWongWangExcInh.lamda, self)
-        self.state_variable_range = JsonFinal(ReducedWongWangExcInh.state_variable_range, self,
+        self.a_e = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().a_e, self)
+        self.b_e = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().b_e, self)
+        self.d_e = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().d_e, self)
+        self.gamma_e = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().gamma_e, self)
+        self.tau_e = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().tau_e, self)
+        self.w_p = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().w_p, self)
+        self.J_N = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().J_N, self)
+        self.W_e = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().W_e, self)
+        self.a_i = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().a_i, self)
+        self.b_i = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().b_i, self)
+        self.d_i = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().d_i, self)
+        self.gamma_i = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().gamma_i, self)
+        self.tau_i = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().tau_i, self)
+        self.J_i = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().J_i, self)
+        self.W_i = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().W_i, self)
+        self.I_o = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().I_o, self)
+        self.G = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().G, self)
+        self.lamda = DataSet(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().lamda, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().state_variable_range,
+                                              self,
                                               json_encoder=StateVariablesEncoder, json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(ReducedWongWangExcInh.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.REDUCED_WONG_WANG_EXCH_INH.get_class().variables_of_interest, self)
 
 
 class ZerlautAdaptationFirstOrderH5(SimulatorConfigurationH5):
 
     def __init__(self, path):
         super(ZerlautAdaptationFirstOrderH5, self).__init__(path)
-        self.g_L = DataSet(ZerlautAdaptationFirstOrder.g_L, self)
-        self.E_L_e = DataSet(ZerlautAdaptationFirstOrder.E_L_e, self)
-        self.E_L_i = DataSet(ZerlautAdaptationFirstOrder.E_L_i, self)
-        self.C_m = DataSet(ZerlautAdaptationFirstOrder.C_m, self)
-        self.a_e = DataSet(ZerlautAdaptationFirstOrder.a_e, self)
-        self.a_i = DataSet(ZerlautAdaptationFirstOrder.a_i, self)
-        self.b_e = DataSet(ZerlautAdaptationFirstOrder.b_e, self)
-        self.b_i = DataSet(ZerlautAdaptationFirstOrder.b_i, self)
-        self.tau_w_e = DataSet(ZerlautAdaptationFirstOrder.tau_w_e, self)
-        self.tau_w_i = DataSet(ZerlautAdaptationFirstOrder.tau_w_i, self)
-        self.E_e = DataSet(ZerlautAdaptationFirstOrder.E_e, self)
-        self.E_i = DataSet(ZerlautAdaptationFirstOrder.E_i, self)
-        self.Q_e = DataSet(ZerlautAdaptationFirstOrder.Q_e, self)
-        self.Q_i = DataSet(ZerlautAdaptationFirstOrder.Q_i, self)
-        self.tau_e = DataSet(ZerlautAdaptationFirstOrder.tau_e, self)
-        self.tau_i = DataSet(ZerlautAdaptationFirstOrder.tau_i, self)
-        self.N_tot = DataSet(ZerlautAdaptationFirstOrder.N_tot, self)
-        self.p_connect = DataSet(ZerlautAdaptationFirstOrder.p_connect, self)
-        self.g = DataSet(ZerlautAdaptationFirstOrder.g, self)
-        self.K_ext_e = DataSet(ZerlautAdaptationFirstOrder.K_ext_e, self)
-        self.K_ext_i = DataSet(ZerlautAdaptationFirstOrder.K_ext_i, self)
-        self.T = DataSet(ZerlautAdaptationFirstOrder.T, self)
-        self.P_e = DataSet(ZerlautAdaptationFirstOrder.P_e, self)
-        self.P_i = DataSet(ZerlautAdaptationFirstOrder.P_i, self)
-        self.external_input_ex_ex = DataSet(ZerlautAdaptationFirstOrder.external_input_ex_ex, self)
-        self.external_input_ex_in = DataSet(ZerlautAdaptationFirstOrder.external_input_ex_in, self)
-        self.external_input_in_ex = DataSet(ZerlautAdaptationFirstOrder.external_input_in_ex, self)
-        self.external_input_in_in = DataSet(ZerlautAdaptationFirstOrder.external_input_in_in, self)
-        self.state_variable_range = JsonFinal(ZerlautAdaptationFirstOrder.state_variable_range, self,
+        self.g_L = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().g_L, self)
+        self.E_L_e = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().E_L_e, self)
+        self.E_L_i = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().E_L_i, self)
+        self.C_m = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().C_m, self)
+        self.a_e = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().a_e, self)
+        self.a_i = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().a_i, self)
+        self.b_e = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().b_e, self)
+        self.b_i = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().b_i, self)
+        self.tau_w_e = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().tau_w_e, self)
+        self.tau_w_i = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().tau_w_i, self)
+        self.E_e = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().E_e, self)
+        self.E_i = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().E_i, self)
+        self.Q_e = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().Q_e, self)
+        self.Q_i = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().Q_i, self)
+        self.tau_e = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().tau_e, self)
+        self.tau_i = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().tau_i, self)
+        self.N_tot = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().N_tot, self)
+        self.p_connect = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().p_connect, self)
+        self.g = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().g, self)
+        self.K_ext_e = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().K_ext_e, self)
+        self.K_ext_i = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().K_ext_i, self)
+        self.T = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().T, self)
+        self.P_e = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().P_e, self)
+        self.P_i = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().P_i, self)
+        self.external_input_ex_ex = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().external_input_ex_ex, self)
+        self.external_input_ex_in = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().external_input_ex_in, self)
+        self.external_input_in_ex = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().external_input_in_ex, self)
+        self.external_input_in_in = DataSet(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().external_input_in_in, self)
+        self.state_variable_range = JsonFinal(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().state_variable_range, self,
                                               json_encoder=StateVariablesEncoder, json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(ZerlautAdaptationFirstOrder.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.ZERLAUT_FIRST_ORDER.get_class().variables_of_interest, self)
 
 
 class ZerlautAdaptationSecondOrderH5(ZerlautAdaptationFirstOrderH5):
 
     def __init__(self, path):
         super(ZerlautAdaptationSecondOrderH5, self).__init__(path)
-        self.state_variable_range = JsonFinal(ZerlautAdaptationSecondOrder.state_variable_range, self,
+        self.state_variable_range = JsonFinal(ModelsEnum.ZERLAUT_SECOND_ORDER.get_class().state_variable_range, self,
                                               json_encoder=StateVariablesEncoder, json_decoder=StateVariablesDecoder)
-        self.variables_of_interest = Json(ZerlautAdaptationSecondOrder.variables_of_interest, self)
+        self.variables_of_interest = Json(ModelsEnum.ZERLAUT_SECOND_ORDER.get_class().variables_of_interest, self)

--- a/framework_tvb/tvb/interfaces/command/benchmark.py
+++ b/framework_tvb/tvb/interfaces/command/benchmark.py
@@ -38,9 +38,9 @@ from datetime import datetime
 from os import path
 from tvb.simulator.coupling import HyperbolicTangent
 from tvb.simulator.integrators import HeunDeterministic
-from tvb.simulator.models import *
 from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
 from tvb.interfaces.command.lab import *
+from tvb.simulator.models import ModelsEnum
 
 
 def _fire_simulation(project_id, **kwargs):
@@ -144,8 +144,8 @@ def main():
 
     g2d_epi = Bench(
         model_kws=[
-            {"model": Generic2dOscillator()},
-            {"model": Epileptor()},
+            {"model": ModelsEnum.GENERIC_2D_OSCILLATOR.get_class()()},
+            {"model": ModelsEnum.EPILEPTOR.get_class()()},
         ],
         connectivities=connectivities,
         conductions=[30.0, 3.0],
@@ -155,7 +155,7 @@ def main():
 
     larter = Bench(
         model_kws=[
-            {"model": LarterBreakspear(), "coupling": HyperbolicTangent()},
+            {"model": ModelsEnum.LARTER_BREAKSPEAR.get_class()(), "coupling": HyperbolicTangent()},
         ],
         connectivities=connectivities,
         conductions=[10.0],

--- a/framework_tvb/tvb/tests/framework/core/services/serialization_manager_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/serialization_manager_test.py
@@ -36,7 +36,7 @@ from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
 from tvb.tests.framework.core.base_testcase import TransactionalTestCase
 from tvb.core.services.burst_config_serialization import INTEGRATOR_PARAMETERS, MODEL_PARAMETERS, SerializationManager
 from tvb.simulator.integrators import HeunStochastic
-from tvb.simulator.models import Hopfield, Generic2dOscillator
+from tvb.simulator.models import ModelsEnum
 from tvb.tests.framework.core.factory import TestFactory
 from os import path
 import tvb_data
@@ -51,7 +51,7 @@ class TestSerializationManager(TransactionalTestCase):
         TestFactory.import_zip_connectivity(self.test_user, self.test_project, zip_path, "John")
         self.connectivity = TestFactory.get_entity(self.test_project, ConnectivityIndex)
 
-        sim_conf = Simulator(model=Hopfield(), integrator=HeunStochastic())
+        sim_conf = Simulator(model=ModelsEnum.HOPFIELD.get_class()(), integrator=HeunStochastic())
 
         self.s_manager = SerializationManager(sim_conf)
         self.empty_manager = SerializationManager(None)
@@ -75,7 +75,7 @@ class TestSerializationManager(TransactionalTestCase):
 
     def test_write_model_parameters_one_dynamic(self, connectivity_factory):
         connectivity = connectivity_factory()
-        m_name = Generic2dOscillator.__name__
+        m_name = ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().__name__
         m_parms = {'I': 0.0, 'a': 1.75, 'alpha': 1.0, 'b': -10.0, 'beta': 1.0, 'c': 0.0,
                    'd': 0.02, 'e': 3.0, 'f': 1.0, 'g': 0.0, 'gamma': 1.0, 'tau': 1.47}
 
@@ -83,7 +83,7 @@ class TestSerializationManager(TransactionalTestCase):
 
         sc = self.s_manager.conf
         # Default model in these tests is Hopfield. Test if the model was changed to Generic2dOscillator
-        assert isinstance(sc.model, Generic2dOscillator)
+        assert isinstance(sc.model, ModelsEnum.GENERIC_2D_OSCILLATOR.get_class())
 
         # a modified parameter
         expected = [1.75]  # we expect same value arrays to contract to 1 element
@@ -96,7 +96,7 @@ class TestSerializationManager(TransactionalTestCase):
 
     def test_write_model_parameters_two_dynamics(self, connectivity_factory):
         connectivity = connectivity_factory()
-        m_name = Generic2dOscillator.__name__
+        m_name = ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().__name__
         m_parms_1 = {'I': 0.0, 'a': 1.75, 'alpha': 1.0, 'b': -10.0, 'beta': 1.0, 'c': 0.0,
                      'd': 0.02, 'e': 3.0, 'f': 1.0, 'g': 0.0, 'gamma': 1.0, 'tau': 1.47}
         m_parms_2 = {'I': 0.0, 'a': 1.75, 'alpha': 1.0, 'b': -5.0, 'beta': 1.0, 'c': 0.0,
@@ -109,7 +109,7 @@ class TestSerializationManager(TransactionalTestCase):
 
         sc = self.s_manager.conf
         # Default model in these tests is Hopfield. Test if the model was changed to Generic2dOscillator
-        assert isinstance(sc.model, Generic2dOscillator)
+        assert isinstance(sc.model, ModelsEnum.GENERIC_2D_OSCILLATOR.get_class())
 
         expected = [1.75]  # array contracted to one value
         actual = sc.model.a

--- a/framework_tvb/tvb/tests/framework/interfaces/web/controllers/noise_configuration_controller_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/web/controllers/noise_configuration_controller_test.py
@@ -42,7 +42,7 @@ from tvb.interfaces.web.controllers import common
 from tvb.interfaces.web.controllers.burst.noise_configuration_controller import NoiseConfigurationController
 from tvb.interfaces.web.controllers.spatial.base_spatio_temporal_controller import INTEGRATOR_PARAMETERS
 from tvb.simulator.integrators import EulerStochastic
-from tvb.simulator.models import Generic2dOscillator
+from tvb.simulator.models import ModelsEnum
 from tvb.simulator.noise import Additive
 
 
@@ -92,7 +92,7 @@ class TestNoiseConfigurationController(BaseTransactionalControllerTest):
 
         # Simulate selection of a specific integration  from the ui
         new_params[PARAM_INTEGRATOR] = {'value': EulerStochastic.__name__}
-        new_params[PARAM_MODEL] = {'value': Generic2dOscillator.__name__}
+        new_params[PARAM_MODEL] = {'value': ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().__name__}
         new_params[INTEGRATOR_PARAMETERS + '_option_EulerStochastic_noise'] = {'value': Additive.__name__}
         stored_burst.simulator_configuration = new_params
         """

--- a/framework_tvb/tvb/tests/framework/interfaces/web/controllers/region_model_parameters_controller_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/web/controllers/region_model_parameters_controller_test.py
@@ -41,7 +41,7 @@ from tvb.core.entities.model.model_burst import Dynamic
 from tvb.core.entities.storage import dao
 from tvb.interfaces.web.controllers.burst.region_model_parameters_controller import RegionsModelParametersController
 from tvb.simulator.integrators import HeunDeterministic
-from tvb.simulator.models import Generic2dOscillator, Kuramoto
+from tvb.simulator.models import ModelsEnum
 from tvb.tests.framework.adapters.simulator.simulator_adapter_test import SIMULATOR_PARAMETERS
 import tvb.interfaces.web.controllers.common as common
 
@@ -73,12 +73,12 @@ class TestRegionsModelParametersController(BaseTransactionalControllerTest):
 
 
     def _setup_dynamic(self):
-        dynamic_g = Dynamic("test_dyn", self.test_user.id, Generic2dOscillator.__name__,
+        dynamic_g = Dynamic("test_dyn", self.test_user.id, ModelsEnum.GENERIC_2D_OSCILLATOR.get_class().__name__,
                             '[["tau", 1.0], ["a", 5.0], ["b", -10.0], ["c", 10.0], ["I", 0.0], ["d", 0.02], '
                             '["e", 3.0], ["f", 1.0], ["g", 0.0], ["alpha", 1.0], ["beta", 5.0], ["gamma", 1.0]]',
                             HeunDeterministic.__name__, None)
 
-        dynamic_k = Dynamic("test_dyn_kura", self.test_user.id, Kuramoto.__name__,
+        dynamic_k = Dynamic("test_dyn_kura", self.test_user.id, ModelsEnum.KURAMOTO.get_class().__name__,
                             '[["omega", 1.0]]', HeunDeterministic.__name__, None)
 
         self.dynamic_g = dao.store_entity(dynamic_g)

--- a/framework_tvb/tvb/tests/framework/interfaces/web/jinja2_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/web/jinja2_test.py
@@ -40,7 +40,7 @@ from tvb.core.adapters.abcadapter import ABCAdapter, ABCAdapterForm
 from tvb.core.neotraits.forms import ArrayField
 from tvb.interfaces.web.controllers.decorators import using_template
 from tvb.interfaces.web.controllers.simulator_controller import SimulatorController
-from tvb.simulator.models import Epileptor
+from tvb.simulator.models import ModelsEnum
 from tvb.simulator.simulator import Simulator
 from tvb.tests.framework.core.base_testcase import BaseTestCase
 
@@ -140,7 +140,7 @@ class TestJinja2Simulator(Jinja2Test):
         all_models_for_ui = get_ui_name_to_model()
         models_form = SimulatorModelFragment()
         simulator = Simulator()
-        simulator.model = Epileptor()
+        simulator.model = ModelsEnum.EPILEPTOR.get_class()()
         models_form.fill_from_trait(simulator)
 
         html = str(models_form)

--- a/scientific_library/tvb/simulator/models/__init__.py
+++ b/scientific_library/tvb/simulator/models/__init__.py
@@ -38,17 +38,106 @@ Specific models inherit from the abstract class Model.
 
 """
 
-from .base import Model
-from .epileptor import Epileptor, Epileptor2D
-from .epileptor_rs import EpileptorRestingState
-from .epileptorcodim3 import EpileptorCodim3, EpileptorCodim3SlowMod
-from .hopfield import Hopfield
-from .jansen_rit import JansenRit, ZetterbergJansen
-from .larter_breakspear import LarterBreakspear
-from .linear import Linear
-from .oscillator import Generic2dOscillator, Kuramoto, SupHopf
-from .stefanescu_jirsa import ReducedSetFitzHughNagumo, ReducedSetHindmarshRose
-from .wilson_cowan import WilsonCowan
-from .wong_wang import ReducedWongWang
-from .wong_wang_exc_inh import ReducedWongWangExcInh
-from .zerlaut import ZerlautAdaptationFirstOrder, ZerlautAdaptationSecondOrder
+# we don't import all models by default here, since they are time consuming
+# to setup (e.g. numba gufunc compilation), but provide them as module-level
+# properties for compatibility with previous version of TVB. For example
+#
+#     import tvb.simulator.models.Epileptor
+#
+# works, but only lazily loads the tvb.simulator.models.epileptor module
+# and returns the Epileptor class.
+
+from enum import Enum
+
+
+class ModelsEnum(Enum):
+    BASE_MODEL = "Model"
+    EPILEPTOR = "Epileptor"
+    EPILEPTOR_2D = "Epileptor2D"
+    EPILEPTOR_RS = "EpileptorRestingState"
+    EPILEPTOR_CODIM_3 = "EpileptorCodim3"
+    EPILEPTOR_CODIM_3_SLOW = "EpileptorCodim3SlowMod"
+    HOPFIELD = "Hopfield"
+    JANSEN_RIT = "JansenRit"
+    ZETTERBERG_JANSEN = "ZetterbergJansen"
+    LARTER_BREAKSPEAR = "LarterBreakspear"
+    LINEAR = "Linear"
+    GENERIC_2D_OSCILLATOR = "Generic2dOscillator"
+    KURAMOTO = "Kuramoto"
+    SUP_HOPF = "SupHopf"
+    REDUCED_SET_FITZ_HUGH_NAGUMO = "ReducedSetFitzHughNagumo"
+    REDUCED_SET_HINDMARSH_ROSE = "ReducedSetHindmarshRose"
+    WILSON_COWAN = "WilsonCowan"
+    REDUCED_WONG_WANG = "ReducedWongWang"
+    REDUCED_WONG_WANG_EXCH_INH = "ReducedWongWangExcInh"
+    ZERLAUT_FIRST_ORDER = "ZerlautFirstOrder"
+    ZERLAUT_SECOND_ORDER = "ZerlautSecondOrder"
+
+    def get_class(self):
+        return _get_imported_model(self.value)
+
+    @staticmethod
+    def get_base_model_subclasses():
+        return [model.get_class() for model in list(ModelsEnum) if model != ModelsEnum.BASE_MODEL]
+
+
+def _get_imported_model(model):
+    import sys
+    # Imported modules
+    imported_modules = sys.modules['tvb.simulator.models']
+    try:
+        return getattr(imported_modules, model)
+    except AttributeError:
+        return None
+
+
+_module_models = {
+    'base': [ModelsEnum.BASE_MODEL],
+    'epileptor': [ModelsEnum.EPILEPTOR, ModelsEnum.EPILEPTOR_2D],
+    'epileptor_rs': [ModelsEnum.EPILEPTOR_RS],
+    'epileptorcodim3': [ModelsEnum.EPILEPTOR_CODIM_3, ModelsEnum.EPILEPTOR_CODIM_3_SLOW],
+    'hopfield': [ModelsEnum.HOPFIELD],
+    'jansen_rit': [ModelsEnum.JANSEN_RIT, ModelsEnum.ZETTERBERG_JANSEN],
+    'larter_breakspear': [ModelsEnum.LARTER_BREAKSPEAR],
+    'linear': [ModelsEnum.LINEAR],
+    'oscillator': [ModelsEnum.GENERIC_2D_OSCILLATOR, ModelsEnum.KURAMOTO, ModelsEnum.SUP_HOPF],
+    'stefanescu_jirsa': [ModelsEnum.REDUCED_SET_HINDMARSH_ROSE, ModelsEnum.REDUCED_SET_FITZ_HUGH_NAGUMO],
+    'wilson_cowan': [ModelsEnum.WILSON_COWAN],
+    'wong_wang': [ModelsEnum.REDUCED_WONG_WANG],
+    'wong_wang_exc_inh': [ModelsEnum.REDUCED_WONG_WANG_EXCH_INH],
+    'zerlaut': [ModelsEnum.ZERLAUT_FIRST_ORDER, ModelsEnum.ZERLAUT_SECOND_ORDER],
+}
+
+
+def _delay_import_one(mod, model):
+    """Create getter thunk for module and model name.
+    """
+    import importlib
+    def do_import(_):
+        module_name = f'tvb.simulator.models.{mod}'
+        model_module = importlib.import_module(module_name)
+        return getattr(model_module, model)
+    return property(do_import)
+
+
+def _delay_model_imports():
+    """Set up this module with all properties for all models.
+    """
+    # create substitute module class & object
+    class _Module:
+        pass
+    module = _Module()
+    module.__dict__ = globals()
+    # create properties for each model
+    for mod, models in _module_models.items():
+        for model in models:
+            setattr(_Module, model.value, _delay_import_one(mod, model.value))
+    # register module object
+    import sys
+    module._module = sys.modules[module.__name__]
+    module._pmodule = module
+    sys.modules[module.__name__] = module
+
+
+_delay_model_imports()
+

--- a/scientific_library/tvb/tests/library/simulator/_opencl_tests.py
+++ b/scientific_library/tvb/tests/library/simulator/_opencl_tests.py
@@ -78,7 +78,7 @@ class TestModels():
         self.n_nodes = 100
 
     def test_RWW_opencl(self):
-        from tvb.simulator.models import ReducedWongWang
+        from tvb.simulator.models.wong_wang import ReducedWongWang
         from tvb.simulator._opencl.models import CLRWW
 
         self.validate(ReducedWongWang(),CLRWW(),1)

--- a/scientific_library/tvb/tests/library/simulator/history_test.py
+++ b/scientific_library/tvb/tests/library/simulator/history_test.py
@@ -41,7 +41,7 @@ from tvb.basic.neotraits.api import List
 from tvb.datatypes.connectivity import Connectivity
 from tvb.simulator.coupling import Coupling
 from tvb.simulator.integrators import Identity
-from tvb.simulator.models import Model
+from tvb.simulator.models.base import Model
 from tvb.simulator.monitors import Raw
 from tvb.simulator.simulator import Simulator
 

--- a/scientific_library/tvb/tests/library/simulator/simulator_test.py
+++ b/scientific_library/tvb/tests/library/simulator/simulator_test.py
@@ -42,6 +42,7 @@ import pytest
 import numpy
 import itertools
 from tvb.datatypes.surfaces import CorticalSurface
+from tvb.simulator.models import ModelsEnum
 from tvb.tests.library.base_testcase import BaseTestCase
 from tvb.simulator import simulator, models, coupling, integrators, monitors, noise
 from tvb.datatypes.connectivity import Connectivity
@@ -50,7 +51,7 @@ from tvb.datatypes.local_connectivity import LocalConnectivity
 from tvb.datatypes.region_mapping import RegionMapping
 from tvb.simulator.integrators import HeunDeterministic, IntegratorStochastic
 
-MODEL_CLASSES = models.Model.get_known_subclasses().values()
+MODEL_CLASSES = ModelsEnum.get_base_model_subclasses()
 METHOD_CLASSES = integrators.Integrator.get_known_subclasses().values()
 
 
@@ -98,7 +99,7 @@ class Simulator(object):
 
         return results
 
-    def configure(self, dt=2 ** -3, model=models.Generic2dOscillator, speed=4.0,
+    def configure(self, dt=2 ** -3, model=ModelsEnum.GENERIC_2D_OSCILLATOR.get_class(), speed=4.0,
                   coupling_strength=0.00042, method=HeunDeterministic,
                   surface_sim=False,
                   default_connectivity=True):


### PR DESCRIPTION
In tvb-framework and library tests we have some use cases where all the models are needed (e.g ui forms and tests). For this we propose adding an enum with all the models in tvb.simulator.models.init.py.