### PR TITLE
TVB-2565 fix numpy integers serialization

### DIFF
--- a/framework_tvb/tvb/core/utils.py
+++ b/framework_tvb/tvb/core/utils.py
@@ -302,7 +302,10 @@ class TVBJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if hasattr(obj, "to_json"):
             return obj.to_json()
-
+        # TODO: Review this quick fix.
+        # TVB-2565 numpy int serialization
+        if isinstance(obj, (numpy.int32, numpy.int64)):
+            return int(obj)
         return json.JSONEncoder.default(self, obj)
 
 

--- a/framework_tvb/tvb/core/utils.py
+++ b/framework_tvb/tvb/core/utils.py
@@ -304,7 +304,7 @@ class TVBJSONEncoder(json.JSONEncoder):
             return obj.to_json()
         # TODO: Review this quick fix.
         # TVB-2565 numpy int serialization
-        if isinstance(obj, (numpy.int32, numpy.int64)):
+        if numpy.issubdtype(obj, numpy.integer):
             return int(obj)
         return json.JSONEncoder.default(self, obj)
 


### PR DESCRIPTION
In Phase Plane page there was a problem with numpy integer serializator for Linear and Epileptor Resting State models. Review this fix in the future.