### PR TITLE
Server version reading is failing

### DIFF
--- a/framework_tvb/tvb/interfaces/web/controllers/users_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/users_controller.py
@@ -413,7 +413,7 @@ class UserController(BaseController):
             try:
                 context = ssl.SSLContext(ssl.PROTOCOL_TLS)
                 content = urlopen(TvbProfile.current.web.URL_TVB_VERSION, timeout=7, context=context).read()
-                self.version_info = json.loads(str(content))
+                self.version_info = json.loads(content.decode('utf-8'))
                 pos = TvbProfile.current.web.URL_TVB_VERSION.find('/tvb')
                 self.version_info['url'] = TvbProfile.current.web.URL_TVB_VERSION[:pos]
                 self.logger.debug("Read version: " + json.dumps(self.version_info))


### PR DESCRIPTION
Now we will decode the response (bytes) using utf-8 instead using str() function. Str() is producing invalid json format in this case.