### PR TITLE
TVB 2599: None Scalar fields should not stored in H5 files 

### DIFF
--- a/framework_tvb/tvb/core/neotraits/_h5accessors.py
+++ b/framework_tvb/tvb/core/neotraits/_h5accessors.py
@@ -35,6 +35,7 @@ import numpy
 import scipy.sparse
 import typing
 from tvb.basic.neotraits.api import HasTraits, Attr, NArray
+from tvb.core.entities.file.exceptions import MissingDataSetException
 from tvb.datatypes import equations
 
 
@@ -85,13 +86,18 @@ class Scalar(Accessor):
         # type: (typing.Union[str, int, float]) -> None
         # noinspection PyProtectedMember
         val = self.trait_attribute._validate_set(None, val)
-        self.owner.storage_manager.set_metadata({self.field_name: val})
+        if val is not None:
+            self.owner.storage_manager.set_metadata({self.field_name: val})
 
     def load(self):
         # type: () -> typing.Union[str, int, float]
         # assuming here that the h5 will return the type we stored.
         # if paranoid do self.trait_attribute.field_type(value)
-        return self.owner.storage_manager.get_metadata()[self.field_name]
+        metadata = self.owner.storage_manager.get_metadata()
+        if self.field_name in metadata:
+            return metadata[self.field_name]
+        else:
+            raise MissingDataSetException(self.field_name)
 
 
 class Uuid(Scalar):


### PR DESCRIPTION
The problem was that None values are put as default values in H5 files, thus if it expects a String and gets None for example, it will set that field to an empty string. HDF5 doesn't have a NULL in its type model. Then, at deserialization, it should be None, but it's an empty string and that's why we got that error. 

 

Solved this problem by simply not storing fields if they are None and then they won't be found in the h5 file at deserializing, so they will be set to default values.