### PR TITLE
WIP: generalize stimulus to allow selection of state variables

### DIFF
--- a/scientific_library/tvb/simulator/models/base.py
+++ b/scientific_library/tvb/simulator/models/base.py
@@ -54,6 +54,7 @@ class Model(HasTraits):
     _nvar = None   # todo make this a prop len(state_variables)
     number_of_modes = 1
     cvar = None
+    stvar = None
     state_variable_boundaries = None
 
     def _build_observer(self):
@@ -91,6 +92,8 @@ class Model(HasTraits):
         "Configure base model."
         for req_attr in 'nvar number_of_modes cvar'.split():
             assert hasattr(self, req_attr)
+        if self.stvar is None:
+            self.stvar = self.cvar
         super(Model, self).configure()
         self.update_derived_parameters()
         self._build_observer()

--- a/scientific_library/tvb/simulator/models/base.py
+++ b/scientific_library/tvb/simulator/models/base.py
@@ -93,7 +93,7 @@ class Model(HasTraits):
         for req_attr in 'nvar number_of_modes cvar'.split():
             assert hasattr(self, req_attr)
         if self.stvar is None:
-            self.stvar = self.cvar
+            self.stvar = self.cvar.copy()
         super(Model, self).configure()
         self.update_derived_parameters()
         self._build_observer()

--- a/scientific_library/tvb/simulator/simulator.py
+++ b/scientific_library/tvb/simulator/simulator.py
@@ -346,7 +346,7 @@ class Simulator(HasTraits):
         if self.stimulus is not None:
             # TODO stim_step != current step
             stim_step = step - (self.current_step + 1)
-            stimulus[self.model.cvar, :, :] = self.stimulus(stim_step).reshape((1, -1, 1))
+            stimulus[self.model.stvar, :, :] = self.stimulus(stim_step).reshape((1, -1, 1))
 
     def _loop_update_history(self, step, n_reg, state):
         """Update history."""

--- a/scientific_library/tvb/tests/library/simulator/models_test.py
+++ b/scientific_library/tvb/tests/library/simulator/models_test.py
@@ -87,14 +87,14 @@ class TestModels(BaseTestCase):
     """
 
     @staticmethod
-    def _validate_initialization(model, expected_sv, expected_models=1):
+    def _validate_initialization(model, expected_sv, expected_modes=1):
 
         model.configure()
         dt = 2 ** -4
         history_shape = (1, model._nvar, 1, model.number_of_modes)
         model_ic = model.initial(dt, history_shape)
         assert expected_sv == model._nvar
-        assert expected_models == model.number_of_modes
+        assert expected_modes == model.number_of_modes
 
         svr = model.state_variable_range
         sv = model.state_variables
@@ -120,6 +120,18 @@ class TestModels(BaseTestCase):
              "x4": numpy.array([min_float, max_float])}
         for sv, sv_bounds in state_variable_boundaries.items():
             assert numpy.allclose(sv_bounds, model.state_variable_boundaries[sv], min_positive)
+
+    def test_stvar_init(self):
+        model = TestBoundsModel()
+        model.configure()
+        numpy.testing.assert_array_equal(model.stvar, model.cvar)
+
+        model = TestBoundsModel()
+        model.stvar=numpy.r_[1,3]
+        model.configure()
+        numpy.testing.assert_array_equal(model.stvar, numpy.r_[1,3])
+
+        
 
     def test_wilson_cowan(self):
         """

--- a/scientific_library/tvb/tests/library/simulator/simulator_test.py
+++ b/scientific_library/tvb/tests/library/simulator/simulator_test.py
@@ -49,6 +49,8 @@ from tvb.datatypes.connectivity import Connectivity
 from tvb.datatypes.cortex import Cortex
 from tvb.datatypes.local_connectivity import LocalConnectivity
 from tvb.datatypes.region_mapping import RegionMapping
+from tvb.datatypes.patterns import StimuliRegion
+from tvb.datatypes.equations import Linear
 from tvb.simulator.integrators import HeunDeterministic, IntegratorStochastic
 
 MODEL_CLASSES = ModelsEnum.get_base_model_subclasses()
@@ -102,7 +104,8 @@ class Simulator(object):
     def configure(self, dt=2 ** -3, model=ModelsEnum.GENERIC_2D_OSCILLATOR.get_class(), speed=4.0,
                   coupling_strength=0.00042, method=HeunDeterministic,
                   surface_sim=False,
-                  default_connectivity=True):
+                  default_connectivity=True,
+                  with_stimulus=False):
         """
         Create an instance of the Simulator class, by default use the
         generic plane oscillator local dynamic model and the deterministic 
@@ -140,8 +143,18 @@ class Simulator(object):
             else:
                 default_cortex.local_connectivity = LocalConnectivity()
             default_cortex.local_connectivity.surface = default_cortex.region_mapping_data.surface
+            # TODO stimulus
         else:
             default_cortex = None
+            if with_stimulus:
+                weights = StimuliRegion.get_default_weights(white_matter.weights.shape[0])
+                weights[10:20] = 1.
+                stimulus = StimuliRegion(
+                        temporal=Linear(parameters={"a":0.0, "b":3.0}),
+                        connectivity=white_matter,
+                        weight=weights
+                )
+
 
         # Order of monitors determines order of returned values.
         self.sim = simulator.Simulator()
@@ -151,6 +164,8 @@ class Simulator(object):
         self.sim.connectivity = white_matter
         self.sim.coupling = white_matter_coupling
         self.sim.monitors = self.monitors
+        if with_stimulus:
+            self.sim.stimulus = stimulus
         self.sim.configure()
 
 
@@ -195,3 +210,28 @@ class TestSimulator(BaseTestCase):
         assert numpy.allclose(state_variable_boundaries,
                               test_simulator.integrator.state_variable_boundaries,
                               1.0/numpy.finfo("single").max)
+
+    @pytest.mark.parametrize('default_connectivity', [True, False])
+    def test_simulator_regional_stimulus(self,default_connectivity):
+        test_simulator = Simulator()
+        test_simulator.configure(surface_sim=False, default_connectivity=default_connectivity, with_stimulus=True)
+        stimulus = test_simulator.sim._prepare_stimulus()
+        self.assert_equal(
+                stimulus.shape, 
+                (
+                    test_simulator.sim.model.nvar,
+                    test_simulator.sim.connectivity.number_of_regions,
+                    test_simulator.sim.model.number_of_modes
+                )
+        )
+
+        test_simulator.sim._loop_update_stimulus(1,stimulus)
+        self.assert_equal( numpy.count_nonzero(stimulus), 10)
+        assert numpy.allclose( stimulus[test_simulator.sim.model.stvar,10:20,:], 
+                               3.0,
+                               1.0/numpy.finfo("single").max)
+
+
+
+        
+        

--- a/scientific_library/tvb/tests/library/simulator/simulator_test.py
+++ b/scientific_library/tvb/tests/library/simulator/simulator_test.py
@@ -87,6 +87,9 @@ class Simulator(object):
         self.method = None
         self.sim = None
 
+        self.stim_nodes = numpy.r_[10,20]
+        self.stim_value = 3.0
+
     def run_simulation(self, simulation_length=2 ** 2):
         """
         Test a simulator constructed with one of the <model>_<scheme> methods.
@@ -148,9 +151,9 @@ class Simulator(object):
             default_cortex = None
             if with_stimulus:
                 weights = StimuliRegion.get_default_weights(white_matter.weights.shape[0])
-                weights[10:20] = 1.
+                weights[self.stim_nodes] = 1.
                 stimulus = StimuliRegion(
-                        temporal=Linear(parameters={"a":0.0, "b":3.0}),
+                        temporal=Linear(parameters={"a":0.0, "b":self.stim_value}),
                         connectivity=white_matter,
                         weight=weights
                 )
@@ -226,9 +229,9 @@ class TestSimulator(BaseTestCase):
         )
 
         test_simulator.sim._loop_update_stimulus(1,stimulus)
-        self.assert_equal( numpy.count_nonzero(stimulus), 10)
-        assert numpy.allclose( stimulus[test_simulator.sim.model.stvar,10:20,:], 
-                               3.0,
+        self.assert_equal( numpy.count_nonzero(stimulus), len(test_simulator.stim_nodes))
+        assert numpy.allclose( stimulus[test_simulator.sim.model.stvar,test_simulator.stim_nodes,:], 
+                               test_simulator.stim_value,
                                1.0/numpy.finfo("single").max)
 
 


### PR DESCRIPTION
Most conservative generalization is to allow specification of variables, upon which the stimulus is applied (currently these are the coupling variables). Next we might also allow e.g. different scaling of the stimulus or completely different stimulus for different state variables. 

Related to https://req.thevirtualbrain.org/browse/TVB-1815