### PR TITLE
TVB-2635 Cleanup deprecated import from collections directly

### DIFF
--- a/framework_tvb/tvb/tests/framework/interfaces/web/jinja2_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/web/jinja2_test.py
@@ -28,7 +28,6 @@
 #
 #
 
-import copy
 import numpy
 from bs4 import BeautifulSoup
 from tvb.adapters.simulator.model_forms import get_ui_name_to_model
@@ -39,7 +38,7 @@ from tvb.basic.profile import TvbProfile
 from tvb.core.adapters.abcadapter import ABCAdapter, ABCAdapterForm
 from tvb.core.neotraits.forms import ArrayField
 from tvb.interfaces.web.controllers.decorators import using_template
-from tvb.interfaces.web.controllers.simulator_controller import SimulatorController
+from tvb.interfaces.web.controllers.simulator_controller import SimulatorFragmentRenderingRules, SimulatorWizzardURLs
 from tvb.simulator.models import ModelsEnum
 from tvb.simulator.simulator import Simulator
 from tvb.tests.framework.core.base_testcase import BaseTestCase
@@ -96,6 +95,7 @@ class TestTraitAdapterForm(Jinja2Test):
     Test HTML generation for a traited form.
     """
 
+    @using_template('form_fields/form')
     def prepare_adapter_for_rendering(self):
         adapter = TraitAdapter()
         datatype = TestTrait()
@@ -103,15 +103,13 @@ class TestTraitAdapterForm(Jinja2Test):
         form = adapter.get_form_class()()
         form.fill_from_trait(datatype)
         adapter.submit_form(form)
-
-        return adapter
+        return {'adapter_form': adapter.get_form()}
 
     def test_multidimensional_array(self):
-        adapter = self.prepare_adapter_for_rendering()
-        html = str(adapter.get_form())
+        html = self.prepare_adapter_for_rendering()
         soup = BeautifulSoup(html)
 
-        array_entry = soup.find_all('input', attrs=dict(name='_test_array'))
+        array_entry = soup.find_all('input', attrs=dict(name='test_array'))
         assert len(array_entry) == 1, 'Array entry not found'
         assert array_entry[0]['value'] == "[[-3.0, -6.0], [3.0, 6.0]]", "Wrong value stored"
 
@@ -122,18 +120,15 @@ class TestJinja2Simulator(Jinja2Test):
     def dummy_renderer(self, template_dict):
         return template_dict
 
-    def get_dict_to_render(self):
-        dict_to_render = copy.deepcopy(SimulatorController.dict_to_render)
-        return dict_to_render
+    def prepare_simulator_form_for_search(self, rendering_rules, form=None):
+        # type: (SimulatorFragmentRenderingRules, ABCAdapterForm) -> BeautifulSoup
+        if form is None:
+            form = SimulatorAdapterForm(project_id=1)
+            form.fill_from_trait(Simulator())
+        rendering_rules.form = form
 
-    def prepare_simulator_form_for_search(self, dict_to_render):
-        sim_adapter_form = SimulatorAdapterForm(project_id=1)
-        sim_adapter_form.fill_from_trait(Simulator())
-        dict_to_render[SimulatorController.FORM_KEY] = sim_adapter_form
-
-        html = self.dummy_renderer(dict_to_render)
+        html = self.dummy_renderer(rendering_rules.to_dict())
         soup = BeautifulSoup(html)
-
         return soup
 
     def test_models_list(self):
@@ -143,8 +138,8 @@ class TestJinja2Simulator(Jinja2Test):
         simulator.model = ModelsEnum.EPILEPTOR.get_class()()
         models_form.fill_from_trait(simulator)
 
-        html = str(models_form)
-        soup = BeautifulSoup(html)
+        rendering_rules = SimulatorFragmentRenderingRules(is_model_fragment=True)
+        soup = self.prepare_simulator_form_for_search(rendering_rules, form=models_form)
 
         select_field = soup.find_all('select')
         assert len(select_field) == 1, 'Number of select inputs is different than 1'
@@ -155,21 +150,20 @@ class TestJinja2Simulator(Jinja2Test):
         assert 'Epileptor' in select_field_choice[0].attrs['value']
 
     def test_simulator_adapter_form(self):
-        dict_to_render = self.get_dict_to_render()
-        soup = self.prepare_simulator_form_for_search(dict_to_render)
+        rendering_rules = SimulatorFragmentRenderingRules()
+        soup = self.prepare_simulator_form_for_search(rendering_rules)
 
-        connectivity_select_field = soup.find_all('select', attrs=dict(name='_connectivity'))
+        connectivity_select_field = soup.find_all('select', attrs=dict(name='connectivity'))
         assert len(connectivity_select_field) == 1, 'Number of connectivity select inputs is different than 1'
-        conduction_speed_input = soup.find_all('input', attrs=dict(name='_conduction_speed'))
+        conduction_speed_input = soup.find_all('input', attrs=dict(name='conduction_speed'))
         assert len(conduction_speed_input) == 1, 'Number of conduction speed inputs is different than 1'
-        coupling_select_filed = soup.find_all('select', attrs=dict(name='_coupling'))
+        coupling_select_filed = soup.find_all('select', attrs=dict(name='coupling'))
         assert len(coupling_select_filed) == 1, 'Number of coupling select inputs is different than 1'
 
     def test_buttons_first_fragment(self):
-        dict_to_render = self.get_dict_to_render()
-        dict_to_render[SimulatorController.IS_FIRST_FRAGMENT_KEY] = True
-
-        soup = self.prepare_simulator_form_for_search(dict_to_render)
+        rendering_rules = SimulatorFragmentRenderingRules(form_action_url=SimulatorWizzardURLs.SET_CONNECTIVITY_URL,
+                                                          is_first_fragment=True)
+        soup = self.prepare_simulator_form_for_search(rendering_rules)
 
         all_buttons = soup.find_all('button')
         assert len(all_buttons) == 1
@@ -178,11 +172,8 @@ class TestJinja2Simulator(Jinja2Test):
         assert len(hidden_buttons) == 0
 
     def test_buttons_first_fragment_copy(self):
-        dict_to_render = self.get_dict_to_render()
-        dict_to_render[SimulatorController.IS_FIRST_FRAGMENT_KEY] = True
-        dict_to_render[SimulatorController.IS_COPY] = True
-
-        soup = self.prepare_simulator_form_for_search(dict_to_render)
+        rendering_rules = SimulatorFragmentRenderingRules(is_first_fragment=True, is_simulation_copy=True)
+        soup = self.prepare_simulator_form_for_search(rendering_rules)
 
         all_buttons = soup.find_all('button')
         assert len(all_buttons) == 1
@@ -191,10 +182,8 @@ class TestJinja2Simulator(Jinja2Test):
         assert len(hidden_buttons) == 1
 
     def test_buttons_last_fragment(self):
-        dict_to_render = self.get_dict_to_render()
-        dict_to_render[SimulatorController.IS_LAST_FRAGMENT_KEY] = True
-
-        soup = self.prepare_simulator_form_for_search(dict_to_render)
+        rendering_rules = SimulatorFragmentRenderingRules(is_launch_fragment=True)
+        soup = self.prepare_simulator_form_for_search(rendering_rules)
 
         all_buttons = soup.find_all('button')
         assert len(all_buttons) == 3
@@ -202,11 +191,8 @@ class TestJinja2Simulator(Jinja2Test):
         assert len(hidden_buttons) == 0
 
     def test_buttons_last_fragment_copy(self):
-        dict_to_render = self.get_dict_to_render()
-        dict_to_render[SimulatorController.IS_LAST_FRAGMENT_KEY] = True
-        dict_to_render[SimulatorController.IS_COPY] = True
-
-        soup = self.prepare_simulator_form_for_search(dict_to_render)
+        rendering_rules = SimulatorFragmentRenderingRules(is_launch_fragment=True, is_simulation_copy=True)
+        soup = self.prepare_simulator_form_for_search(rendering_rules)
 
         all_buttons = soup.find_all('button')
         assert len(all_buttons) == 4
@@ -214,33 +200,26 @@ class TestJinja2Simulator(Jinja2Test):
         assert len(hidden_buttons) == 0
 
     def test_buttons_last_fragment_readonly(self):
-        dict_to_render = self.get_dict_to_render()
-        dict_to_render[SimulatorController.IS_LAST_FRAGMENT_KEY] = True
-        dict_to_render[SimulatorController.IS_LOAD] = True
-
-        soup = self.prepare_simulator_form_for_search(dict_to_render)
+        rendering_rules = SimulatorFragmentRenderingRules(is_launch_fragment=True, is_simulation_readonly_load=True)
+        soup = self.prepare_simulator_form_for_search(rendering_rules)
 
         all_buttons = soup.find_all('button')
         assert len(all_buttons) == 1
         hidden_buttons = soup.find_all('button', attrs=dict(style="visibility: hidden"))
         assert len(hidden_buttons) == 1
 
-    def test_buttons_middle_fragment(self):
-        dict_to_render = self.get_dict_to_render()
-        dict_to_render[SimulatorController.IS_MODEL_FRAGMENT_KEY] = True
-        dict_to_render[SimulatorController.IS_SURFACE_SIMULATION_KEY] = True
-
-        soup = self.prepare_simulator_form_for_search(dict_to_render)
+    def test_buttons_model_fragment(self):
+        rendering_rules = SimulatorFragmentRenderingRules(is_model_fragment=True, is_surface_simulation=True)
+        soup = self.prepare_simulator_form_for_search(rendering_rules)
 
         all_buttons = soup.find_all('button')
         assert len(all_buttons) == 4
         hidden_buttons = soup.find_all('button', attrs=dict(style="visibility: hidden"))
         assert len(hidden_buttons) == 0
 
-    def test_buttons_model_fragment(self):
-        dict_to_render = self.get_dict_to_render()
-
-        soup = self.prepare_simulator_form_for_search(dict_to_render)
+    def test_buttons_middle_fragment(self):
+        rendering_rules = SimulatorFragmentRenderingRules()
+        soup = self.prepare_simulator_form_for_search(rendering_rules)
 
         all_buttons = soup.find_all('button')
         assert len(all_buttons) == 2

--- a/scientific_library/tvb/basic/neotraits/_attr.py
+++ b/scientific_library/tvb/basic/neotraits/_attr.py
@@ -31,22 +31,17 @@
 """
 This private module implements concrete declarative attributes
 """
-import types
-import collections
+import collections.abc
 import numpy
-import logging
-from ._declarative_base import _Attr
+import types
+import typing
+from ._core import HasTraits
+from ._declarative_base import _Attr, MetaType
 from .ex import TraitValueError, TraitTypeError, TraitAttributeError
-import sys
-
-if sys.version_info[0] == 3:
-    import typing
-    if typing.TYPE_CHECKING:
-        from ._core import HasTraits
-        from tvb.basic.neotraits._declarative_base import MetaType
+from tvb.basic.logger.builder import get_logger
 
 # a logger for the whole traits system
-log = logging.getLogger('tvb.traits')
+log = get_logger('tvb.traits')
 
 
 class Attr(_Attr):
@@ -246,7 +241,7 @@ class List(Attr):
     def __init__(self, of=object, default=(), doc='', label='', final=False, choices=None):
         # type: (type, tuple, str, str, bool, typing.Optional[tuple]) -> None
         super(List, self).__init__(
-            field_type=collections.Sequence,
+            field_type=collections.abc.Sequence,
             default=default,
             doc=doc,
             label=label,
@@ -472,7 +467,7 @@ class NArray(Attr):
                 if d is not Dim.any and type(d) != Dim:
                     raise TraitValueError("shape elements must be Dim's not {}".format(type(d)), attr=self)
             self.ndim = len(self.shape)
-        elif self.dim_names:   # no shape but dim_names
+        elif self.dim_names:  # no shape but dim_names
             self.ndim = len(self.dim_names)
         else:
             self.ndim = None

--- a/scientific_library/tvb/basic/neotraits/_attr.py
+++ b/scientific_library/tvb/basic/neotraits/_attr.py
@@ -35,10 +35,12 @@ import collections.abc
 import numpy
 import types
 import typing
-from ._core import HasTraits
 from ._declarative_base import _Attr, MetaType
 from .ex import TraitValueError, TraitTypeError, TraitAttributeError
 from tvb.basic.logger.builder import get_logger
+
+if typing.TYPE_CHECKING:
+    from ._core import HasTraits
 
 # a logger for the whole traits system
 log = get_logger('tvb.traits')

--- a/scientific_library/tvb/basic/neotraits/_core.py
+++ b/scientific_library/tvb/basic/neotraits/_core.py
@@ -32,18 +32,16 @@
 This module implements neotraits.
 It is private only to shield public usage of the imports and logger.
 """
-import sys
+
 import uuid
 import numpy
+import typing
 from six import add_metaclass
 from ._attr import Attr
 from ._declarative_base import _Property, MetaType
 from .info import trait_object_str, trait_object_repr_html, narray_summary_info
 from .ex import TraitAttributeError, TraitTypeError, TraitError
 from tvb.basic.logger.builder import get_logger
-
-if sys.version_info[0] == 3:
-    import typing
 
 
 

--- a/scientific_library/tvb/basic/neotraits/_declarative_base.py
+++ b/scientific_library/tvb/basic/neotraits/_declarative_base.py
@@ -34,18 +34,13 @@ The basic Attribute Property and their automatic discovery by the Metaclass.
 """
 import abc
 import inspect
-import logging
-
+import typing
 from tvb.basic.neotraits.ex import TraitTypeError, TraitAttributeError
 from tvb.basic.neotraits.info import auto_docstring
-
-import sys
-
-if sys.version_info[0] == 3:
-    import typing
+from tvb.basic.logger.builder import get_logger
 
 # a logger for the whole traits system
-log = logging.getLogger('tvb.traits')
+log = get_logger('tvb.traits')
 
 
 class _Attr(object):

--- a/scientific_library/tvb/basic/neotraits/info.py
+++ b/scientific_library/tvb/basic/neotraits/info.py
@@ -35,10 +35,7 @@ Some of these functions are here so that they won't clutter the core trait imple
 """
 
 import numpy
-import sys
-
-if sys.version_info[0] == 3:
-    import typing
+import typing
 
 
 def auto_docstring(cls):

--- a/scientific_library/tvb/simulator/models/base.py
+++ b/scientific_library/tvb/simulator/models/base.py
@@ -30,17 +30,12 @@
 This module defines the common imports and abstract base class for model definitions.
 
 """
-import sys
 import abc
 import numpy
+import typing
 from tvb.basic.neotraits.api import HasTraits
-if sys.version_info[0] == 3:
-    import typing
 
-import sys
 
-if sys.version_info[0] == 3:
-    import typing
 
 
 class Model(HasTraits):


### PR DESCRIPTION
- Cleanup imports
- remove checks `if sys.version_info[0] == 3:` as we no longer support py2
- use get_logger in traited modules, to display logs uniformly
- migrate jinja2 unit-test towards the new format of usage in the code