### PR TITLE
TVB-2641 Use Fraunhofen REST url by default

### DIFF
--- a/framework_tvb/tvb/interfaces/rest/client/examples/fire_simulation.py
+++ b/framework_tvb/tvb/interfaces/rest/client/examples/fire_simulation.py
@@ -37,7 +37,7 @@ from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
 from tvb.adapters.datatypes.h5.time_series_h5 import TimeSeriesH5
 from tvb.adapters.simulator.simulator_adapter import SimulatorAdapterModel
 from tvb.basic.logger.builder import get_logger
-from tvb.interfaces.rest.client.examples.utils import monitor_operation
+from tvb.interfaces.rest.client.examples.utils import monitor_operation, compute_rest_url
 from tvb.interfaces.rest.client.tvb_client import TVBClient
 
 if __name__ == '__main__':
@@ -45,7 +45,7 @@ if __name__ == '__main__':
     logger = get_logger(__name__)
 
     logger.info("Preparing client...")
-    tvb_client = TVBClient("http://localhost:9090")
+    tvb_client = TVBClient(compute_rest_url())
 
     logger.info("Attempt to login")
     tvb_client.browser_login()

--- a/framework_tvb/tvb/interfaces/rest/client/examples/launch_operation.py
+++ b/framework_tvb/tvb/interfaces/rest/client/examples/launch_operation.py
@@ -39,14 +39,14 @@ from tvb.adapters.uploaders.zip_connectivity_importer import ZIPConnectivityImpo
 from tvb.adapters.uploaders.zip_surface_importer import ZIPSurfaceImporterModel, ZIPSurfaceImporter
 from tvb.basic.logger.builder import get_logger
 from tvb.datatypes.surfaces import CORTICAL
-from tvb.interfaces.rest.client.examples.utils import compute_tvb_data_path, monitor_operation
+from tvb.interfaces.rest.client.examples.utils import compute_tvb_data_path, monitor_operation, compute_rest_url
 from tvb.interfaces.rest.client.tvb_client import TVBClient
 
 if __name__ == '__main__':
     logger = get_logger(__name__)
 
     logger.info("Preparing client...")
-    tvb_client = TVBClient("http://localhost:9090")
+    tvb_client = TVBClient(compute_rest_url())
 
     logger.info("Attempt to login")
     tvb_client.browser_login()

--- a/framework_tvb/tvb/interfaces/rest/client/examples/utils.py
+++ b/framework_tvb/tvb/interfaces/rest/client/examples/utils.py
@@ -29,11 +29,22 @@
 #
 
 import os
+import sys
 import time
 
 import tvb_data
 from tvb.basic.logger.builder import get_logger
 from tvb.core.entities.model.model_operation import STATUS_ERROR, STATUS_CANCELED, STATUS_FINISHED
+
+
+def compute_rest_url():
+    rest_url = "https://tvb-sim3.scai.fraunhofer.de"
+    if len(sys.argv) > 0:
+        for i in range(0, len(sys.argv)):
+            if "--rest-url=" in sys.argv[i]:
+                rest_url = sys.argv[i].split("=")[1]
+
+    return rest_url
 
 
 def compute_tvb_data_path(folder, filename):


### PR DESCRIPTION
Use Fraunhofen REST url by default in examples. 
There is also an option to pass the REST url to the examples:

python -m tvb.interfaces.rest.client.examples.fire_simulation --rest-url=http://localhost:8080