### PR TITLE
TVB-2463: Simulation Launch to work with GUID ranges

### DIFF
--- a/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
@@ -218,7 +218,7 @@ class SimulatorPSEParamRangeFragment(ABCAdapterForm):
 
         else:
             self.pse_param1_dt = DataTypeSelectField(h5.REGISTRY.get_index_for_datatype(pse_param1.type), self,
-                                                     name='pse_param1', required=True, label='pse_param1',
+                                                     name='pse_param1_guid', required=True, label='pse_param1_guid',
                                                      dynamic_conditions=pse_param1.range_definition,
                                                      has_all_option=True)
 
@@ -234,7 +234,7 @@ class SimulatorPSEParamRangeFragment(ABCAdapterForm):
                                                         default=pse_param2.range_definition.step)
             else:
                 self.pse_param2_dt = DataTypeSelectField(h5.REGISTRY.get_index_for_datatype(pse_param2.type), self,
-                                                         name='pse_param2', required=True, label='pse_param2',
+                                                         name='pse_param2_guid', required=True, label='pse_param2_guid',
                                                          dynamic_conditions=pse_param2.range_definition,
                                                          has_all_option=True)
 
@@ -258,8 +258,7 @@ class SimulatorPSEParamRangeFragment(ABCAdapterForm):
                                           Range(float(pse_param1_lo), float(pse_param1_hi), float(pse_param1_step)),
                                           is_array=pse_param1.is_array)
         else:
-            param1_range_str = data.get('pse_param1')
-            pse_param1_name += '.gid'
+            param1_range_str = data.get('pse_param1_guid')
             param1_range = RangeParameter(pse_param1_name, pse_param1.type,
                                           SimulatorPSEParamRangeFragment._prepare_pse_uuid_list(param1_range_str))
 
@@ -274,9 +273,8 @@ class SimulatorPSEParamRangeFragment(ABCAdapterForm):
                                               Range(float(pse_param2_lo), float(pse_param2_hi), float(pse_param2_step)),
                                               is_array=pse_param2.is_array)
             else:
-                param2_range_str = data.get('pse_param2')
-                pse_param2_name += '.gid'
-                param2_range = RangeParameter(pse_param2_name, pse_param1.type,
+                param2_range_str = data.get('pse_param2_guid')
+                param2_range = RangeParameter(pse_param2_name, pse_param2.type,
                                               SimulatorPSEParamRangeFragment._prepare_pse_uuid_list(param2_range_str))
 
         return param1_range, param2_range

--- a/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
@@ -209,32 +209,32 @@ class SimulatorPSEParamRangeFragment(ABCAdapterForm):
         super(SimulatorPSEParamRangeFragment, self).__init__(prefix, project_id)
         self.pse_param1_name = SimpleHiddenField(self, name='pse_param1_name', default=pse_param1.name)
         if pse_param1.type is float:
-            self.pse_param1_lo = SimpleFloatField(self, name='pse_param1_lo', required=True, label='pse_param1_lo',
+            self.pse_param1_lo = SimpleFloatField(self, name='pse_param1_lo', required=True, label='PSE param1 lo',
                                                   default=pse_param1.range_definition.lo)
-            self.pse_param1_hi = SimpleFloatField(self, name='pse_param1_hi', required=True, label='pse_param1_hi',
+            self.pse_param1_hi = SimpleFloatField(self, name='pse_param1_hi', required=True, label='PSE param1 hi',
                                                   default=pse_param1.range_definition.hi)
             self.pse_param1_step = SimpleFloatField(self, name='pse_param1_step', required=True,
-                                                    label='pse_param1_step', default=pse_param1.range_definition.step)
+                                                    label='PSE param1 step', default=pse_param1.range_definition.step)
 
         else:
             self.pse_param1_dt = DataTypeSelectField(h5.REGISTRY.get_index_for_datatype(pse_param1.type), self,
-                                                     name='pse_param1_guid', required=True, label='pse_param1_guid',
+                                                     name='pse_param1_guid', required=True, label='PSE param1 guid',
                                                      dynamic_conditions=pse_param1.range_definition,
                                                      has_all_option=True)
 
         if pse_param2:
             self.pse_param2_name = SimpleHiddenField(self, name='pse_param2_name', default=pse_param2.name)
             if pse_param2.type is float:
-                self.pse_param2_lo = SimpleFloatField(self, name='pse_param2_lo', required=True, label='pse_param2_lo',
+                self.pse_param2_lo = SimpleFloatField(self, name='pse_param2_lo', required=True, label='PSE param2 lo',
                                                       default=pse_param2.range_definition.lo)
-                self.pse_param2_hi = SimpleFloatField(self, name='pse_param2_hi', required=True, label='pse_param2_hi',
+                self.pse_param2_hi = SimpleFloatField(self, name='pse_param2_hi', required=True, label='PSE param2 hi',
                                                       default=pse_param2.range_definition.hi)
                 self.pse_param2_step = SimpleFloatField(self, name='pse_param2_step', required=True,
-                                                        label='pse_param2_step',
+                                                        label='PSE param2 step',
                                                         default=pse_param2.range_definition.step)
             else:
                 self.pse_param2_dt = DataTypeSelectField(h5.REGISTRY.get_index_for_datatype(pse_param2.type), self,
-                                                         name='pse_param2_guid', required=True, label='pse_param2_guid',
+                                                         name='pse_param2_guid', required=True, label='PSE param2 guid',
                                                          dynamic_conditions=pse_param2.range_definition,
                                                          has_all_option=True)
 

--- a/framework_tvb/tvb/core/services/simulator_service.py
+++ b/framework_tvb/tvb/core/services/simulator_service.py
@@ -167,11 +167,22 @@ class SimulatorService(object):
                     simulator = copy.deepcopy(session_stored_simulator)
                     simulator.gid = uuid.uuid4()
                     self._set_simulator_range_parameter(simulator, range_param1.name, param1_value)
-                    ranges = {range_param1.name: param1_value[0] if type(param1_value) is numpy.ndarray else param1_value}
+                    if type(param1_value) is numpy.ndarray:
+                        ranges = {range_param1.name: param1_value[0]}
+                    elif isinstance(param1_value, uuid.UUID):
+                        ranges = {range_param1.name: param1_value.hex}
+                    else:
+                        ranges = {range_param1.name: param1_value}
 
                     if param2_value is not None:
                         self._set_simulator_range_parameter(simulator, range_param2.name, param2_value)
-                        ranges[range_param2.name] = param2_value[0] if type(param2_value) is numpy.ndarray else param2_value
+
+                        if type(param2_value) is numpy.ndarray:
+                            ranges[range_param2.name] = param2_value[0]
+                        elif isinstance(param2_value, uuid.UUID):
+                            ranges[range_param2.name] = param2_value.hex
+                        else:
+                            ranges[range_param2.name] = param2_value
 
                     ranges = json.dumps(ranges)
 
@@ -180,7 +191,7 @@ class SimulatorService(object):
                                                         {DataTypeMetaData.KEY_BURST: burst_config.id}, ranges)
 
                     storage_path = self.files_helper.get_project_folder(project, str(operation.id))
-                    SimulatorSerializer().serialize_simulator(simulator,  None, storage_path)
+                    SimulatorSerializer().serialize_simulator(simulator, None, storage_path)
                     operations.append(operation)
                     if first_simulator is None:
                         first_simulator = simulator

--- a/framework_tvb/tvb/core/services/simulator_service.py
+++ b/framework_tvb/tvb/core/services/simulator_service.py
@@ -148,6 +148,15 @@ class SimulatorService(object):
         except Exception as excep:
             self.logger.error(excep)
 
+    @staticmethod
+    def _set_range_param_in_dict(param_value):
+        if type(param_value) is numpy.ndarray:
+            return param_value[0]
+        elif isinstance(param_value, uuid.UUID):
+            return param_value.hex
+        else:
+            return param_value
+
     def async_launch_and_prepare_pse(self, burst_config, user, project, simulator_algo, range_param1, range_param2,
                                      session_stored_simulator):
         try:
@@ -167,22 +176,12 @@ class SimulatorService(object):
                     simulator = copy.deepcopy(session_stored_simulator)
                     simulator.gid = uuid.uuid4()
                     self._set_simulator_range_parameter(simulator, range_param1.name, param1_value)
-                    if type(param1_value) is numpy.ndarray:
-                        ranges = {range_param1.name: param1_value[0]}
-                    elif isinstance(param1_value, uuid.UUID):
-                        ranges = {range_param1.name: param1_value.hex}
-                    else:
-                        ranges = {range_param1.name: param1_value}
+
+                    ranges = {range_param1.name: self._set_range_param_in_dict(param1_value)}
 
                     if param2_value is not None:
                         self._set_simulator_range_parameter(simulator, range_param2.name, param2_value)
-
-                        if type(param2_value) is numpy.ndarray:
-                            ranges[range_param2.name] = param2_value[0]
-                        elif isinstance(param2_value, uuid.UUID):
-                            ranges[range_param2.name] = param2_value.hex
-                        else:
-                            ranges[range_param2.name] = param2_value
+                        ranges[range_param2.name] = self._set_range_param_in_dict(param2_value)
 
                     ranges = json.dumps(ranges)
 

--- a/framework_tvb/tvb/interfaces/web/static/js/bursts.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/bursts.js
@@ -936,7 +936,7 @@ function displayBurstTree(selectedHref, selectedProjectID, baseURL) {
     $("#div-burst-tree").show();
 }
 
-function calculateValuesInRage(pse_param_lo, pse_param_hi, pse_param_step){
+function _calculateValuesInRage(pse_param_lo, pse_param_hi, pse_param_step){
     const param_difference = pse_param_hi - pse_param_lo;
     let pse_param_number = Math.floor(param_difference / pse_param_step);
     const remainder_param = param_difference % pse_param_step;
@@ -946,7 +946,17 @@ function calculateValuesInRage(pse_param_lo, pse_param_hi, pse_param_step){
     return pse_param_number;
 }
 
-function displayPseSimulationMessage() {
+function _getRangeValueForGuidParameter(pse_param_guid){
+    pse_param_guid = pse_param_guid[0];
+
+    if(pse_param_guid.options.selectedIndex === pse_param_guid.options.length - 1){
+        return pse_param_guid.options.length - 1;
+    }
+
+    return 1;
+}
+
+function _displayPseSimulationMessage() {
     const THREASHOLD_WARNING = 500;
     const THREASHOLD_ERROR = 50000;
 
@@ -957,12 +967,12 @@ function displayPseSimulationMessage() {
         pse_param1_lo = pse_param1_lo[0].valueAsNumber;
         const pse_param1_hi = $("#pse_param1_hi")[0].valueAsNumber;
         const pse_param1_step = $("#pse_param1_step")[0].valueAsNumber;
-        pse_param1_number = calculateValuesInRage(pse_param1_lo, pse_param1_hi, pse_param1_step);
+        pse_param1_number = _calculateValuesInRage(pse_param1_lo, pse_param1_hi, pse_param1_step);
     }else{
         // We have range parameter with guid
-        let pse_param1_guid = $("#pse_param1_guid")[0];
-        if(pse_param1_guid.options.selectedIndex === pse_param1_guid.options.length - 1){
-            pse_param1_number = pse_param1_guid.options.length - 1;
+        let pse_param1_guid = $("#pse_param1_guid");
+        if(pse_param1_guid.length !== 0){
+            pse_param1_number = _getRangeValueForGuidParameter(pse_param1_guid);
         }
     }
 
@@ -973,14 +983,11 @@ function displayPseSimulationMessage() {
         pse_param2_lo = pse_param2_lo[0].valueAsNumber;
         const pse_param2_hi = $("#pse_param2_hi")[0].valueAsNumber;
         const pse_param2_step = $("#pse_param2_step")[0].valueAsNumber;
-        pse_param2_number = calculateValuesInRage(pse_param2_lo, pse_param2_hi, pse_param2_step);
+        pse_param2_number = _calculateValuesInRage(pse_param2_lo, pse_param2_hi, pse_param2_step);
     }else{
         let pse_param2_guid = $("#pse_param2_guid");
         if(pse_param2_guid.length !== 0){
-            pse_param2_guid = pse_param2_guid[0];
-            if(pse_param2_guid.options.selectedIndex === pse_param2_guid.options.length - 1){
-                pse_param2_number = pse_param2_guid.options.length - 1;
-            }
+           pse_param2_number = _getRangeValueForGuidParameter(pse_param2_guid)
         }
     }
 
@@ -1009,7 +1016,7 @@ function setPseRangeParameters(){
         e.target.id === 'pse_param2_step' ||
         e.target.id === 'pse_param1_guid' ||
         e.target.id === 'pse_param2_guid')){
-            displayPseSimulationMessage();
+            _displayPseSimulationMessage();
         }
     });
 }
@@ -1228,7 +1235,7 @@ function fill_burst_name(burstName, isReadOnly, addPrefix) {
 }
 
 function launchNewPSEBurst(currentForm) {
-    displayPseSimulationMessage();
+    _displayPseSimulationMessage();
     var form_data = $(currentForm).serialize();
 
     doAjaxCall({

--- a/framework_tvb/tvb/interfaces/web/static/js/bursts.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/bursts.js
@@ -943,6 +943,7 @@ function _calculateValuesInRage(pse_param_lo, pse_param_hi, pse_param_step){
     if(remainder_param !== 0){
         pse_param_number = pse_param_number + 1;
     }
+
     return pse_param_number;
 }
 
@@ -956,40 +957,31 @@ function _getRangeValueForGuidParameter(pse_param_guid){
     return 1;
 }
 
+function _computeRangeNumberForParamPrefix(prefix){
+    //check if param exists and does not have guid
+    let pse_param_lo = $("#".concat(prefix, "_lo"));
+    if(pse_param_lo.length !== 0){
+        pse_param_lo = pse_param_lo[0].valueAsNumber;
+        const pse_param_hi = $("#".concat(prefix, "_hi"))[0].valueAsNumber;
+        const pse_param_step = $("#".concat(prefix, "_step"))[0].valueAsNumber;
+        return _calculateValuesInRage(pse_param_lo, pse_param_hi, pse_param_step);
+    }
+
+    //check if we have param with guid
+    let pse_param_guid = $("#".concat(prefix, "_guid"));
+    if(pse_param_guid.length !== 0){
+        return _getRangeValueForGuidParameter(pse_param_guid);
+    }
+
+    return 1;
+}
+
 function _displayPseSimulationMessage() {
     const THREASHOLD_WARNING = 500;
     const THREASHOLD_ERROR = 50000;
 
-    // Check if we have first range parameter with guid
-    let pse_param1_lo = $("#pse_param1_lo");
-    let pse_param1_number = 1;
-    if(pse_param1_lo.length !== 0){
-        pse_param1_lo = pse_param1_lo[0].valueAsNumber;
-        const pse_param1_hi = $("#pse_param1_hi")[0].valueAsNumber;
-        const pse_param1_step = $("#pse_param1_step")[0].valueAsNumber;
-        pse_param1_number = _calculateValuesInRage(pse_param1_lo, pse_param1_hi, pse_param1_step);
-    }else{
-        // We have range parameter with guid
-        let pse_param1_guid = $("#pse_param1_guid");
-        if(pse_param1_guid.length !== 0){
-            pse_param1_number = _getRangeValueForGuidParameter(pse_param1_guid);
-        }
-    }
-
-    // Check if second range parameter exists and if it has guid or not
-    let pse_param2_lo = $("#pse_param2_lo");
-    let pse_param2_number = 1;
-    if(pse_param2_lo.length !== 0) {
-        pse_param2_lo = pse_param2_lo[0].valueAsNumber;
-        const pse_param2_hi = $("#pse_param2_hi")[0].valueAsNumber;
-        const pse_param2_step = $("#pse_param2_step")[0].valueAsNumber;
-        pse_param2_number = _calculateValuesInRage(pse_param2_lo, pse_param2_hi, pse_param2_step);
-    }else{
-        let pse_param2_guid = $("#pse_param2_guid");
-        if(pse_param2_guid.length !== 0){
-           pse_param2_number = _getRangeValueForGuidParameter(pse_param2_guid)
-        }
-    }
+    pse_param1_number = _computeRangeNumberForParamPrefix('pse_param1');
+    pse_param2_number = _computeRangeNumberForParamPrefix('pse_param2');
 
     let nrOps = pse_param1_number * pse_param2_number;
     let className = "infoMessage";

--- a/framework_tvb/tvb/interfaces/web/static/js/bursts.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/bursts.js
@@ -950,11 +950,23 @@ function displayPseSimulationMessage() {
     const THREASHOLD_WARNING = 500;
     const THREASHOLD_ERROR = 50000;
 
-    const pse_param1_lo = $("#pse_param1_lo")[0].valueAsNumber;
-    const pse_param1_hi = $("#pse_param1_hi")[0].valueAsNumber;
-    const pse_param1_step = $("#pse_param1_step")[0].valueAsNumber;
-    const pse_param1_number = calculateValuesInRage(pse_param1_lo, pse_param1_hi, pse_param1_step);
+    // Check if we have first range parameter with guid
+    let pse_param1_lo = $("#pse_param1_lo");
+    let pse_param1_number = 1;
+    if(pse_param1_lo.length !== 0){
+        pse_param1_lo = pse_param1_lo[0].valueAsNumber;
+        const pse_param1_hi = $("#pse_param1_hi")[0].valueAsNumber;
+        const pse_param1_step = $("#pse_param1_step")[0].valueAsNumber;
+        pse_param1_number = calculateValuesInRage(pse_param1_lo, pse_param1_hi, pse_param1_step);
+    }else{
+        // We have range parameter with guid
+        let pse_param1_guid = $("#pse_param1_guid")[0];
+        if(pse_param1_guid.options.selectedIndex === pse_param1_guid.options.length - 1){
+            pse_param1_number = pse_param1_guid.options.length - 1;
+        }
+    }
 
+    // Check if second range parameter exists and if it has guid or not
     let pse_param2_lo = $("#pse_param2_lo");
     let pse_param2_number = 1;
     if(pse_param2_lo.length !== 0) {
@@ -962,6 +974,14 @@ function displayPseSimulationMessage() {
         const pse_param2_hi = $("#pse_param2_hi")[0].valueAsNumber;
         const pse_param2_step = $("#pse_param2_step")[0].valueAsNumber;
         pse_param2_number = calculateValuesInRage(pse_param2_lo, pse_param2_hi, pse_param2_step);
+    }else{
+        let pse_param2_guid = $("#pse_param2_guid");
+        if(pse_param2_guid.length !== 0){
+            pse_param2_guid = pse_param2_guid[0];
+            if(pse_param2_guid.options.selectedIndex === pse_param2_guid.options.length - 1){
+                pse_param2_number = pse_param2_guid.options.length - 1;
+            }
+        }
     }
 
     let nrOps = pse_param1_number * pse_param2_number;
@@ -986,7 +1006,9 @@ function setPseRangeParameters(){
         e.target.id === 'pse_param1_step' ||
         e.target.id === 'pse_param2_lo' ||
         e.target.id === 'pse_param2_hi' ||
-        e.target.id === 'pse_param2_step')){
+        e.target.id === 'pse_param2_step' ||
+        e.target.id === 'pse_param1_guid' ||
+        e.target.id === 'pse_param2_guid')){
             displayPseSimulationMessage();
         }
     });


### PR DESCRIPTION
I managed to succesfully launch a simulation with connectivity as range param and I was able to see if with the Discrete Visualizer. I also adapted the js code which calculates the operations.

A question: Should we add a filter which only lets you run with connectivities that have the same number of regions as the original connectivity chosen for simulation?