### PR TITLE
TVB-2537. Serialize BurstConfiguration and fix import/export simulation

### DIFF
--- a/framework_tvb/tvb/adapters/datatypes/h5/burst_configuration_h5.py
+++ b/framework_tvb/tvb/adapters/datatypes/h5/burst_configuration_h5.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+#
+# TheVirtualBrain-Framework Package. This package holds all Data Management, and
+# Web-UI helpful to run brain-simulations. To use it, you also need do download
+# TheVirtualBrain-Scientific Package (for simulators). See content of the
+# documentation-folder for more details. See also http://www.thevirtualbrain.org
+#
+# (c) 2012-2020, Baycrest Centre for Geriatric Care ("Baycrest") and others
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this
+# program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+#   CITATION:
+# When using The Virtual Brain for scientific publications, please cite it as follows:
+#
+#   Paula Sanz Leon, Stuart A. Knock, M. Marmaduke Woodman, Lia Domide,
+#   Jochen Mersmann, Anthony R. McIntosh, Viktor Jirsa (2013)
+#       The Virtual Brain: a simulator of primate brain network dynamics.
+#   Frontiers in Neuroinformatics (7:10. doi: 10.3389/fninf.2013.00010)
+#
+#
+
+import uuid
+from tvb.basic.neotraits.api import Attr
+from tvb.core.neotraits.h5 import H5File, Scalar, Reference, Json
+from tvb.core.utils import date2string, string2date
+
+
+class BurstConfigurationH5(H5File):
+    def __init__(self, path):
+        super(BurstConfigurationH5, self).__init__(path)
+        self.name = Scalar(Attr(str), self, name='name')
+        self.status = Scalar(Attr(str), self, name='status')
+        self.error_message = Scalar(Attr(str, required=False), self, name='error_message')
+        self.start_time = Scalar(Attr(str), self, name='start_time')
+        self.finish_time = Scalar(Attr(str, required=False), self, name='finish_time')
+        self.simulator = Reference(Attr(str), self, name='simulator')
+        self.range1 = Json(Attr(str, required=False), self, name='range1')
+        self.range2 = Json(Attr(str, required=False), self, name='range2')
+
+    def store_index(self, burst_config):
+        self.name.store(burst_config.name)
+        self.status.store(burst_config.status)
+        self.error_message.store(burst_config.error_message or 'None')
+        self.start_time.store(date2string(burst_config.start_time))
+        self.finish_time.store(date2string(burst_config.finish_time))
+        self.simulator.store(uuid.UUID(burst_config.simulator_gid))
+        if burst_config.operation_group_id:
+            self.range1.store(burst_config.range1)
+            self.range2.store(burst_config.range2)
+
+    def load_into_index(self, burst_config):
+        burst_config.name = self.name.load()
+        burst_config.status = self.status.load()
+        burst_config.error_message = self.error_message.load()
+        burst_config.start_time = string2date(self.start_time.load())
+        burst_config.finish_time = string2date(self.finish_time.load())
+        burst_config.simulator_gid = self.simulator.load().hex
+        burst_config.range1 = self.range1.load()
+        burst_config.range2 = self.range2.load()

--- a/framework_tvb/tvb/adapters/simulator/range_parameter.py
+++ b/framework_tvb/tvb/adapters/simulator/range_parameter.py
@@ -38,36 +38,48 @@ from tvb.simulator.simulator import Simulator
 
 
 class RangeParameter(object):
+    KEY_FLOAT_LO = 'lo'
+    KEY_FLOAT_STEP = 'step'
+    KEY_FLOAT_HI = 'hi'
 
-    def __init__(self, name, type, range_definition, is_array=False):
+    def __init__(self, name, type, range_definition, is_array=False, range_values=None):
         self.name = name
         self.type = type
         self.is_array = is_array
+        # range_definition is a Range object when is_array=True and a FilterChain otherwise
         self.range_definition = range_definition
+        self.range_values = range_values
 
     def to_json(self):
         if self.type is float:
-            return json.dumps([self.name, [self.range_definition.lo, self.range_definition.step, self.range_definition.hi]])
-        gid_str_list = [gid.hex for gid in self.range_definition]
-        return json.dumps([self.name, gid_str_list])
+            return json.dumps([self.name, {self.KEY_FLOAT_LO: self.range_definition.lo,
+                                           self.KEY_FLOAT_STEP: self.range_definition.step,
+                                           self.KEY_FLOAT_HI: self.range_definition.hi}])
 
-    # TODO: use this from fill_operationgroup_name?
+        return json.dumps([self.name, self.range_definition])
+
     @staticmethod
     def from_json(range_json):
         range_list = json.loads(range_json)
-        if isinstance(range_list[1][0], float):
-            return RangeParameter(range_list[0], float, Range(range_list[1][0], range_list[1][2], range_list[1][1]))
+        if isinstance(range_list[1], dict):
+            return RangeParameter(range_list[0], float,
+                                  Range(range_list[1][RangeParameter.KEY_FLOAT_LO],
+                                        range_list[1][RangeParameter.KEY_FLOAT_HI],
+                                        range_list[1][RangeParameter.KEY_FLOAT_STEP]))
+
         return RangeParameter(range_list[0], HasTraits, range_list[1])
 
     def get_range_values(self):
         if self.type is float:
-            range_values = self.range_definition.to_array()
+            self.range_values = self.range_definition.to_array()
             if self.is_array:
-                range_values = [numpy.array([value]) for value in range_values]
-        else:
-            # TODO: is this correct for non-floats?
-            range_values = self.range_definition
-        return range_values
+                self.range_values = [numpy.array([value]) for value in self.range_values]
+        return self.range_values
+
+    def fill_from_default(self, range_param):
+        # type: (RangeParameter) -> None
+        self.type = range_param.type
+        self.is_array = range_param.is_array
 
 
 class SimulatorRangeParameters(object):
@@ -128,6 +140,7 @@ class SimulatorRangeParameters(object):
         return all_range_parameters
 
     def add_connectivity_filter(self, filter):
+        # TODO: add to FilterChain not to list
         if self.connectivity_filters is None:
             self.connectivity_filters = []
         self.connectivity_filters.append(filter)

--- a/framework_tvb/tvb/adapters/simulator/range_parameter.py
+++ b/framework_tvb/tvb/adapters/simulator/range_parameter.py
@@ -46,7 +46,7 @@ class RangeParameter(object):
         self.name = name
         self.type = type
         self.is_array = is_array
-        # range_definition is a Range object when is_array=True and a FilterChain otherwise
+        # range_definition is a Range object when type=float and a FilterChain otherwise
         self.range_definition = range_definition
         self.range_values = range_values
 

--- a/framework_tvb/tvb/core/entities/file/simulator/burst_configuration_h5.py
+++ b/framework_tvb/tvb/core/entities/file/simulator/burst_configuration_h5.py
@@ -46,7 +46,7 @@ class BurstConfigurationH5(H5File):
         self.range1 = Json(Attr(str, required=False), self, name='range1')
         self.range2 = Json(Attr(str, required=False), self, name='range2')
 
-    def store_index(self, burst_config):
+    def store(self, burst_config, scalars_only=False, store_references=False):
         self.name.store(burst_config.name)
         self.status.store(burst_config.status)
         self.error_message.store(burst_config.error_message or 'None')
@@ -57,7 +57,7 @@ class BurstConfigurationH5(H5File):
             self.range1.store(burst_config.range1)
             self.range2.store(burst_config.range2)
 
-    def load_into_index(self, burst_config):
+    def load_into(self, burst_config):
         burst_config.name = self.name.load()
         burst_config.status = self.status.load()
         burst_config.error_message = self.error_message.load()

--- a/framework_tvb/tvb/core/entities/model/model_burst.py
+++ b/framework_tvb/tvb/core/entities/model/model_burst.py
@@ -143,9 +143,6 @@ class BurstConfiguration(HasTraitsIndex):
     selected_tab = -1
     is_group = False
 
-    range1 = None
-    range2 = None
-
     datatypes_number = Column(Integer)
     dynamic_ids = Column(String, default='[]', nullable=False)
 
@@ -187,6 +184,8 @@ class BurstConfiguration(HasTraitsIndex):
     def clone(self):
         new_burst = BurstConfiguration(self.project_id)
         new_burst.name = self.name
+        new_burst.range1 = self.range1
+        new_burst.range2 = self.range2
         new_burst.status = self.BURST_RUNNING
         return new_burst
 

--- a/framework_tvb/tvb/core/entities/model/model_burst.py
+++ b/framework_tvb/tvb/core/entities/model/model_burst.py
@@ -146,9 +146,8 @@ class BurstConfiguration(HasTraitsIndex):
     datatypes_number = Column(Integer)
     dynamic_ids = Column(String, default='[]', nullable=False)
 
-    # TODO: decide upon these transient fields task TVB-2537
-    range1 = None
-    range2 = None
+    range1 = Column(String, nullable=True)
+    range2 = Column(String, nullable=True)
 
     id = Column(Integer, ForeignKey(HasTraitsIndex.id), primary_key=True)
 
@@ -194,3 +193,6 @@ class BurstConfiguration(HasTraitsIndex):
         if self.finish_time is not None and self.start_time is not None:
             return format_timedelta(self.finish_time - self.start_time)
         return ''
+
+    def is_pse_burst(self):
+        return self.range1 is not None

--- a/framework_tvb/tvb/core/entities/model/model_burst.py
+++ b/framework_tvb/tvb/core/entities/model/model_burst.py
@@ -142,6 +142,10 @@ class BurstConfiguration(HasTraitsIndex):
     nr_of_tabs = 0
     selected_tab = -1
     is_group = False
+
+    range1 = None
+    range2 = None
+
     datatypes_number = Column(Integer)
     dynamic_ids = Column(String, default='[]', nullable=False)
 

--- a/framework_tvb/tvb/core/neotraits/forms.py
+++ b/framework_tvb/tvb/core/neotraits/forms.py
@@ -230,13 +230,15 @@ class DataTypeSelectField(Field):
     missing_value = 'explicit-None-value'
 
     def __init__(self, datatype_index, form, name=None, disabled=False, required=False, label='', doc='',
-                 conditions=None, draw_dynamic_conditions_buttons=True, dynamic_conditions=None, has_all_option=False):
+                 conditions=None, draw_dynamic_conditions_buttons=True, dynamic_conditions=None, has_all_option=False,
+                 show_only_all_option=False):
         super(DataTypeSelectField, self).__init__(form, name, disabled, required, label, doc)
         self.datatype_index = datatype_index
         self.conditions = conditions
         self.draw_dynamic_conditions_buttons = draw_dynamic_conditions_buttons
         self.dynamic_conditions = dynamic_conditions
         self.has_all_option = has_all_option
+        self.show_only_all_option = show_only_all_option
 
     @property
     def get_dynamic_filters(self):
@@ -266,13 +268,14 @@ class DataTypeSelectField(Field):
                 checked=self.data is None
             )
 
-        for i, datatype in enumerate(filtered_datatypes):
-            yield Option(
-                id='{}_{}'.format(self.name, i),
-                value=datatype[2],
-                label=self._prepare_display_name(datatype),
-                checked=self.data == datatype[2]
-            )
+        if not self.show_only_all_option:
+            for i, datatype in enumerate(filtered_datatypes):
+                yield Option(
+                    id='{}_{}'.format(self.name, i),
+                    value=datatype[2],
+                    label=self._prepare_display_name(datatype),
+                    checked=self.data == datatype[2]
+                )
 
         if self.has_all_option:
             if not self.owner.draw_ranges:

--- a/framework_tvb/tvb/core/services/burst_service.py
+++ b/framework_tvb/tvb/core/services/burst_service.py
@@ -179,9 +179,7 @@ class BurstService(object):
         # type: (BurstConfiguration) -> None
         project = dao.get_project_by_id(burst_configuration.project_id)
         storage_path = self.file_helper.get_project_folder(project, str(burst_configuration.fk_simulation_id))
-        bc_path = h5.path_for(storage_path, BurstConfigurationH5, burst_configuration.gid)
-        with BurstConfigurationH5(os.path.join(storage_path, bc_path)) as bc_h5:
-            bc_h5.store(burst_configuration)
+        self.store_burst_configuration(burst_configuration, storage_path)
 
     def load_burst_configuration(self, burst_config_id):
         # type: (int) -> BurstConfiguration
@@ -206,3 +204,8 @@ class BurstService(object):
         burst_config.metric_operation_group = metric_operation_group
         burst_config.metric_operation_group_id = metric_operation_group.id
         dao.store_entity(burst_config)
+
+    def store_burst_configuration(self, burst_config, storage_path):
+        bc_path = h5.path_for(storage_path, BurstConfigurationH5, burst_config.gid)
+        with BurstConfigurationH5(bc_path) as bc_h5:
+            bc_h5.store(burst_config)

--- a/framework_tvb/tvb/core/services/burst_service.py
+++ b/framework_tvb/tvb/core/services/burst_service.py
@@ -30,9 +30,9 @@
 
 import os
 from datetime import datetime
-from tvb.adapters.datatypes.h5.burst_configuration_h5 import BurstConfigurationH5
 from tvb.basic.logger.builder import get_logger
 from tvb.core.entities.file.files_helper import FilesHelper
+from tvb.core.entities.file.simulator.burst_configuration_h5 import BurstConfigurationH5
 from tvb.core.entities.model.model_datatype import DataTypeGroup
 from tvb.core.entities.model.model_burst import BurstConfiguration
 from tvb.core.entities.model.model_operation import OperationGroup
@@ -181,7 +181,7 @@ class BurstService(object):
         storage_path = self.file_helper.get_project_folder(project, str(burst_configuration.fk_simulation_id))
         bc_path = h5.path_for(storage_path, BurstConfigurationH5, burst_configuration.gid)
         with BurstConfigurationH5(os.path.join(storage_path, bc_path)) as bc_h5:
-            bc_h5.store_index(burst_configuration)
+            bc_h5.store(burst_configuration)
 
     def load_burst_configuration(self, burst_config_id):
         # type: (int) -> BurstConfiguration

--- a/framework_tvb/tvb/core/services/burst_service.py
+++ b/framework_tvb/tvb/core/services/burst_service.py
@@ -38,6 +38,7 @@ from tvb.core.entities.model.model_burst import BurstConfiguration
 from tvb.core.entities.model.model_operation import OperationGroup
 from tvb.core.entities.storage import dao
 from tvb.core.neocom import h5
+from tvb.core.neocom.h5 import DirLoader
 from tvb.core.utils import format_bytes_human, format_timedelta
 
 MAX_BURSTS_DISPLAYED = 50
@@ -209,3 +210,10 @@ class BurstService(object):
         bc_path = h5.path_for(storage_path, BurstConfigurationH5, burst_config.gid)
         with BurstConfigurationH5(bc_path) as bc_h5:
             bc_h5.store(burst_config)
+
+    def load_burst_configuration_from_folder(self, simulator_folder, project):
+        bc_h5_filename = DirLoader(simulator_folder, None).find_file_for_has_traits_type(BurstConfiguration)
+        burst_config = BurstConfiguration(project.id)
+        with BurstConfigurationH5(os.path.join(simulator_folder, bc_h5_filename)) as bc_h5:
+            bc_h5.load_into(burst_config)
+        return burst_config

--- a/framework_tvb/tvb/core/services/burst_service.py
+++ b/framework_tvb/tvb/core/services/burst_service.py
@@ -186,10 +186,6 @@ class BurstService(object):
     def load_burst_configuration(self, burst_config_id):
         # type: (int) -> BurstConfiguration
         burst_config = dao.get_burst_by_id(burst_config_id)
-        if burst_config.operation_group_id:
-            operation_group = dao.get_operationgroup_by_id(burst_config.operation_group_id)
-            burst_config.range1 = operation_group.range1
-            burst_config.range2 = operation_group.range2
         return burst_config
 
     def prepare_burst_for_pse(self, burst_config):

--- a/framework_tvb/tvb/core/services/import_service.py
+++ b/framework_tvb/tvb/core/services/import_service.py
@@ -482,3 +482,25 @@ class ImportService(object):
 
         burst_entity = BurstConfiguration(project_id)
         return burst_entity
+
+    def import_simulator_configuration_zip(self, zip_file, project_id):
+        # Now compute the name of the folder where to explode uploaded ZIP file
+        temp_folder = self._compute_unpack_path()
+        uq_file_name = temp_folder + ".zip"
+
+        if isinstance(zip_file, FieldStorage) or isinstance(zip_file, Part):
+            if not zip_file.file:
+                #TODO: proper exceptions
+                raise Exception("Please select the archive that contains a simulator configuration.")
+
+            with open(uq_file_name, 'wb') as file_obj:
+                self.files_helper.copy_file(zip_file.file, file_obj)
+        else:
+            shutil.copy2(zip_file, uq_file_name)
+
+        try:
+            self.files_helper.unpack_zip(uq_file_name, temp_folder)
+            return temp_folder
+        except FileStructureException as excep:
+            self.logger.exception(excep)
+            raise Exception("Bad ZIP archive provided. A simulator configuration is expected")

--- a/framework_tvb/tvb/core/services/import_service.py
+++ b/framework_tvb/tvb/core/services/import_service.py
@@ -51,7 +51,7 @@ from tvb.core.entities.model.model_project import Project
 from tvb.core.entities.model.model_burst import BurstConfiguration
 from tvb.core.entities.storage import dao, transactional
 from tvb.core.entities.model.model_burst import BURST_INFO_FILE, BURSTS_DICT_KEY, DT_BURST_MAP
-from tvb.core.services.exceptions import ProjectImportException
+from tvb.core.services.exceptions import ProjectImportException, ServicesBaseException
 from tvb.core.services.flow_service import FlowService
 from tvb.core.project_versions.project_update_manager import ProjectUpdateManager
 from tvb.core.entities.file.xml_metadata_handlers import XMLReader
@@ -483,15 +483,14 @@ class ImportService(object):
         burst_entity = BurstConfiguration(project_id)
         return burst_entity
 
-    def import_simulator_configuration_zip(self, zip_file, project_id):
+    def import_simulator_configuration_zip(self, zip_file):
         # Now compute the name of the folder where to explode uploaded ZIP file
         temp_folder = self._compute_unpack_path()
         uq_file_name = temp_folder + ".zip"
 
         if isinstance(zip_file, FieldStorage) or isinstance(zip_file, Part):
             if not zip_file.file:
-                #TODO: proper exceptions
-                raise Exception("Please select the archive that contains a simulator configuration.")
+                raise ServicesBaseException("Could not process the given ZIP file...")
 
             with open(uq_file_name, 'wb') as file_obj:
                 self.files_helper.copy_file(zip_file.file, file_obj)
@@ -502,5 +501,4 @@ class ImportService(object):
             self.files_helper.unpack_zip(uq_file_name, temp_folder)
             return temp_folder
         except FileStructureException as excep:
-            self.logger.exception(excep)
-            raise Exception("Bad ZIP archive provided. A simulator configuration is expected")
+            raise ServicesBaseException("Could not process the given ZIP file..." + str(excep))

--- a/framework_tvb/tvb/core/services/simulator_service.py
+++ b/framework_tvb/tvb/core/services/simulator_service.py
@@ -38,9 +38,9 @@ import os
 import shutil
 import uuid
 import numpy
-from tvb.adapters.datatypes.h5.burst_configuration_h5 import BurstConfigurationH5
 from tvb.basic.logger.builder import get_logger
 from tvb.core.entities.file.files_helper import FilesHelper
+from tvb.core.entities.file.simulator.burst_configuration_h5 import BurstConfigurationH5
 from tvb.core.entities.file.simulator.simulator_h5 import SimulatorH5
 from tvb.core.entities.model.model_datatype import DataTypeGroup
 from tvb.core.entities.model.model_operation import Operation
@@ -102,7 +102,7 @@ class SimulatorService(object):
             burst_config = BurstService.update_simulation_fields(burst_config.id, operation.id, session_stored_simulator.gid)
             bc_path = h5.path_for(storage_path, BurstConfigurationH5, burst_config.gid)
             with BurstConfigurationH5(bc_path) as bc_h5:
-                bc_h5.store_index(burst_config)
+                bc_h5.store(burst_config)
 
             wf_errs = 0
             try:
@@ -201,7 +201,7 @@ class SimulatorService(object):
             burst_config = BurstService.update_simulation_fields(burst_config.id, first_operation.id, first_simulator.gid)
             bc_path = h5.path_for(storage_path, BurstConfigurationH5, burst_config.gid)
             with BurstConfigurationH5(bc_path) as bc_h5:
-                bc_h5.store_index(burst_config)
+                bc_h5.store(burst_config)
             datatype_group = DataTypeGroup(operation_group, operation_id=first_operation.id,
                                            fk_parent_burst=burst_config.id,
                                            state=json.loads(first_operation.meta_data)[DataTypeMetaData.KEY_STATE])

--- a/framework_tvb/tvb/core/services/simulator_service.py
+++ b/framework_tvb/tvb/core/services/simulator_service.py
@@ -53,10 +53,6 @@ from tvb.core.services.simulator_serializer import SimulatorSerializer
 
 
 class SimulatorService(object):
-    MAX_BURSTS_DISPLAYED = 50
-    LAUNCH_NEW = 'new'
-    LAUNCH_BRANCH = 'branch'
-
     def __init__(self):
         self.logger = get_logger(self.__class__.__module__)
         self.operation_service = OperationService()

--- a/framework_tvb/tvb/interfaces/web/controllers/project/project_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/project/project_controller.py
@@ -625,7 +625,8 @@ class ProjectController(BaseController):
             self.set_project_structure_grouping(first_level, second_level)
 
         selected_filter = StaticFiltersFactory.build_datatype_filters(single_filter=visibility_filter)
-
+        if project_id == 'undefined':
+            project_id = common.get_current_project().id
         project = self.project_service.find_project(project_id)
         json_structure = self.project_service.get_project_structure(project, selected_filter,
                                                                     first_level, second_level, filter_value)

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
@@ -31,8 +31,8 @@ import os
 import threading
 from cherrypy.lib.static import serve_file
 from tvb.adapters.datatypes.db.simulation_history import SimulationHistoryIndex
-from tvb.adapters.datatypes.h5.burst_configuration_h5 import BurstConfigurationH5
 from tvb.adapters.exporters.export_manager import ExportManager
+from tvb.core.entities.file.simulator.burst_configuration_h5 import BurstConfigurationH5
 from tvb.core.entities.file.simulator.simulator_h5 import SimulatorH5
 from tvb.core.neocom.h5 import DirLoader
 from tvb.core.services.import_service import ImportService
@@ -1145,7 +1145,7 @@ class SimulatorController(BurstBaseController):
                 bc_h5_filename = DirLoader(simulator_folder, None).find_file_for_has_traits_type(BurstConfiguration)
                 burst_config = BurstConfiguration(project.id)
                 with BurstConfigurationH5(os.path.join(simulator_folder, bc_h5_filename)) as bc_h5:
-                    bc_h5.load_into_index(burst_config)
+                    bc_h5.load_into(burst_config)
 
                 common.add2session(common.KEY_BURST_CONFIG, burst_config)
                 common.add2session(common.KEY_SIMULATOR_CONFIG, simulator)

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
@@ -1117,19 +1117,8 @@ class SimulatorController(BurstBaseController):
         try:
             upload_param = "uploadedfile"
             if upload_param in data and data[upload_param]:
-                import_service = ImportService()
-                simulator_folder = import_service.import_simulator_configuration_zip(data[upload_param])
-
                 project = common.get_current_project()
-                simulator_h5_filename = DirLoader(simulator_folder, None).find_file_for_has_traits_type(Simulator)
-                with SimulatorH5(os.path.join(simulator_folder, simulator_h5_filename)) as sim_h5:
-                    simulator_gid = sim_h5.gid.load()
-                simulator = SimulatorSerializer.deserialize_simulator(simulator_gid, simulator_folder)
-
-                bc_h5_filename = DirLoader(simulator_folder, None).find_file_for_has_traits_type(BurstConfiguration)
-                burst_config = BurstConfiguration(project.id)
-                with BurstConfigurationH5(os.path.join(simulator_folder, bc_h5_filename)) as bc_h5:
-                    bc_h5.load_into(burst_config)
+                simulator, burst_config = self.simulator_service.load_from_zip(data[upload_param], project)
 
                 common.add2session(common.KEY_BURST_CONFIG, burst_config)
                 common.add2session(common.KEY_SIMULATOR_CONFIG, simulator)

--- a/framework_tvb/tvb/interfaces/web/static/js/bursts.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/bursts.js
@@ -74,6 +74,7 @@ function resetToNewBurst() {
         success: function (response) {
             let simParamElem = $("#div-simulator-parameters");
             simParamElem.html(response);
+            displayBurstTree(undefined);
             displayMessage("Completely new configuration loaded!");
         },
         error: function () {
@@ -478,6 +479,7 @@ function loadBurstReadOnly(burst_id, first_wizzard_form_url) {
                     let simParamElem = $("#div-simulator-parameters");
                     simParamElem.html(response);
                     _renderAllSimulatorForms(first_wizzard_form_url, stop_at_url);
+                    displayBurstTree(burst_id);
                     displayMessage("The simulation configuration was loaded for you!");
                 },
                 error: function () {
@@ -759,4 +761,16 @@ function wizzard_submit(currentForm, success_function = null, div_id = 'div-simu
             }
         }
     })
+}
+
+function displayBurstTree(selectedBurstID) {
+    let filterValue = {'type': 'from_burst', 'value': selectedBurstID};
+    if (filterValue.value === undefined) {
+        filterValue = {'type': 'from_burst', 'value': "0"};
+    }
+    updateTree("#treeOverlay", null, JSON.stringify(filterValue));
+    $("#portlets-display").hide();
+    $("#portlets-configure").hide();
+    $("#portlet-param-config").hide();
+    $("#div-burst-tree").show();
 }

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/burst/burst_history.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/burst/burst_history.html
@@ -1,6 +1,6 @@
 <div>
     <h4>History</h4>
-    <a href="#" title="Import simulation from JSON " class="column-control action-big-upload" onclick="showOverlay('/burst/get_upload_overlay', true);">Import</a>
+    <a href="#" title="Import simulation from ZIP " class="column-control action-big-upload" onclick="showOverlay('/burst/get_upload_overlay', true);">Import</a>
     <a href="#" title="Prepare a new simulation " class="column-control action action-big-new" onclick="resetToNewBurst();">New</a>
 
     <ul class="burst-list" id="burst-history">
@@ -27,8 +27,8 @@
                             <p><button class="action action-copy" onclick="copyBurst({{ burst.id }}, '{{ first_fragment_url }}')" title="Create a copy of the current simulation configuration.">
                                 Copy</button></p>
                             <p><button class="action action-export" onclick="window.location='/burst/export/{{ burst.id }}'; return false;"
-                                        title="Export simulation JSON, for later import or use in command line">
-                                Export JSON</button></p>
+                                        title="Export simulation as ZIP, for later import or use in command line">
+                                Export ZIP</button></p>
 
                             <p class="burst-prop-processtime"><mark>Processing time : </mark><span>{{ burst.process_time }}</span></p>
                             {% if burst.datatypes_number %}

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/burst/main_burst.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/burst/main_burst.html
@@ -66,8 +66,9 @@
         	{% endfor %}
 
             <li class="{{ 'active' if '-1' == (burstConfig.selected_tab | string) else none }}">
+                {% set currentBurstID = burstConfig.id if burstConfig.id else undefined %}
                 <a href="#" id="tab-burst-tree"
-                   onclick="displayBurstTree(this, {{ selectedProject.id }});">Results</a>
+                   onclick="displayBurstTree({{ currentBurstID }});">Results</a>
             </li>
 		</ul>
 

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/burst/upload_burst_overlay.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/burst/upload_burst_overlay.html
@@ -1,4 +1,4 @@
-<form method="post" enctype="multipart/form-data" action="/burst/load_burst_from_json">
+<form method="post" enctype="multipart/form-data" action="/burst/load_simulator_configuration_from_zip">
     <section class="uploader upload-burst active">
         <fieldset class="toolbar-inline">
             <ul>
@@ -11,11 +11,11 @@
         <fieldset>
             <dl>
                 <dt class="field-mandatory">
-                    <label for="uploadedfile">Simulation JSON</label>
+                    <label for="uploadedfile">Simulation ZIP</label>
                 </dt>
                 <dd>
                     <p class="field-data">
-                        <input id="uploadedfile" type="file" tabindex='3' name='uploadedfile' class="inputField" accept=".json"/>
+                        <input id="uploadedfile" type="file" tabindex='3' name='uploadedfile' class="inputField" accept=".zip"/>
                     </p>
                 </dd>
             </dl>

--- a/framework_tvb/tvb/tests/framework/core/factory.py
+++ b/framework_tvb/tvb/tests/framework/core/factory.py
@@ -40,6 +40,7 @@ Project, User, Operation, basic imports (e.g. CFF).
 
 import os
 import random
+import uuid
 import tvb_data
 from cherrypy._cpreqbody import Part
 from cherrypy.lib.httputil import HeaderMap
@@ -48,6 +49,7 @@ from tvb.adapters.datatypes.db.region_mapping import RegionMappingIndex
 from tvb.adapters.uploaders.projection_matrix_importer import ProjectionMatrixImporterForm
 from tvb.adapters.uploaders.region_mapping_importer import RegionMappingImporterForm
 from tvb.core.entities.model.model_burst import BurstConfiguration
+from tvb.core.services.burst_service import BurstService
 from tvb.core.utils import hash_password
 from tvb.datatypes.surfaces import CorticalSurface
 from tvb.adapters.uploaders.gifti_surface_importer import GIFTISurfaceImporterForm
@@ -190,13 +192,18 @@ class TestFactory(object):
         return ABCAdapter.build_adapter(algorithm)
 
     @staticmethod
-    def store_burst(project_id, simulator_config=None):
+    def store_burst(project_id, operation=None):
         """
         Build and persist BurstConfiguration entity.
         """
         burst = BurstConfiguration(project_id)
-        if simulator_config is not None:
-            burst.simulator_configuration = simulator_config
+        if operation is not None:
+            burst.name = 'dummy_burst'
+            burst.status = BurstConfiguration.BURST_FINISHED
+            burst.start_time = datetime.datetime.now()
+            burst.fk_simulation_id = operation.id
+            burst.simulator_gid = uuid.uuid4().hex
+            BurstService().update_burst_configuration_h5(burst)
         return dao.store_entity(burst)
 
     @staticmethod

--- a/framework_tvb/tvb/tests/framework/core/factory.py
+++ b/framework_tvb/tvb/tests/framework/core/factory.py
@@ -201,6 +201,8 @@ class TestFactory(object):
             burst.name = 'dummy_burst'
             burst.status = BurstConfiguration.BURST_FINISHED
             burst.start_time = datetime.datetime.now()
+            burst.range1 = '["conduction_speed", {"lo": 50, "step": 1.0, "hi": 100.0}]'
+            burst.range2 = '["connectivity", null]'
             burst.fk_simulation_id = operation.id
             burst.simulator_gid = uuid.uuid4().hex
             BurstService().update_burst_configuration_h5(burst)

--- a/framework_tvb/tvb/tests/framework/core/services/burst_service_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/burst_service_test.py
@@ -129,6 +129,8 @@ class TestBurstService(BaseTestCase):
         assert first_burst.name == second_burst.name, "Names not equal for bursts."
         assert first_burst.project_id == second_burst.project_id, "Projects not equal for bursts."
         assert first_burst.status == second_burst.status, "Statuses not equal for bursts."
+        assert first_burst.range1 == second_burst.range1, "Statuses not equal for bursts."
+        assert first_burst.range2 == second_burst.range2, "Statuses not equal for bursts."
 
 
     def test_getavailablebursts_none(self):

--- a/framework_tvb/tvb/tests/framework/core/services/burst_service_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/burst_service_test.py
@@ -107,8 +107,7 @@ class TestBurstService(BaseTestCase):
         first_burst = TestFactory.store_burst(self.test_project.id)
         cloned_burst = first_burst.clone()
         self._compare_bursts(first_burst, cloned_burst)
-        assert first_burst.selected_tab == cloned_burst.selected_tab, "Selected tabs not equal for bursts."
-        assert len(first_burst.tabs) == len(cloned_burst.tabs), "Tabs not equal for bursts."
+        assert cloned_burst.name == first_burst.name, 'Cloned burst should have the same name'
         assert cloned_burst.id is None, 'id should be none for cloned entry.'
 
 
@@ -128,7 +127,7 @@ class TestBurstService(BaseTestCase):
         Compare that all important attributes are the same between two bursts. (name, project id and status)
         """
         assert first_burst.name == second_burst.name, "Names not equal for bursts."
-        assert first_burst.fk_project == second_burst.fk_project, "Projects not equal for bursts."
+        assert first_burst.project_id == second_burst.project_id, "Projects not equal for bursts."
         assert first_burst.status == second_burst.status, "Statuses not equal for bursts."
 
 
@@ -162,31 +161,15 @@ class TestBurstService(BaseTestCase):
                          "Incorrect bursts retrieved for project %s." % self.test_project
 
 
-    def test_rename_burst(self):
+    def test_rename_burst(self, operation_factory):
         """
         Test that renaming of a burst functions properly.
         """
-        burst_config = TestFactory.store_burst(self.test_project.id)
+        operation = operation_factory()
+        burst_config = TestFactory.store_burst(self.test_project.id, operation)
         self.burst_service.rename_burst(burst_config.id, "new_burst_name")
         loaded_burst = dao.get_burst_by_id(burst_config.id)
         assert loaded_burst.name == "new_burst_name", "Burst was not renamed properly."
-
-
-    def test_load_burst(self):
-        """ 
-        Test that the load burst works properly. NOTE: this method is also tested
-        in the actual burst launch tests. This is just basic test to verify that the simulator
-        interface is loaded properly.
-        """
-        burst_config = TestFactory.store_burst(self.test_project.id)
-        loaded_burst = self.burst_service.load_burst(burst_config.id)[0]
-        assert loaded_burst.simulator_configuration == {}, "No simulator configuration should have been loaded"
-        assert burst_config.fk_project == loaded_burst.fk_project, "Loaded burst different from original one."
-        burst_config = TestFactory.store_burst(self.test_project.id, simulator_config={"test": "test"})
-        loaded_burst, _ = self.burst_service.load_burst(burst_config.id)
-        assert loaded_burst.simulator_configuration == {"test": "test"}, "different burst loaded"
-        assert burst_config.fk_project == loaded_burst.fk_project, "Loaded burst different from original one."
-
 
     def test_remove_burst(self):
         """

--- a/framework_tvb/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
@@ -566,10 +566,9 @@ class TestSimulationController(BaseTransactionalControllerTest, helper.CPWebCase
         assert int(result[4][2:-4]) >= 0, "Running time should be greater than or equal to 0."
 
     def test_rename_burst(self):
-        burst_config = BurstConfiguration(self.test_project.id)
-        burst_config.name = 'Test Burst Configuration'
         new_name = "Test Burst Configuration 2"
-        dao.store_entity(burst_config)
+        operation = TestFactory.create_operation()
+        burst_config = TestFactory.store_burst(self.test_project.id, operation)
         burst = dao.get_bursts_for_project(self.test_project.id)
         self.sess_mock['burst_id'] = str(burst[0].id)
         self.sess_mock['burst_name'] = new_name
@@ -577,7 +576,7 @@ class TestSimulationController(BaseTransactionalControllerTest, helper.CPWebCase
         with patch('cherrypy.session', self.sess_mock, create=True):
             common.add2session(common.KEY_BURST_CONFIG, self.session_stored_simulator)
             common.add2session(common.KEY_BURST_CONFIG, burst_config)
-            result = self.simulator_controller.rename_burst(str(burst[0].id), new_name)
+            result = self.simulator_controller.rename_burst(burst[0].id, new_name)
 
         assert result == '{"success": "Simulation successfully renamed!"}', \
             "Some error happened at renaming, probably because of invalid new name."


### PR DESCRIPTION
I would prefer to merge this after PR#91 in order to ensure usage of ranges from BurstConfiguration at load time is correct.

It also brings adjustments to pse params handling and adds new DB columns to BurstConfiguration entity. Also, the display of right-side tree.