### PR TITLE
TVB-2666 Uniform column names in BurstConfiguration and *Index classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ TEST_OUTPUT/
 # other tools
 .mypy_cache/
 /framework_tvb/tvb/interfaces/web/static/help/
+/tvb_build/docker/step1/
+

--- a/framework_tvb/tvb/adapters/analyzers/cross_correlation_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/cross_correlation_adapter.py
@@ -191,7 +191,7 @@ class CrossCorrelateAdapter(ABCAsynchronous):
         cross_corr_h5.source.store(uuid.UUID(self.input_time_series_index.gid))
         cross_corr_h5.gid.store(uuid.UUID(cross_corr_index.gid))
 
-        cross_corr_index.source_gid = self.input_time_series_index.gid
+        cross_corr_index.fk_source_gid = self.input_time_series_index.gid
         cross_corr_index.labels_ordering = cross_corr_h5.labels_ordering.load()
         cross_corr_index.type = type(cross_corr_index).__name__
         cross_corr_index.array_data_min = ts_array_metadata.min
@@ -398,7 +398,7 @@ class PearsonCorrelationCoefficientAdapter(ABCAsynchronous):
             ts_array_metadata = corr_coef_h5.array_data.get_cached_metadata()
             corr_coef_index.ndim = len(corr_coef_h5.array_data.shape)
 
-        corr_coef_index.source_gid = self.input_time_series_index.gid
+        corr_coef_index.fk_source_gid = self.input_time_series_index.gid
         corr_coef_index.subtype = type(corr_coef_index).__name__
         corr_coef_index.labels_ordering = json.dumps(labels_ordering)
         corr_coef_index.array_data_min = ts_array_metadata.min

--- a/framework_tvb/tvb/adapters/analyzers/fcd_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/fcd_adapter.py
@@ -209,7 +209,7 @@ class FunctionalConnectivityDynamicsAdapter(ABCAsynchronous):
 
     @staticmethod
     def _populate_fcd_index(fcd_index, source_gid, fcd_data, metadata):
-        fcd_index.source_gid = source_gid
+        fcd_index.fk_source_gid = source_gid
         fcd_index.labels_ordering = json.dumps(Fcd.labels_ordering.default)
         fcd_index.ndim = fcd_data.ndim
         fcd_index.array_data_min = metadata.min
@@ -271,7 +271,7 @@ class FunctionalConnectivityDynamicsAdapter(ABCAsynchronous):
                         cm_data = eigvect_dict[mode][var][ep][eig]
                         cm_index = ConnectivityMeasureIndex()
                         cm_index.type = ConnectivityMeasure.__name__
-                        cm_index.connectivity_gid = connectivity_gid.hex
+                        cm_index.fk_connectivity_gid = connectivity_gid.hex
                         cm_index.title = "Epoch # %d, \n eigenvalue = %s,\n variable = %s,\n " \
                                          "mode = %s." % (ep, eigval_dict[mode][var][ep][eig], var, mode)
 

--- a/framework_tvb/tvb/adapters/analyzers/fmri_balloon_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/fmri_balloon_adapter.py
@@ -238,9 +238,9 @@ class BalloonModelAdapter(ABCAsynchronous):
         result_index.data_length_1d, result_index.data_length_2d, \
         result_index.data_length_3d, result_index.data_length_4d = prepare_array_shape_meta(result_signal_shape)
 
-        result_index.connectivity_gid = self.input_time_series_index.connectivity_gid
-        result_index.region_mapping_gid = self.input_time_series_index.region_mapping_gid
-        result_index.region_mapping_volume_gid = self.input_time_series_index.region_mapping_volume_gid
+        result_index.fk_connectivity_gid = self.input_time_series_index.fk_connectivity_gid
+        result_index.fk_region_mapping_gid = self.input_time_series_index.fk_region_mapping_gid
+        result_index.fk_region_mapping_volume_gid = self.input_time_series_index.fk_region_mapping_volume_gid
 
         result_index.sample_period = self.input_time_series_index.sample_period
         result_index.sample_period_unit = self.input_time_series_index.sample_period_unit

--- a/framework_tvb/tvb/adapters/analyzers/fourier_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/fourier_adapter.py
@@ -179,7 +179,7 @@ class FourierAdapter(abcadapter.ABCAsynchronous):
 
         """
         fft_index = FourierSpectrumIndex()
-        fft_index.source_gid = view_model.time_series.hex
+        fft_index.fk_source_gid = view_model.time_series.hex
 
         block_size = int(math.floor(self.input_shape[2] / self.memory_factor))
         blocks = int(math.ceil(self.input_shape[2] / block_size))

--- a/framework_tvb/tvb/adapters/analyzers/ica_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/ica_adapter.py
@@ -148,7 +148,7 @@ class ICAAdapter(ABCAsynchronous):
         """
         # --------- Prepare a IndependentComponents object for result ----------##
         ica_index = IndependentComponentsIndex()
-        ica_index.source_gid = view_model.time_series.hex
+        ica_index.fk_source_gid = view_model.time_series.hex
 
         time_series_h5 = h5.h5_file_for_index(self.input_time_series_index)
 

--- a/framework_tvb/tvb/adapters/analyzers/metrics_group_timeseries.py
+++ b/framework_tvb/tvb/adapters/analyzers/metrics_group_timeseries.py
@@ -202,7 +202,7 @@ class TimeseriesMetricsAdapter(ABCAsynchronous):
                 metrics_results[algorithm_name] = unstored_result
 
         result = DatatypeMeasureIndex()
-        result.source_gid = self.input_time_series_index.gid
+        result.fk_source_gid = self.input_time_series_index.gid
         result.metrics = json.dumps(metrics_results)
 
         result_path = h5.path_for(self.storage_path, DatatypeMeasureH5, result.gid)

--- a/framework_tvb/tvb/adapters/analyzers/node_coherence_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/node_coherence_adapter.py
@@ -174,7 +174,7 @@ class NodeCoherenceAdapter(ABCAsynchronous):
         coherence_spectrum_index.ndim = len(coherence_h5.array_data.shape)
         time_series_h5.close()
 
-        coherence_spectrum_index.source_gid = self.input_time_series_index.gid
+        coherence_spectrum_index.fk_source_gid = self.input_time_series_index.gid
         coherence_spectrum_index.nfft = partial_coh.nfft
         coherence_spectrum_index.frequencies = partial_coh.frequency
 

--- a/framework_tvb/tvb/adapters/analyzers/node_complex_coherence_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/node_complex_coherence_adapter.py
@@ -185,7 +185,7 @@ class NodeComplexCoherenceAdapter(ABCAsynchronous):
         spectra_h5.close()
         time_series_h5.close()
 
-        complex_coherence_spectrum_index.source_gid = self.input_time_series_index.gid
+        complex_coherence_spectrum_index.fk_source_gid = self.input_time_series_index.gid
         complex_coherence_spectrum_index.epoch_length = partial_result.epoch_length
         complex_coherence_spectrum_index.segment_length = partial_result.segment_length
         complex_coherence_spectrum_index.windowing_function = partial_result.windowing_function

--- a/framework_tvb/tvb/adapters/analyzers/node_covariance_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/node_covariance_adapter.py
@@ -162,7 +162,7 @@ class NodeCovarianceAdapter(ABCAsynchronous):
                     covariance_h5.write_data_slice(partial_cov.array_data)
             ts_array_metadata = covariance_h5.array_data.get_cached_metadata()
 
-        covariance_index.source_gid = self.input_time_series_index.gid
+        covariance_index.fk_source_gid = self.input_time_series_index.gid
         covariance_index.subtype = type(covariance_index).__name__
         covariance_index.array_data_min = ts_array_metadata.min
         covariance_index.array_data_max = ts_array_metadata.max

--- a/framework_tvb/tvb/adapters/analyzers/pca_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/pca_adapter.py
@@ -143,7 +143,7 @@ class PCAAdapter(ABCAsynchronous):
         """
         # --------- Prepare a PrincipalComponents object for result ----------##
         principal_components_index = PrincipalComponentsIndex()
-        principal_components_index.source_gid = view_model.time_series.hex
+        principal_components_index.fk_source_gid = view_model.time_series.hex
 
         time_series_h5 = h5.h5_file_for_index(self.input_time_series_index)
 

--- a/framework_tvb/tvb/adapters/analyzers/wavelet_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/wavelet_adapter.py
@@ -224,7 +224,7 @@ class ContinuousWaveletTransformAdapter(ABCAsynchronous):
         wavelet_h5.close()
         time_series_h5.close()
 
-        wavelet_index.source_gid = self.input_time_series_index.gid
+        wavelet_index.fk_source_gid = self.input_time_series_index.gid
         wavelet_index.mother = self.algorithm.mother
         wavelet_index.normalisation = self.algorithm.normalisation
         wavelet_index.q_ratio = self.algorithm.q_ratio

--- a/framework_tvb/tvb/adapters/creators/connectivity_creator.py
+++ b/framework_tvb/tvb/adapters/creators/connectivity_creator.py
@@ -134,10 +134,10 @@ class ConnectivityCreator(ABCAsynchronous):
     def _store_related_region_mappings(self, original_conn_gid, new_connectivity_ht):
         result = []
 
-        linked_region_mappings = dao.get_generic_entity(RegionMappingIndex, original_conn_gid, 'connectivity_gid')
+        linked_region_mappings = dao.get_generic_entity(RegionMappingIndex, original_conn_gid, 'fk_connectivity_gid')
         for mapping in linked_region_mappings:
             original_rm = h5.load_from_index(mapping)
-            surface_idx = dao.get_generic_entity(SurfaceIndex, mapping.surface_gid, 'gid')[0]
+            surface_idx = dao.get_generic_entity(SurfaceIndex, mapping.fk_surface_gid, 'gid')[0]
             surface = h5.load_from_index(surface_idx)
 
             new_rm = RegionMapping()

--- a/framework_tvb/tvb/adapters/datatypes/db/annotation.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/annotation.py
@@ -104,9 +104,9 @@ class ConnectivityAnnotationsIndex(DataType):
     """
     id = Column(Integer, ForeignKey(DataType.id), primary_key=True)
 
-    connectivity_gid = Column(String(32), ForeignKey(ConnectivityIndex.gid), nullable=False)
-    connectivity = relationship(ConnectivityIndex, foreign_keys=connectivity_gid,
-                                primaryjoin=ConnectivityIndex.gid == connectivity_gid, cascade='none')
+    fk_connectivity_gid = Column(String(32), ForeignKey(ConnectivityIndex.gid), nullable=False)
+    connectivity = relationship(ConnectivityIndex, foreign_keys=fk_connectivity_gid,
+                                primaryjoin=ConnectivityIndex.gid == fk_connectivity_gid, cascade='none')
 
     annotations_length = Column(Integer)
 
@@ -114,4 +114,4 @@ class ConnectivityAnnotationsIndex(DataType):
         # type: (ConnectivityAnnotations)  -> None
         super(ConnectivityAnnotationsIndex, self).fill_from_has_traits(datatype)
         self.annotations_length = datatype.region_annotations.shape[0]
-        self.connectivity_gid = datatype.connectivity.gid.hex
+        self.fk_connectivity_gid = datatype.connectivity.gid.hex

--- a/framework_tvb/tvb/adapters/datatypes/db/fcd.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/fcd.py
@@ -42,8 +42,8 @@ class FcdIndex(DataTypeMatrix):
     array_data_min = Column(Float)
     array_data_max = Column(Float)
     array_data_mean = Column(Float)
-    source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=not Fcd.source.required)
-    source = relationship(TimeSeriesIndex, foreign_keys=source_gid, primaryjoin=TimeSeriesIndex.gid == source_gid)
+    fk_source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=not Fcd.source.required)
+    source = relationship(TimeSeriesIndex, foreign_keys=fk_source_gid, primaryjoin=TimeSeriesIndex.gid == fk_source_gid)
 
     labels_ordering = Column(String)
 
@@ -52,4 +52,4 @@ class FcdIndex(DataTypeMatrix):
         super(FcdIndex, self).fill_from_has_traits(datatype)
         self.array_data_min, self.array_data_max, self.array_data_mean = from_ndarray(datatype.array_data)
         self.labels_ordering = json.dumps(datatype.labels_ordering)
-        self.source_gid = datatype.source.gid.hex
+        self.fk_source_gid = datatype.source.gid.hex

--- a/framework_tvb/tvb/adapters/datatypes/db/graph.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/graph.py
@@ -45,8 +45,8 @@ class CovarianceIndex(DataTypeMatrix):
     array_data_max = Column(Float)
     array_data_mean = Column(Float)
 
-    source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=not Covariance.source.required)
-    source = relationship(TimeSeriesIndex, foreign_keys=source_gid, primaryjoin=TimeSeriesIndex.gid == source_gid)
+    fk_source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=not Covariance.source.required)
+    source = relationship(TimeSeriesIndex, foreign_keys=fk_source_gid, primaryjoin=TimeSeriesIndex.gid == fk_source_gid)
 
     subtype = Column(String)
 
@@ -55,7 +55,7 @@ class CovarianceIndex(DataTypeMatrix):
         super(CovarianceIndex, self).fill_from_has_traits(datatype)
         self.subtype = datatype.__class__.__name__
         self.array_data_min, self.array_data_max, self.array_data_mean = from_ndarray(datatype.array_data)
-        self.source_gid = datatype.source.gid.hex
+        self.fk_source_gid = datatype.source.gid.hex
 
 
 class CorrelationCoefficientsIndex(DataTypeMatrix):
@@ -65,9 +65,9 @@ class CorrelationCoefficientsIndex(DataTypeMatrix):
     array_data_max = Column(Float)
     array_data_mean = Column(Float)
 
-    source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid),
-                        nullable=not CorrelationCoefficients.source.required)
-    source = relationship(TimeSeriesIndex, foreign_keys=source_gid, primaryjoin=TimeSeriesIndex.gid == source_gid)
+    fk_source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid),
+                           nullable=not CorrelationCoefficients.source.required)
+    source = relationship(TimeSeriesIndex, foreign_keys=fk_source_gid, primaryjoin=TimeSeriesIndex.gid == fk_source_gid)
 
     subtype = Column(String)
 
@@ -79,7 +79,7 @@ class CorrelationCoefficientsIndex(DataTypeMatrix):
         self.subtype = datatype.__class__.__name__
         self.labels_ordering = datatype.labels_ordering
         self.array_data_min, self.array_data_max, self.array_data_mean = from_ndarray(datatype.array_data)
-        self.source_gid = datatype.source.gid.hex
+        self.fk_source_gid = datatype.source.gid.hex
 
 
 class ConnectivityMeasureIndex(DataTypeMatrix):
@@ -87,10 +87,10 @@ class ConnectivityMeasureIndex(DataTypeMatrix):
 
     subtype = Column(String)
 
-    connectivity_gid = Column(String(32), ForeignKey(ConnectivityIndex.gid),
-                              nullable=ConnectivityMeasure.connectivity.required)
-    connectivity = relationship(ConnectivityIndex, foreign_keys=connectivity_gid,
-                                primaryjoin=ConnectivityIndex.gid == connectivity_gid)
+    fk_connectivity_gid = Column(String(32), ForeignKey(ConnectivityIndex.gid),
+                                 nullable=ConnectivityMeasure.connectivity.required)
+    connectivity = relationship(ConnectivityIndex, foreign_keys=fk_connectivity_gid,
+                                primaryjoin=ConnectivityIndex.gid == fk_connectivity_gid)
 
     array_data_min = Column(Float)
     array_data_max = Column(Float)
@@ -103,6 +103,6 @@ class ConnectivityMeasureIndex(DataTypeMatrix):
         super(ConnectivityMeasureIndex, self).fill_from_has_traits(datatype)
         self.subtype = datatype.__class__.__name__
         self.array_data_min, self.array_data_max, self.array_data_mean = from_ndarray(datatype.array_data)
-        self.connectivity_gid = datatype.connectivity.gid.hex
+        self.fk_connectivity_gid = datatype.connectivity.gid.hex
         self.shape = json.dumps(datatype.array_data.shape)
         self.ndim = len(datatype.array_data.shape)

--- a/framework_tvb/tvb/adapters/datatypes/db/local_connectivity.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/local_connectivity.py
@@ -39,8 +39,8 @@ from tvb.core.neotraits.db import from_ndarray
 class LocalConnectivityIndex(DataType):
     id = Column(Integer, ForeignKey(DataType.id), primary_key=True)
 
-    surface_gid = Column(String(32), ForeignKey(SurfaceIndex.gid), nullable=not LocalConnectivity.surface.required)
-    surface = relationship(SurfaceIndex, foreign_keys=surface_gid, primaryjoin=SurfaceIndex.gid == surface_gid)
+    fk_surface_gid = Column(String(32), ForeignKey(SurfaceIndex.gid), nullable=not LocalConnectivity.surface.required)
+    surface = relationship(SurfaceIndex, foreign_keys=fk_surface_gid, primaryjoin=SurfaceIndex.gid == fk_surface_gid)
 
     matrix_non_zero_min = Column(Float)
     matrix_non_zero_max = Column(Float)
@@ -51,4 +51,4 @@ class LocalConnectivityIndex(DataType):
         super(LocalConnectivityIndex, self).fill_from_has_traits(datatype)
         I, J, V = scipy.sparse.find(datatype.matrix)
         self.matrix_non_zero_min, self.matrix_non_zero_max, self.matrix_non_zero_mean = from_ndarray(V)
-        self.surface_gid = datatype.surface.gid.hex
+        self.fk_surface_gid = datatype.surface.gid.hex

--- a/framework_tvb/tvb/adapters/datatypes/db/mapped_value.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/mapped_value.py
@@ -63,8 +63,8 @@ class DatatypeMeasureIndex(DataType):
     # Actual measure (dictionary Algorithm: single Value) serialized
     metrics = Column(String)
     # DataType for which the measure was computed.
-    source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=False)
-    source = relationship(TimeSeriesIndex, foreign_keys=source_gid, primaryjoin=TimeSeriesIndex.gid == source_gid)
+    fk_source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=False)
+    source = relationship(TimeSeriesIndex, foreign_keys=fk_source_gid, primaryjoin=TimeSeriesIndex.gid == fk_source_gid)
 
     @property
     def display_name(self):

--- a/framework_tvb/tvb/adapters/datatypes/db/mode_decompositions.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/mode_decompositions.py
@@ -37,8 +37,8 @@ from tvb.core.entities.model.model_datatype import DataType
 class PrincipalComponentsIndex(DataType):
     id = Column(Integer, ForeignKey(DataType.id), primary_key=True)
 
-    source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=not PrincipalComponents.source.required)
-    source = relationship(TimeSeriesIndex, foreign_keys=source_gid, primaryjoin=TimeSeriesIndex.gid == source_gid)
+    fk_source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=not PrincipalComponents.source.required)
+    source = relationship(TimeSeriesIndex, foreign_keys=fk_source_gid, primaryjoin=TimeSeriesIndex.gid == fk_source_gid)
 
     subtype = Column(String)
 
@@ -46,14 +46,14 @@ class PrincipalComponentsIndex(DataType):
         # type: (PrincipalComponents)  -> None
         super(PrincipalComponentsIndex, self).fill_from_has_traits(datatype)
         self.subtype = datatype.__class__.__name__
-        self.source_gid = datatype.source.gid
+        self.fk_source_gid = datatype.source.gid
 
 
 class IndependentComponentsIndex(DataType):
     id = Column(Integer, ForeignKey(DataType.id), primary_key=True)
 
-    source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=not PrincipalComponents.source.required)
-    source = relationship(TimeSeriesIndex, foreign_keys=source_gid, primaryjoin=TimeSeriesIndex.gid == source_gid)
+    fk_source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=not PrincipalComponents.source.required)
+    source = relationship(TimeSeriesIndex, foreign_keys=fk_source_gid, primaryjoin=TimeSeriesIndex.gid == fk_source_gid)
 
     subtype = Column(String)
 
@@ -61,4 +61,4 @@ class IndependentComponentsIndex(DataType):
         # type: (IndependentComponents)  -> None
         super(IndependentComponentsIndex, self).fill_from_has_traits(datatype)
         self.subtype = datatype.__class__.__name__
-        self.source_gid = datatype.source.gid.hex
+        self.fk_source_gid = datatype.source.gid.hex

--- a/framework_tvb/tvb/adapters/datatypes/db/patterns.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/patterns.py
@@ -44,10 +44,10 @@ class StimuliRegionIndex(DataType):
     temporal_equation = Column(String, nullable=False)
     temporal_parameters = Column(String)
 
-    connectivity_gid = Column(String(32), ForeignKey(ConnectivityIndex.gid),
-                              nullable=not StimuliRegion.connectivity.required)
-    connectivity = relationship(ConnectivityIndex, foreign_keys=connectivity_gid,
-                                primaryjoin=ConnectivityIndex.gid == connectivity_gid)
+    fk_connectivity_gid = Column(String(32), ForeignKey(ConnectivityIndex.gid),
+                                 nullable=not StimuliRegion.connectivity.required)
+    connectivity = relationship(ConnectivityIndex, foreign_keys=fk_connectivity_gid,
+                                primaryjoin=ConnectivityIndex.gid == fk_connectivity_gid)
 
     def fill_from_has_traits(self, datatype):
         # type: (StimuliRegion)  -> None
@@ -56,7 +56,7 @@ class StimuliRegionIndex(DataType):
         self.spatial_parameters = json.dumps(datatype.spatial.parameters)
         self.temporal_equation = datatype.temporal.__class__.__name__
         self.temporal_parameters = json.dumps(datatype.temporal.parameters)
-        self.connectivity_gid = datatype.connectivity.gid.hex
+        self.fk_connectivity_gid = datatype.connectivity.gid.hex
 
 
 class StimuliSurfaceIndex(DataType):
@@ -67,8 +67,8 @@ class StimuliSurfaceIndex(DataType):
     temporal_equation = Column(String, nullable=False)
     temporal_parameters = Column(String)
 
-    surface_gid = Column(String(32), ForeignKey(SurfaceIndex.gid), nullable=not StimuliSurface.surface.required)
-    surface = relationship(SurfaceIndex, foreign_keys=surface_gid, primaryjoin=SurfaceIndex.gid == surface_gid)
+    fk_surface_gid = Column(String(32), ForeignKey(SurfaceIndex.gid), nullable=not StimuliSurface.surface.required)
+    surface = relationship(SurfaceIndex, foreign_keys=fk_surface_gid, primaryjoin=SurfaceIndex.gid == fk_surface_gid)
 
     def fill_from_has_traits(self, datatype):
         # type: (StimuliSurface)  -> None
@@ -77,4 +77,4 @@ class StimuliSurfaceIndex(DataType):
         self.spatial_parameters = json.dumps(datatype.spatial.parameters)
         self.temporal_equation = datatype.temporal.__class__.__name__
         self.temporal_parameters = json.dumps(datatype.temporal.parameters)
-        self.surface_gid = datatype.surface.gid.hex
+        self.fk_surface_gid = datatype.surface.gid.hex

--- a/framework_tvb/tvb/adapters/datatypes/db/projections.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/projections.py
@@ -40,25 +40,25 @@ class ProjectionMatrixIndex(DataType):
 
     projection_type = Column(String, nullable=False)
 
-    brain_skull_gid = Column(String(32), ForeignKey(SurfaceIndex.gid),
-                             nullable=not ProjectionMatrix.brain_skull.required)
-    brain_skull = relationship(SurfaceIndex, foreign_keys=brain_skull_gid,
-                               primaryjoin=SurfaceIndex.gid == brain_skull_gid, cascade='none')
+    fk_brain_skull_gid = Column(String(32), ForeignKey(SurfaceIndex.gid),
+                                nullable=not ProjectionMatrix.brain_skull.required)
+    brain_skull = relationship(SurfaceIndex, foreign_keys=fk_brain_skull_gid,
+                               primaryjoin=SurfaceIndex.gid == fk_brain_skull_gid, cascade='none')
 
-    skull_skin_gid = Column(String(32), ForeignKey(SurfaceIndex.gid), nullable=not ProjectionMatrix.skull_skin.required)
-    skull_skin = relationship(SurfaceIndex, foreign_keys=skull_skin_gid, primaryjoin=SurfaceIndex.gid == skull_skin_gid,
+    fk_skull_skin_gid = Column(String(32), ForeignKey(SurfaceIndex.gid), nullable=not ProjectionMatrix.skull_skin.required)
+    skull_skin = relationship(SurfaceIndex, foreign_keys=fk_skull_skin_gid, primaryjoin=SurfaceIndex.gid == fk_skull_skin_gid,
                               cascade='none')
 
-    skin_air_gid = Column(String(32), ForeignKey(SurfaceIndex.gid), nullable=not ProjectionMatrix.skin_air.required)
-    skin_air = relationship(SurfaceIndex, foreign_keys=skin_air_gid, primaryjoin=SurfaceIndex.gid == skin_air_gid,
+    fk_skin_air_gid = Column(String(32), ForeignKey(SurfaceIndex.gid), nullable=not ProjectionMatrix.skin_air.required)
+    skin_air = relationship(SurfaceIndex, foreign_keys=fk_skin_air_gid, primaryjoin=SurfaceIndex.gid == fk_skin_air_gid,
                             cascade='none')
 
-    source_gid = Column(String(32), ForeignKey(SurfaceIndex.gid), nullable=not ProjectionMatrix.sources.required)
-    source = relationship(SurfaceIndex, foreign_keys=source_gid, primaryjoin=SurfaceIndex.gid == source_gid,
+    fk_source_gid = Column(String(32), ForeignKey(SurfaceIndex.gid), nullable=not ProjectionMatrix.sources.required)
+    source = relationship(SurfaceIndex, foreign_keys=fk_source_gid, primaryjoin=SurfaceIndex.gid == fk_source_gid,
                           cascade='none')
 
-    sensors_gid = Column(String(32), ForeignKey(SensorsIndex.gid), nullable=not ProjectionMatrix.sensors.required)
-    sensors = relationship(SensorsIndex, foreign_keys=sensors_gid, primaryjoin=SensorsIndex.gid == sensors_gid,
+    fk_sensors_gid = Column(String(32), ForeignKey(SensorsIndex.gid), nullable=not ProjectionMatrix.sensors.required)
+    sensors = relationship(SensorsIndex, foreign_keys=fk_sensors_gid, primaryjoin=SensorsIndex.gid == fk_sensors_gid,
                            cascade='none')
 
     def fill_from_has_traits(self, datatype):
@@ -66,13 +66,13 @@ class ProjectionMatrixIndex(DataType):
         super(ProjectionMatrixIndex, self).fill_from_has_traits(datatype)
         self.projection_type = datatype.projection_type
         if datatype.brain_skull is not None:
-            self.brain_skull_gid = datatype.brain_skull.gid.hex
+            self.fk_brain_skull_gid = datatype.brain_skull.gid.hex
         if datatype.skull_skin is not None:
-            self.skull_skin_gid = datatype.skull_skin.gid.hex
+            self.fk_skull_skin_gid = datatype.skull_skin.gid.hex
         if datatype.skin_air is not None:
-            self.skin_air_gid = datatype.skin_air.gid.hex
-        self.sensors_gid = datatype.sensors.gid.hex
-        self.source_gid = datatype.sources.gid.hex
+            self.fk_skin_air_gid = datatype.skin_air.gid.hex
+        self.fk_sensors_gid = datatype.sensors.gid.hex
+        self.fk_source_gid = datatype.sources.gid.hex
 
     @property
     def display_name(self):

--- a/framework_tvb/tvb/adapters/datatypes/db/region_mapping.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/region_mapping.py
@@ -44,21 +44,21 @@ class RegionMappingIndex(DataType):
     array_data_max = Column(Float)
     array_data_mean = Column(Float)
 
-    surface_gid = Column(String(32), ForeignKey(SurfaceIndex.gid), nullable=not RegionMapping.surface.required)
-    surface = relationship(SurfaceIndex, foreign_keys=surface_gid, primaryjoin=SurfaceIndex.gid == surface_gid,
+    fk_surface_gid = Column(String(32), ForeignKey(SurfaceIndex.gid), nullable=not RegionMapping.surface.required)
+    surface = relationship(SurfaceIndex, foreign_keys=fk_surface_gid, primaryjoin=SurfaceIndex.gid == fk_surface_gid,
                            cascade='none')
 
-    connectivity_gid = Column(String(32), ForeignKey(ConnectivityIndex.gid),
-                              nullable=not RegionMapping.connectivity.required)
-    connectivity = relationship(ConnectivityIndex, foreign_keys=connectivity_gid,
-                                primaryjoin=ConnectivityIndex.gid == connectivity_gid, cascade='none')
+    fk_connectivity_gid = Column(String(32), ForeignKey(ConnectivityIndex.gid),
+                                 nullable=not RegionMapping.connectivity.required)
+    connectivity = relationship(ConnectivityIndex, foreign_keys=fk_connectivity_gid,
+                                primaryjoin=ConnectivityIndex.gid == fk_connectivity_gid, cascade='none')
 
     def fill_from_has_traits(self, datatype):
         # type: (RegionMapping)  -> None
         super(RegionMappingIndex, self).fill_from_has_traits(datatype)
         self.array_data_min, self.array_data_max, self.array_data_mean = from_ndarray(datatype.array_data)
-        self.surface_gid = datatype.surface.gid.hex
-        self.connectivity_gid = datatype.connectivity.gid.hex
+        self.fk_surface_gid = datatype.surface.gid.hex
+        self.fk_connectivity_gid = datatype.connectivity.gid.hex
 
 
 class RegionVolumeMappingIndex(DataTypeMatrix):
@@ -68,18 +68,18 @@ class RegionVolumeMappingIndex(DataTypeMatrix):
     array_data_max = Column(Float)
     array_data_mean = Column(Float)
 
-    connectivity_gid = Column(String(32), ForeignKey(ConnectivityIndex.gid),
-                              nullable=not RegionVolumeMapping.connectivity.required)
-    connectivity = relationship(ConnectivityIndex, foreign_keys=connectivity_gid,
-                                primaryjoin=ConnectivityIndex.gid == connectivity_gid, cascade='none')
+    fk_connectivity_gid = Column(String(32), ForeignKey(ConnectivityIndex.gid),
+                                 nullable=not RegionVolumeMapping.connectivity.required)
+    connectivity = relationship(ConnectivityIndex, foreign_keys=fk_connectivity_gid,
+                                primaryjoin=ConnectivityIndex.gid == fk_connectivity_gid, cascade='none')
 
-    volume_gid = Column(String(32), ForeignKey(VolumeIndex.gid), nullable=not RegionVolumeMapping.volume.required)
-    volume = relationship(VolumeIndex, foreign_keys=volume_gid, primaryjoin=VolumeIndex.gid == volume_gid,
+    fk_volume_gid = Column(String(32), ForeignKey(VolumeIndex.gid), nullable=not RegionVolumeMapping.volume.required)
+    volume = relationship(VolumeIndex, foreign_keys=fk_volume_gid, primaryjoin=VolumeIndex.gid == fk_volume_gid,
                           cascade='none')
 
     def fill_from_has_traits(self, datatype):
         # type: (RegionVolumeMapping)  -> None
         super(RegionVolumeMappingIndex, self).fill_from_has_traits(datatype)
         self.array_data_min, self.array_data_max, self.array_data_mean = from_ndarray(datatype.array_data)
-        self.connectivity_gid = datatype.connectivity.gid.hex
-        self.volume_gid = datatype.volume.gid.hex
+        self.fk_connectivity_gid = datatype.connectivity.gid.hex
+        self.fk_volume_gid = datatype.volume.gid.hex

--- a/framework_tvb/tvb/adapters/datatypes/db/spectral.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/spectral.py
@@ -43,8 +43,8 @@ class FourierSpectrumIndex(DataTypeMatrix):
     frequency_step = Column(Float, nullable=False)
     max_frequency = Column(Float, nullable=False)
 
-    source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=not FourierSpectrum.source.required)
-    source = relationship(TimeSeriesIndex, foreign_keys=source_gid, primaryjoin=TimeSeriesIndex.gid == source_gid)
+    fk_source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=not FourierSpectrum.source.required)
+    source = relationship(TimeSeriesIndex, foreign_keys=fk_source_gid, primaryjoin=TimeSeriesIndex.gid == fk_source_gid)
 
     def fill_from_has_traits(self, datatype):
         # type: (FourierSpectrum)  -> None
@@ -53,14 +53,14 @@ class FourierSpectrumIndex(DataTypeMatrix):
         self.windowing_function = datatype.windowing_function
         self.frequency_step = datatype.frequency_step
         self.max_frequency = datatype.max_frequency
-        self.source_gid = datatype.source.gid.hex
+        self.fk_source_gid = datatype.source.gid.hex
 
 
 class WaveletCoefficientsIndex(DataTypeMatrix):
     id = Column(Integer, ForeignKey(DataTypeMatrix.id), primary_key=True)
 
-    source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=not WaveletCoefficients.source.required)
-    source = relationship(TimeSeriesIndex, foreign_keys=source_gid, primaryjoin=TimeSeriesIndex.gid == source_gid)
+    fk_source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=not WaveletCoefficients.source.required)
+    source = relationship(TimeSeriesIndex, foreign_keys=fk_source_gid, primaryjoin=TimeSeriesIndex.gid == fk_source_gid)
 
     mother = Column(String, nullable=False)
     normalisation = Column(String, nullable=False)
@@ -80,14 +80,14 @@ class WaveletCoefficientsIndex(DataTypeMatrix):
         self.sample_period = datatype.sample_period
         self.number_of_scales = datatype.frequencies.shape[0]
         self.frequencies_min, self.frequencies_max, _ = from_ndarray(datatype.frequency)
-        self.source_gid = datatype.source.gid.hex
+        self.fk_source_gid = datatype.source.gid.hex
 
 
 class CoherenceSpectrumIndex(DataTypeMatrix):
     id = Column(Integer, ForeignKey(DataTypeMatrix.id), primary_key=True)
 
-    source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=not CoherenceSpectrum.source.required)
-    source = relationship(TimeSeriesIndex, foreign_keys=source_gid, primaryjoin=TimeSeriesIndex.gid == source_gid)
+    fk_source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=not CoherenceSpectrum.source.required)
+    source = relationship(TimeSeriesIndex, foreign_keys=fk_source_gid, primaryjoin=TimeSeriesIndex.gid == fk_source_gid)
 
     nfft = Column(Integer, nullable=False)
     frequencies_min = Column(Float)
@@ -98,15 +98,15 @@ class CoherenceSpectrumIndex(DataTypeMatrix):
         super(CoherenceSpectrumIndex, self).fill_from_has_traits(datatype)
         self.nfft = datatype.nfft
         self.frequencies_min, self.frequencies_max, _ = from_ndarray(datatype.frequency)
-        self.source_gid = datatype.source.gid.hex
+        self.fk_source_gid = datatype.source.gid.hex
 
 
 class ComplexCoherenceSpectrumIndex(DataTypeMatrix):
     id = Column(Integer, ForeignKey(DataTypeMatrix.id), primary_key=True)
 
-    source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid),
-                        nullable=not ComplexCoherenceSpectrum.source.required)
-    source = relationship(TimeSeriesIndex, foreign_keys=source_gid, primaryjoin=TimeSeriesIndex.gid == source_gid)
+    fk_source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid),
+                           nullable=not ComplexCoherenceSpectrum.source.required)
+    source = relationship(TimeSeriesIndex, foreign_keys=fk_source_gid, primaryjoin=TimeSeriesIndex.gid == fk_source_gid)
 
     epoch_length = Column(Float, nullable=False)
     segment_length = Column(Float, nullable=False)
@@ -122,4 +122,4 @@ class ComplexCoherenceSpectrumIndex(DataTypeMatrix):
         self.windowing_function = datatype.windowing_function
         self.frequency_step = datatype.freq_step
         self.max_frequency = datatype.max_freq
-        self.source_gid = datatype.source.gid.hex
+        self.fk_source_gid = datatype.source.gid.hex

--- a/framework_tvb/tvb/adapters/datatypes/db/structural.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/structural.py
@@ -44,12 +44,12 @@ class StructuralMRIIndex(DataTypeMatrix):
 
     weighting = Column(String, nullable=False)
 
-    volume_gid = Column(String(32), ForeignKey(VolumeIndex.gid), nullable=not StructuralMRI.volume.required)
-    volume = relationship(VolumeIndex, foreign_keys=volume_gid, primaryjoin=VolumeIndex.gid == volume_gid)
+    fk_volume_gid = Column(String(32), ForeignKey(VolumeIndex.gid), nullable=not StructuralMRI.volume.required)
+    volume = relationship(VolumeIndex, foreign_keys=fk_volume_gid, primaryjoin=VolumeIndex.gid == fk_volume_gid)
 
     def fill_from_has_traits(self, datatype):
         # type: (StructuralMRI)  -> None
         super(StructuralMRIIndex, self).fill_from_has_traits(datatype)
         self.weighting = datatype.weighting
         self.array_data_min, self.array_data_max, self.array_data_mean = from_ndarray(datatype.array_data)
-        self.volume_gid = datatype.volume.gid.hex
+        self.fk_volume_gid = datatype.volume.gid.hex

--- a/framework_tvb/tvb/adapters/datatypes/db/temporal_correlations.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/temporal_correlations.py
@@ -43,8 +43,8 @@ class CrossCorrelationIndex(DataType):
     array_data_max = Column(Float)
     array_data_mean = Column(Float)
 
-    source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=not CrossCorrelation.source.required)
-    source = relationship(TimeSeriesIndex, foreign_keys=source_gid, primaryjoin=TimeSeriesIndex.gid == source_gid)
+    fk_source_gid = Column(String(32), ForeignKey(TimeSeriesIndex.gid), nullable=not CrossCorrelation.source.required)
+    source = relationship(TimeSeriesIndex, foreign_keys=fk_source_gid, primaryjoin=TimeSeriesIndex.gid == fk_source_gid)
 
     labels_ordering = Column(String, nullable=False)
     subtype = Column(String)
@@ -55,4 +55,4 @@ class CrossCorrelationIndex(DataType):
         self.array_data_min, self.array_data_max, self.array_data_mean = from_ndarray(datatype.array_data)
         self.labels_ordering = json.dumps(datatype.labels_ordering)
         self.subtype = datatype.__class__.__name__
-        self.source_gid = datatype.source.gid.hex
+        self.fk_source_gid = datatype.source.gid.hex

--- a/framework_tvb/tvb/adapters/datatypes/db/time_series.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/time_series.py
@@ -125,90 +125,90 @@ class TimeSeriesIndex(DataType):
 class TimeSeriesEEGIndex(TimeSeriesIndex):
     id = Column(Integer, ForeignKey(TimeSeriesIndex.id), primary_key=True)
 
-    sensors_gid = Column(String(32), ForeignKey(SensorsIndex.gid), nullable=not TimeSeriesEEG.sensors.required)
-    sensors = relationship(SensorsIndex, foreign_keys=sensors_gid)
+    fk_sensors_gid = Column(String(32), ForeignKey(SensorsIndex.gid), nullable=not TimeSeriesEEG.sensors.required)
+    sensors = relationship(SensorsIndex, foreign_keys=fk_sensors_gid)
 
     def fill_from_has_traits(self, datatype):
         # type: (TimeSeriesEEG)  -> None
         super(TimeSeriesEEGIndex, self).fill_from_has_traits(datatype)
-        self.sensors_gid = datatype.sensors.gid.hex
+        self.fk_sensors_gid = datatype.sensors.gid.hex
 
 
 class TimeSeriesMEGIndex(TimeSeriesIndex):
     id = Column(Integer, ForeignKey(TimeSeriesIndex.id), primary_key=True)
 
-    sensors_gid = Column(String(32), ForeignKey(SensorsIndex.gid), nullable=not TimeSeriesMEG.sensors.required)
-    sensors = relationship(SensorsIndex, foreign_keys=sensors_gid)
+    fk_sensors_gid = Column(String(32), ForeignKey(SensorsIndex.gid), nullable=not TimeSeriesMEG.sensors.required)
+    sensors = relationship(SensorsIndex, foreign_keys=fk_sensors_gid)
 
     def fill_from_has_traits(self, datatype):
         # type: (TimeSeriesMEG)  -> None
         super(TimeSeriesMEGIndex, self).fill_from_has_traits(datatype)
-        self.sensors_gid = datatype.sensors.gid.hex
+        self.fk_sensors_gid = datatype.sensors.gid.hex
 
 
 class TimeSeriesSEEGIndex(TimeSeriesIndex):
     id = Column(Integer, ForeignKey(TimeSeriesIndex.id), primary_key=True)
 
-    sensors_gid = Column(String(32), ForeignKey(SensorsIndex.gid), nullable=not TimeSeriesSEEG.sensors.required)
-    sensors = relationship(SensorsIndex, foreign_keys=sensors_gid)
+    fk_sensors_gid = Column(String(32), ForeignKey(SensorsIndex.gid), nullable=not TimeSeriesSEEG.sensors.required)
+    sensors = relationship(SensorsIndex, foreign_keys=fk_sensors_gid)
 
     def fill_from_has_traits(self, datatype):
         # type: (TimeSeriesSEEG)  -> None
         super(TimeSeriesSEEGIndex, self).fill_from_has_traits(datatype)
-        self.sensors_gid = datatype.sensors.gid.hex
+        self.fk_sensors_gid = datatype.sensors.gid.hex
 
 
 class TimeSeriesRegionIndex(TimeSeriesIndex):
     id = Column(Integer, ForeignKey(TimeSeriesIndex.id), primary_key=True)
 
-    connectivity_gid = Column(String(32), ForeignKey(ConnectivityIndex.gid),
-                              nullable=not TimeSeriesRegion.connectivity.required)
-    connectivity = relationship(ConnectivityIndex, foreign_keys=connectivity_gid,
-                                primaryjoin=ConnectivityIndex.gid == connectivity_gid)
+    fk_connectivity_gid = Column(String(32), ForeignKey(ConnectivityIndex.gid),
+                                 nullable=not TimeSeriesRegion.connectivity.required)
+    connectivity = relationship(ConnectivityIndex, foreign_keys=fk_connectivity_gid,
+                                primaryjoin=ConnectivityIndex.gid == fk_connectivity_gid)
 
-    region_mapping_volume_gid = Column(String(32), ForeignKey(RegionVolumeMappingIndex.gid),
-                                       nullable=not TimeSeriesRegion.region_mapping_volume.required)
-    region_mapping_volume = relationship(RegionVolumeMappingIndex, foreign_keys=region_mapping_volume_gid,
-                                         primaryjoin=RegionVolumeMappingIndex.gid==region_mapping_volume_gid)
+    fk_region_mapping_volume_gid = Column(String(32), ForeignKey(RegionVolumeMappingIndex.gid),
+                                          nullable=not TimeSeriesRegion.region_mapping_volume.required)
+    region_mapping_volume = relationship(RegionVolumeMappingIndex, foreign_keys=fk_region_mapping_volume_gid,
+                                         primaryjoin=RegionVolumeMappingIndex.gid == fk_region_mapping_volume_gid)
 
-    region_mapping_gid = Column(String(32), ForeignKey(RegionMappingIndex.gid),
-                                nullable=not TimeSeriesRegion.region_mapping.required)
-    region_mapping = relationship(RegionMappingIndex, foreign_keys=region_mapping_gid,
-                                  primaryjoin=RegionMappingIndex.gid==region_mapping_gid)
+    fk_region_mapping_gid = Column(String(32), ForeignKey(RegionMappingIndex.gid),
+                                   nullable=not TimeSeriesRegion.region_mapping.required)
+    region_mapping = relationship(RegionMappingIndex, foreign_keys=fk_region_mapping_gid,
+                                  primaryjoin=RegionMappingIndex.gid == fk_region_mapping_gid)
 
     def fill_from_has_traits(self, datatype):
         # type: (TimeSeriesRegion)  -> None
         super(TimeSeriesRegionIndex, self).fill_from_has_traits(datatype)
-        self.connectivity_gid = datatype.connectivity.gid.hex
+        self.fk_connectivity_gid = datatype.connectivity.gid.hex
         if datatype.region_mapping_volume is not None:
-            self.region_mapping_volume_gid = datatype.region_mapping_volume.gid.hex
+            self.fk_region_mapping_volume_gid = datatype.region_mapping_volume.gid.hex
             self.has_volume_mapping = True
         if datatype.region_mapping is not None:
-            self.region_mapping_gid = datatype.region_mapping.gid.hex
+            self.fk_region_mapping_gid = datatype.region_mapping.gid.hex
             self.has_surface_mapping = True
 
 
 class TimeSeriesSurfaceIndex(TimeSeriesIndex):
     id = Column(Integer, ForeignKey(TimeSeriesIndex.id), primary_key=True)
 
-    surface_gid = Column(String(32), ForeignKey(SurfaceIndex.gid), nullable=not TimeSeriesSurface.surface.required)
-    surface = relationship(SurfaceIndex, foreign_keys=surface_gid)
+    fk_surface_gid = Column(String(32), ForeignKey(SurfaceIndex.gid), nullable=not TimeSeriesSurface.surface.required)
+    surface = relationship(SurfaceIndex, foreign_keys=fk_surface_gid)
 
     def fill_from_has_traits(self, datatype):
         # type: (TimeSeriesSurface)  -> None
         super(TimeSeriesSurfaceIndex, self).fill_from_has_traits(datatype)
-        self.surface_gid = datatype.surface.gid.hex
+        self.fk_surface_gid = datatype.surface.gid.hex
         self.has_surface_mapping = True
 
 
 class TimeSeriesVolumeIndex(TimeSeriesIndex):
     id = Column(Integer, ForeignKey(TimeSeriesIndex.id), primary_key=True)
 
-    volume_gid = Column(String(32), ForeignKey(VolumeIndex.gid), nullable=not TimeSeriesVolume.volume.required)
-    volume = relationship(VolumeIndex, foreign_keys=volume_gid)
+    fk_volume_gid = Column(String(32), ForeignKey(VolumeIndex.gid), nullable=not TimeSeriesVolume.volume.required)
+    volume = relationship(VolumeIndex, foreign_keys=fk_volume_gid)
 
     def fill_from_has_traits(self, datatype):
         # type: (TimeSeriesVolume)  -> None
         super(TimeSeriesVolumeIndex, self).fill_from_has_traits(datatype)
         self.has_volume_mapping = True
-        self.volume_gid = datatype.volume.gid.hex
+        self.fk_volume_gid = datatype.volume.gid.hex

--- a/framework_tvb/tvb/adapters/datatypes/db/tracts.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/tracts.py
@@ -37,12 +37,12 @@ from tvb.core.entities.model.model_datatype import DataType
 class TractsIndex(DataType):
     id = Column(Integer, ForeignKey(DataType.id), primary_key=True)
 
-    region_volume_map_gid = Column(String(32), ForeignKey(RegionVolumeMappingIndex.gid),
-                                   nullable=not Tracts.region_volume_map.required)
-    region_volume_map = relationship(RegionVolumeMappingIndex, foreign_keys=region_volume_map_gid,
-                                     primaryjoin=RegionVolumeMappingIndex.gid == region_volume_map_gid)
+    fk_region_volume_map_gid = Column(String(32), ForeignKey(RegionVolumeMappingIndex.gid),
+                                      nullable=not Tracts.region_volume_map.required)
+    region_volume_map = relationship(RegionVolumeMappingIndex, foreign_keys=fk_region_volume_map_gid,
+                                     primaryjoin=RegionVolumeMappingIndex.gid == fk_region_volume_map_gid)
 
     def fill_from_has_traits(self, datatype):
         # type: (Tracts)  -> None
         super(TractsIndex, self).fill_from_has_traits(datatype)
-        self.region_volume_map_gid = datatype.region_volume_map.gid.hex
+        self.fk_region_volume_map_gid = datatype.region_volume_map.gid.hex

--- a/framework_tvb/tvb/adapters/exporters/export_manager.py
+++ b/framework_tvb/tvb/adapters/exporters/export_manager.py
@@ -317,7 +317,7 @@ class ExportManager:
         if burst is None:
             raise InvalidExportDataException("Could not find burst with ID " + str(burst_id))
 
-        op_folder = FilesHelper().get_project_folder(burst.project, str(burst.fk_simulation_id))
+        op_folder = FilesHelper().get_project_folder(burst.project, str(burst.fk_simulation))
 
         now = datetime.now()
         date_str = now.strftime("%Y-%m-%d_%H-%M")

--- a/framework_tvb/tvb/adapters/simulator/simulator_adapter.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_adapter.py
@@ -200,7 +200,7 @@ class SimulatorAdapter(ABCAsynchronous):
             rm_index = self.load_entity_by_gid(view_model.surface.region_mapping_data.hex)
             rm = h5.load_from_index(rm_index)
 
-            rm_surface_index = self.load_entity_by_gid(rm_index.surface_gid)
+            rm_surface_index = self.load_entity_by_gid(rm_index.fk_surface_gid)
             rm_surface = h5.load_from_index(rm_surface_index, CorticalSurface)
             rm.surface = rm_surface
             rm.connectivity = conn
@@ -208,7 +208,7 @@ class SimulatorAdapter(ABCAsynchronous):
             simulator.surface.region_mapping_data = rm
             if simulator.surface.local_connectivity:
                 lc = self.load_traited_by_gid(view_model.surface.local_connectivity)
-                assert lc.surface.gid == rm_index.surface_gid
+                assert lc.surface.gid == rm_index.fk_surface_gid
                 lc.surface = rm_surface
                 simulator.surface.local_connectivity = lc
 
@@ -301,7 +301,7 @@ class SimulatorAdapter(ABCAsynchronous):
         :return: None or instance of "mapping_class"
         """
 
-        dts_list = dao.get_generic_entity(mapping_class, connectivity_gid, 'connectivity_gid')
+        dts_list = dao.get_generic_entity(mapping_class, connectivity_gid, 'fk_connectivity_gid')
         if len(dts_list) < 1:
             return None
 
@@ -376,7 +376,7 @@ class SimulatorAdapter(ABCAsynchronous):
             ts_h5.nr_dimensions.store(ts_index.data_ndim)
 
             if self.algorithm.surface:
-                ts_index.surface_gid = self.algorithm.surface.region_mapping_data.surface.gid.hex
+                ts_index.fk_surface_gid = self.algorithm.surface.region_mapping_data.surface.gid.hex
                 ts_h5.surface.store(self.algorithm.surface.gid)
             else:
                 ts_h5.store_references(ts)

--- a/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
@@ -61,8 +61,8 @@ class SimulatorSurfaceFragment(ABCAdapterForm):
     def fill_from_trait(self, trait):
         # type: (Simulator) -> None
         if trait.surface:
-            if hasattr(trait.surface, 'surface_gid'):
-                self.surface.data = trait.surface.surface_gid.hex
+            if hasattr(trait.surface, 'fk_surface_gid'):
+                self.surface.data = trait.surface.fk_surface_gid.hex
         else:
             self.surface.data = None
 
@@ -72,7 +72,7 @@ class SimulatorRMFragment(ABCAdapterForm):
         super(SimulatorRMFragment, self).__init__(prefix, project_id)
         conditions = None
         if surface_index:
-            conditions = FilterChain(fields=[FilterChain.datatype + '.surface_gid'], operations=["=="],
+            conditions = FilterChain(fields=[FilterChain.datatype + '.fk_surface_gid'], operations=["=="],
                                      values=[str(surface_index.gid)])
         self.rm = DataTypeSelectField(RegionMappingIndex, self, name='region_mapping', required=True,
                                       label=Cortex.region_mapping_data.label,

--- a/framework_tvb/tvb/adapters/uploaders/gifti_timeseries_importer.py
+++ b/framework_tvb/tvb/adapters/uploaders/gifti_timeseries_importer.py
@@ -128,7 +128,7 @@ class GIFTITimeSeriesImporter(ABCUploader):
                 raise LaunchException(msg)
             else:
                 ts_h5.surface.store(uuid.UUID(surface.gid))
-                ts_idx.surface_gid = surface.gid
+                ts_idx.fk_surface_gid = surface.gid
             ts_h5.close()
 
             ts_idx.sample_period_unit = partial_time_series.sample_period_unit

--- a/framework_tvb/tvb/adapters/uploaders/mat_timeseries_importer.py
+++ b/framework_tvb/tvb/adapters/uploaders/mat_timeseries_importer.py
@@ -150,7 +150,7 @@ class RegionTimeSeriesImporter(ABCUploader):
             raise LaunchException("Data has %d channels but the connectivity has %d nodes"
                                   % (data_shape[1], connectivity.number_of_regions))
         ts_idx = TimeSeriesRegionIndex()
-        ts_idx.connectivity_gid = connectivity.gid
+        ts_idx.fk_connectivity_gid = connectivity.gid
         ts_idx.has_surface_mapping = True
 
         ts_h5_path = h5.path_for(self.storage_path, TimeSeriesRegionH5, ts_idx.gid)
@@ -165,7 +165,7 @@ class RegionTimeSeriesImporter(ABCUploader):
                                   % (data_shape[1], sensors.number_of_sensors))
 
         ts_idx = TimeSeriesEEGIndex()
-        ts_idx.sensors_gid = sensors.gid
+        ts_idx.fk_sensors_gid = sensors.gid
 
         ts_h5_path = h5.path_for(self.storage_path, TimeSeriesEEGH5, ts_idx.gid)
         ts_h5 = TimeSeriesEEGH5(ts_h5_path)

--- a/framework_tvb/tvb/adapters/visualizers/annotations_viewer.py
+++ b/framework_tvb/tvb/adapters/visualizers/annotations_viewer.py
@@ -128,13 +128,13 @@ class ConnectivityAnnotationsView(ABCSurfaceDisplayer):
         annotations_index = self.load_entity_by_gid(view_model.annotations_index)
 
         if view_model.connectivity_index is None:
-            connectivity_index = self.load_entity_by_gid(annotations_index.connectivity_gid)
+            connectivity_index = self.load_entity_by_gid(annotations_index.fk_connectivity_gid)
         else:
             connectivity_index = self.load_entity_by_gid(view_model.connectivity_index)
 
         if view_model.region_mapping_index is None:
             region_map = dao.get_generic_entity(RegionMappingIndex, connectivity_index.gid,
-                                                'connectivity_gid')
+                                                'fk_connectivity_gid')
             if len(region_map) < 1:
                 raise LaunchException(
                     "Can not launch this viewer unless we have at least a RegionMapping for the current Connectivity!")
@@ -142,11 +142,11 @@ class ConnectivityAnnotationsView(ABCSurfaceDisplayer):
         else:
             region_mapping_index = self.load_entity_by_gid(view_model.region_mapping_index)
 
-        boundary_url = SurfaceURLGenerator.get_url_for_region_boundaries(region_mapping_index.surface_gid,
+        boundary_url = SurfaceURLGenerator.get_url_for_region_boundaries(region_mapping_index.fk_surface_gid,
                                                                          region_mapping_index.gid,
                                                                          self.stored_adapter.id)
 
-        surface_index = self.load_entity_by_gid(region_mapping_index.surface_gid)
+        surface_index = self.load_entity_by_gid(region_mapping_index.fk_surface_gid)
         surface_h5 = h5.h5_file_for_index(surface_index)
         assert isinstance(surface_h5, SurfaceH5)
         url_vertices_pick, url_normals_pick, url_triangles_pick = SurfaceURLGenerator.get_urls_for_pick_rendering(

--- a/framework_tvb/tvb/adapters/visualizers/brain.py
+++ b/framework_tvb/tvb/adapters/visualizers/brain.py
@@ -179,26 +179,26 @@ class BrainViewer(ABCSurfaceDisplayer):
 
         if self.one_to_one_map:
             self.PAGE_SIZE /= 10
-            surface_gid = time_series_index.surface_gid
+            surface_gid = time_series_index.fk_surface_gid
             surface_index = dao.get_datatype_by_gid(surface_gid)
-            region_map_indexes = dao.get_generic_entity(RegionMappingIndex, surface_gid, 'surface_gid')
+            region_map_indexes = dao.get_generic_entity(RegionMappingIndex, surface_gid, 'fk_surface_gid')
             if len(region_map_indexes) < 1:
                 region_map_index = None
                 connectivity_index = None
             else:
                 region_map_index = region_map_indexes[0]
-                connectivity_index = dao.get_datatype_by_gid(region_map_index.connectivity_gid)
+                connectivity_index = dao.get_datatype_by_gid(region_map_index.fk_connectivity_gid)
         else:
-            connectivity_index = dao.get_datatype_by_gid(time_series_index.connectivity_gid)
+            connectivity_index = dao.get_datatype_by_gid(time_series_index.fk_connectivity_gid)
 
-            if time_series_index.region_mapping_gid:
-                region_map_index = dao.get_datatype_by_gid(time_series_index.region_mapping_gid)
+            if time_series_index.fk_region_mapping_gid:
+                region_map_index = dao.get_datatype_by_gid(time_series_index.fk_region_mapping_gid)
             else:
                 region_map_indexes = dao.get_generic_entity(RegionMappingIndex, connectivity_index.gid,
-                                                            'connectivity_gid')
+                                                            'fk_connectivity_gid')
                 region_map_index = region_map_indexes[0]
 
-            surface_index = dao.get_datatype_by_gid(region_map_index.surface_gid)
+            surface_index = dao.get_datatype_by_gid(region_map_index.fk_surface_gid)
 
         self.connectivity_index = connectivity_index
         self.region_map_gid = None if region_map_index is None else region_map_index.gid
@@ -446,7 +446,7 @@ class DualBrainViewer(BrainViewer):
         if isinstance(time_series, TimeSeriesRegionIndex):
             return BrainViewer.retrieve_measure_points_params(self, time_series)
 
-        sensors_index = dao.get_datatype_by_gid(time_series.sensors_gid)
+        sensors_index = dao.get_datatype_by_gid(time_series.fk_sensors_gid)
         self.measure_points_no = sensors_index.number_of_sensors
 
         if isinstance(time_series, TimeSeriesEEGIndex):

--- a/framework_tvb/tvb/adapters/visualizers/fourier_spectrum.py
+++ b/framework_tvb/tvb/adapters/visualizers/fourier_spectrum.py
@@ -117,7 +117,7 @@ class FourierSpectrumDisplay(ABCDisplayer):
             fourier_spectrum.segment_length = input_h5.segment_length.load()
             fourier_spectrum.windowing_function = input_h5.windowing_function.load()
 
-        ts_index = self.load_entity_by_gid(fs_input_index.source_gid)
+        ts_index = self.load_entity_by_gid(fs_input_index.fk_source_gid)
         state_list = ts_index.get_labels_for_dimension(1)
         if len(state_list) == 0:
             state_list = list(range(shape[1]))

--- a/framework_tvb/tvb/adapters/visualizers/matrix_viewer.py
+++ b/framework_tvb/tvb/adapters/visualizers/matrix_viewer.py
@@ -137,7 +137,7 @@ class MappedArraySVGVisualizerMixin(ABCSpaceDisplayer):
         with h5.h5_file_for_index(datatype_index) as datatype_h5:
             matrix = datatype_h5.array_data[:]
 
-        source_index = self.load_entity_by_gid(datatype_index.source_gid)
+        source_index = self.load_entity_by_gid(datatype_index.fk_source_gid)
         with h5.h5_file_for_index(source_index) as source_h5:
             labels = self.get_space_labels(source_h5)
 

--- a/framework_tvb/tvb/adapters/visualizers/surface_view.py
+++ b/framework_tvb/tvb/adapters/visualizers/surface_view.py
@@ -419,7 +419,7 @@ class SurfaceViewer(ABCSurfaceDisplayer):
 
         surface_h5 = h5.h5_file_for_index(surface_index)
         region_map_gid = region_map_index.gid if region_map_index is not None else None
-        connectivity_gid = region_map_index.connectivity_gid if region_map_index is not None else None
+        connectivity_gid = region_map_index.fk_connectivity_gid if region_map_index is not None else None
         assert isinstance(surface_h5, SurfaceH5)
 
         params = dict(title=surface_index.display_name, extended_view=False,
@@ -486,7 +486,7 @@ class RegionMappingViewer(SurfaceViewer):
     def launch(self, view_model):
         # type: (BaseSurfaceViewerModel) -> dict
         region_map_index = self.load_entity_by_gid(view_model.region_map.hex)
-        surface_gid = region_map_index.surface_gid
+        surface_gid = region_map_index.fk_surface_gid
 
         surface_viewer_model = SurfaceViewerModel(surface=uuid.UUID(surface_gid),
                                                   region_map=view_model.region_map,
@@ -534,22 +534,22 @@ class ConnectivityMeasureOnSurfaceViewer(SurfaceViewer):
         # type: (BaseSurfaceViewerModel) -> dict
 
         connectivity_measure_index = self.load_entity_by_gid(view_model.connectivity_measure.hex)
-        cm_connectivity_gid = connectivity_measure_index.connectivity_gid
+        cm_connectivity_gid = connectivity_measure_index.fk_connectivity_gid
         cm_connectivity_index = dao.get_datatype_by_gid(cm_connectivity_gid)
 
         region_map_index = None
         rm_connectivity_index = None
         if view_model.region_map:
             region_map_index = self.load_entity_by_gid(view_model.region_map.hex)
-            rm_connectivity_gid = region_map_index.connectivity_gid
+            rm_connectivity_gid = region_map_index.fk_connectivity_gid
             rm_connectivity_index = dao.get_datatype_by_gid(rm_connectivity_gid)
 
         if not region_map_index or rm_connectivity_index.number_of_regions != cm_connectivity_index.number_of_regions:
-            region_maps = dao.get_generic_entity(RegionMappingIndex, cm_connectivity_gid, 'connectivity_gid')
+            region_maps = dao.get_generic_entity(RegionMappingIndex, cm_connectivity_gid, 'fk_connectivity_gid')
             if region_maps:
                 region_map_index = region_maps[0]
 
-        surface_gid = region_map_index.surface_gid
+        surface_gid = region_map_index.fk_surface_gid
         surface_viewer_model = SurfaceViewerModel(surface=surface_gid,
                                                   region_map=region_map_index.gid,
                                                   connectivity_measure=view_model.connectivity_measure,

--- a/framework_tvb/tvb/adapters/visualizers/topographic.py
+++ b/framework_tvb/tvb/adapters/visualizers/topographic.py
@@ -251,7 +251,7 @@ class TopographicViewer(ABCDisplayer):
             if measure is not None:
                 measure_index = self.load_entity_by_gid(measure.hex)
                 measures_ht.append(h5.load_from_index(measure_index))
-                conn_index = self.load_entity_by_gid(measure_index.connectivity_gid)
+                conn_index = self.load_entity_by_gid(measure_index.fk_connectivity_gid)
                 connectivities_idx.append(conn_index)
 
         with h5.h5_file_for_index(connectivities_idx[0]) as conn_h5:

--- a/framework_tvb/tvb/adapters/visualizers/wavelet_spectrogram.py
+++ b/framework_tvb/tvb/adapters/visualizers/wavelet_spectrogram.py
@@ -120,7 +120,7 @@ class WaveletSpectrogramVisualizer(ABCDisplayer):
             data_matrix = input_h5.power[slices]
             data_matrix = data_matrix.sum(axis=3)
 
-        ts_index = self.load_entity_by_gid(input_index.source_gid)
+        ts_index = self.load_entity_by_gid(input_index.fk_source_gid)
         assert isinstance(ts_index, TimeSeriesIndex)
 
         wavelet_sample_period = ts_index.sample_period * max((1, int(input_sample_period / ts_index.sample_period)))

--- a/framework_tvb/tvb/core/entities/model/model_burst.py
+++ b/framework_tvb/tvb/core/entities/model/model_burst.py
@@ -163,7 +163,7 @@ class BurstConfiguration(HasTraitsIndex):
 
     # This will store the first Simulation Operation, and First Simulator GID, in case of PSE
     simulator_gid = Column(String, nullable=True)
-    fk_simulation_id = Column(Integer, ForeignKey('OPERATIONS.id'), nullable=True)
+    fk_simulation = Column(Integer, ForeignKey('OPERATIONS.id'), nullable=True)
 
     fk_operation_group = Column(Integer, ForeignKey('OPERATION_GROUPS.id'), nullable=True)
     operation_group = relationship(OperationGroup, foreign_keys=fk_operation_group,

--- a/framework_tvb/tvb/core/entities/model/model_burst.py
+++ b/framework_tvb/tvb/core/entities/model/model_burst.py
@@ -151,7 +151,7 @@ class BurstConfiguration(HasTraitsIndex):
 
     id = Column(Integer, ForeignKey(HasTraitsIndex.id), primary_key=True)
 
-    project_id = Column(Integer, ForeignKey('PROJECTS.id', ondelete='CASCADE'))
+    fk_project = Column(Integer, ForeignKey('PROJECTS.id', ondelete='CASCADE'))
     project = relationship(Project, backref=backref('BurstConfiguration', cascade='all,delete'))
 
     name = Column(String)
@@ -165,23 +165,23 @@ class BurstConfiguration(HasTraitsIndex):
     simulator_gid = Column(String, nullable=True)
     fk_simulation_id = Column(Integer, ForeignKey('OPERATIONS.id'), nullable=True)
 
-    operation_group_id = Column(Integer, ForeignKey('OPERATION_GROUPS.id'), nullable=True)
-    operation_group = relationship(OperationGroup, foreign_keys=operation_group_id,
-                                   primaryjoin=OperationGroup.id == operation_group_id, cascade='none')
+    fk_operation_group = Column(Integer, ForeignKey('OPERATION_GROUPS.id'), nullable=True)
+    operation_group = relationship(OperationGroup, foreign_keys=fk_operation_group,
+                                   primaryjoin=OperationGroup.id == fk_operation_group, cascade='none')
 
-    metric_operation_group_id = Column(Integer, ForeignKey('OPERATION_GROUPS.id'), nullable=True)
-    metric_operation_group = relationship(OperationGroup, foreign_keys=metric_operation_group_id,
-                                          primaryjoin=OperationGroup.id == metric_operation_group_id, cascade='none')
+    fk_metric_operation_group = Column(Integer, ForeignKey('OPERATION_GROUPS.id'), nullable=True)
+    metric_operation_group = relationship(OperationGroup, foreign_keys=fk_metric_operation_group,
+                                          primaryjoin=OperationGroup.id == fk_metric_operation_group, cascade='none')
 
     def __init__(self, project_id, status="running", name=None):
         super().__init__()
-        self.project_id = project_id
+        self.fk_project = project_id
         self.name = name
         self.status = status
         self.dynamic_ids = '[]'
 
     def clone(self):
-        new_burst = BurstConfiguration(self.project_id)
+        new_burst = BurstConfiguration(self.fk_project)
         new_burst.name = self.name
         new_burst.range1 = self.range1
         new_burst.range2 = self.range2

--- a/framework_tvb/tvb/core/entities/storage/burst_dao.py
+++ b/framework_tvb/tvb/core/entities/storage/burst_dao.py
@@ -27,7 +27,7 @@
 #   Frontiers in Neuroinformatics (7:10. doi: 10.3389/fninf.2013.00010)
 #
 #
-from operator import not_
+
 from sqlalchemy import desc, func
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm.exc import NoResultFound
@@ -45,7 +45,7 @@ class BurstDAO(RootDAO):
         """Get latest 50 BurstConfiguration entities for the current project"""
         try:
             bursts = self.session.query(BurstConfiguration
-                                        ).filter_by(project_id=project_id
+                                        ).filter_by(fk_project=project_id
                                                     ).order_by(desc(BurstConfiguration.start_time))
             if count:
                 return bursts.count()
@@ -79,9 +79,10 @@ class BurstDAO(RootDAO):
         count = 0
         try:
             count = self.session.query(BurstConfiguration
-                                       ).filter_by(project_id=project_id
-                                       ).filter(BurstConfiguration.name.notlike(burst_name + '%')
-                                                ).count()
+                                    ).filter_by(fk_project=project_id
+                                    ).filter(BurstConfiguration.name.like(burst_name + '%')
+                                    ).filter(BurstConfiguration.name.notlike(burst_name + '/_%/_%', escape='/')
+                ).count()
         except SQLAlchemyError as excep:
             self.logger.exception(excep)
         return count

--- a/framework_tvb/tvb/core/entities/storage/datatype_dao.py
+++ b/framework_tvb/tvb/core/entities/storage/datatype_dao.py
@@ -120,7 +120,7 @@ class DatatypeDAO(RootDAO):
 
     def get_number_of_bursts(self, project_id):
         try:
-            bursts = self.session.query(BurstConfiguration).filter_by(project_id=project_id)
+            bursts = self.session.query(BurstConfiguration).filter_by(fk_project=project_id)
             return bursts.count()
         except SQLAlchemyError as excep:
             self.logger.exception(excep)

--- a/framework_tvb/tvb/core/entities/transient/pse.py
+++ b/framework_tvb/tvb/core/entities/transient/pse.py
@@ -142,7 +142,7 @@ class PSEModel(object):
                     # Load proper entity class from DB.
                     measures = dao.get_generic_entity(DatatypeMeasureIndex, datatype.gid, 'gid')
                 else:
-                    measures = dao.get_generic_entity(DatatypeMeasureIndex, datatype.gid, 'source_gid')
+                    measures = dao.get_generic_entity(DatatypeMeasureIndex, datatype.gid, 'fk_source_gid')
                 if len(measures) > 0:
                     datatype_measure = measures[0]
 

--- a/framework_tvb/tvb/core/operation_async_launcher.py
+++ b/framework_tvb/tvb/core/operation_async_launcher.py
@@ -78,10 +78,10 @@ def do_operation_launch(operation_id):
         OperationService().initiate_prelaunch(curent_operation, adapter_instance)
         if curent_operation.fk_operation_group:
             parent_burst = dao.get_generic_entity(BurstConfiguration, curent_operation.fk_operation_group,
-                                                  'operation_group_id')[0]
+                                                  'fk_metric_operation_group')[0]
             operations_in_group = dao.get_operations_in_group(curent_operation.fk_operation_group)
-            if parent_burst.metric_operation_group_id:
-                operations_in_group.extend(dao.get_operations_in_group(parent_burst.metric_operation_group_id))
+            if parent_burst.fk_metric_operation_group:
+                operations_in_group.extend(dao.get_operations_in_group(parent_burst.fk_metric_operation_group))
             for operation in operations_in_group:
                 if not has_finished(operation.status):
                     break

--- a/framework_tvb/tvb/core/services/burst_service.py
+++ b/framework_tvb/tvb/core/services/burst_service.py
@@ -178,7 +178,7 @@ class BurstService(object):
 
     def update_burst_configuration_h5(self, burst_configuration):
         # type: (BurstConfiguration) -> None
-        project = dao.get_project_by_id(burst_configuration.project_id)
+        project = dao.get_project_by_id(burst_configuration.fk_project)
         storage_path = self.file_helper.get_project_folder(project, str(burst_configuration.fk_simulation_id))
         self.store_burst_configuration(burst_configuration, storage_path)
 
@@ -194,16 +194,16 @@ class BurstService(object):
         else:
             ranges = [burst_config.range1]
 
-        operation_group = OperationGroup(burst_config.project_id, ranges=ranges)
+        operation_group = OperationGroup(burst_config.fk_project, ranges=ranges)
         operation_group = dao.store_entity(operation_group)
 
-        metric_operation_group = OperationGroup(burst_config.project_id, ranges=ranges)
+        metric_operation_group = OperationGroup(burst_config.fk_project, ranges=ranges)
         metric_operation_group = dao.store_entity(metric_operation_group)
 
         burst_config.operation_group = operation_group
-        burst_config.operation_group_id = operation_group.id
+        burst_config.fk_operation_group = operation_group.id
         burst_config.metric_operation_group = metric_operation_group
-        burst_config.metric_operation_group_id = metric_operation_group.id
+        burst_config.fk_metric_operation_group = metric_operation_group.id
         dao.store_entity(burst_config)
 
     def store_burst_configuration(self, burst_config, storage_path):

--- a/framework_tvb/tvb/core/services/burst_service.py
+++ b/framework_tvb/tvb/core/services/burst_service.py
@@ -171,7 +171,7 @@ class BurstService(object):
     @staticmethod
     def update_simulation_fields(burst_id, op_simulation_id, simulation_gid):
         burst = dao.get_burst_by_id(burst_id)
-        burst.fk_simulation_id = op_simulation_id
+        burst.fk_simulation = op_simulation_id
         burst.simulator_gid = simulation_gid.hex
         burst = dao.store_entity(burst)
         return burst
@@ -179,7 +179,7 @@ class BurstService(object):
     def update_burst_configuration_h5(self, burst_configuration):
         # type: (BurstConfiguration) -> None
         project = dao.get_project_by_id(burst_configuration.fk_project)
-        storage_path = self.file_helper.get_project_folder(project, str(burst_configuration.fk_simulation_id))
+        storage_path = self.file_helper.get_project_folder(project, str(burst_configuration.fk_simulation))
         self.store_burst_configuration(burst_configuration, storage_path)
 
     def load_burst_configuration(self, burst_config_id):

--- a/framework_tvb/tvb/core/services/import_service.py
+++ b/framework_tvb/tvb/core/services/import_service.py
@@ -48,7 +48,6 @@ from tvb.config.algorithm_categories import UploadAlgorithmCategoryConfig
 from tvb.core.entities.model.model_datatype import DataTypeGroup
 from tvb.core.entities.model.model_operation import ResultFigure, Operation
 from tvb.core.entities.model.model_project import Project
-from tvb.core.entities.model.model_burst import BurstConfiguration
 from tvb.core.entities.storage import dao, transactional
 from tvb.core.entities.model.model_burst import BURST_INFO_FILE, BURSTS_DICT_KEY, DT_BURST_MAP
 from tvb.core.services.exceptions import ProjectImportException, ServicesBaseException
@@ -469,19 +468,6 @@ class ImportService(object):
 
         return operation_entity, datatype_group
 
-
-    def load_burst_entity(self, json_burst, project_id):
-        """
-        Load BurstConfiguration from JSON (possibly exported from a different machine).
-        Nothing gets persisted in DB or on disk.
-
-        :param json_burst: Burst JSON export
-        :param project_id: Current project ID (it will be used if the user later starts this simulation)
-        :return: BurstConfiguration  filled from JSON
-        """
-
-        burst_entity = BurstConfiguration(project_id)
-        return burst_entity
 
     def import_simulator_configuration_zip(self, zip_file):
         # Now compute the name of the folder where to explode uploaded ZIP file

--- a/framework_tvb/tvb/core/services/operation_service.py
+++ b/framework_tvb/tvb/core/services/operation_service.py
@@ -189,7 +189,7 @@ class OperationService:
         meta_str = json.dumps(metadata)
 
         parent_burst = dao.get_generic_entity(BurstConfiguration, time_series_index.fk_parent_burst, 'id')[0]
-        metric_operation_group_id = parent_burst.metric_operation_group_id
+        metric_operation_group_id = parent_burst.fk_metric_operation_group
         metric_operation = Operation(sim_operation.fk_launched_by, sim_operation.fk_launched_in, metric_algo.id,
                                      json.dumps({'gid': view_model.gid.hex}),
                                      meta_str, op_group_id=metric_operation_group_id, range_values=range_values)

--- a/framework_tvb/tvb/core/services/simulator_serializer.py
+++ b/framework_tvb/tvb/core/services/simulator_serializer.py
@@ -95,6 +95,6 @@ class SimulatorSerializer(object):
                 simulator_in.surface.local_connectivity = cortex_h5.local_connectivity.load()
                 simulator_in.surface.region_mapping_data = cortex_h5.region_mapping_data.load()
                 rm_index = dao.get_datatype_by_gid(simulator_in.surface.region_mapping_data.hex)
-                simulator_in.surface.surface_gid = uuid.UUID(rm_index.surface_gid)
+                simulator_in.surface.fk_surface_gid = uuid.UUID(rm_index.fk_surface_gid)
 
         return simulator_in

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
@@ -365,7 +365,7 @@ class SimulatorController(BurstBaseController):
                 self._update_last_loaded_fragment_url(SimulatorWizzardURLs.SET_CORTEX_URL)
                 surface_index = ABCAdapter.load_entity_by_gid(surface_index_gid)
                 session_stored_simulator.surface = CortexViewModel()
-                session_stored_simulator.surface.surface_gid = uuid.UUID(surface_index_gid)
+                session_stored_simulator.surface.fk_surface_gid = uuid.UUID(surface_index_gid)
 
         if session_stored_simulator.surface is None:
             stimuli_fragment = SimulatorStimulusFragment('', common.get_current_project().id, False)
@@ -1007,7 +1007,7 @@ class SimulatorController(BurstBaseController):
             burst_config = self.burst_service.load_burst_configuration(burst_config_id)
             common.add2session(common.KEY_BURST_CONFIG, burst_config)
             project = common.get_current_project()
-            storage_path = self.files_helper.get_project_folder(project, str(burst_config.fk_simulation_id))
+            storage_path = self.files_helper.get_project_folder(project, str(burst_config.fk_simulation))
             simulator = SimulatorSerializer().deserialize_simulator(burst_config.simulator_gid, storage_path)
 
             common.add2session(common.KEY_SIMULATOR_CONFIG, simulator)
@@ -1034,7 +1034,7 @@ class SimulatorController(BurstBaseController):
         burst_config = self.burst_service.load_burst_configuration(burst_config_id)
         common.add2session(common.KEY_BURST_CONFIG, burst_config)
         project = common.get_current_project()
-        storage_path = self.files_helper.get_project_folder(project, str(burst_config.fk_simulation_id))
+        storage_path = self.files_helper.get_project_folder(project, str(burst_config.fk_simulation))
         simulator = SimulatorSerializer().deserialize_simulator(burst_config.simulator_gid, storage_path)
         simulator.gid = uuid.uuid4()
         # Generate a new GUID, as it needs to be unique

--- a/framework_tvb/tvb/interfaces/web/controllers/spatial/local_connectivity_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/spatial/local_connectivity_controller.py
@@ -191,7 +191,7 @@ class LocalConnectivityController(SpatioTemporalController):
         template_specification['displayedMessage'] = msg
         if current_lconn is not None:
             selected_local_conn = ABCAdapter.load_entity_by_gid(current_lconn.gid.hex)
-            template_specification.update(self.display_surface(selected_local_conn.surface_gid))
+            template_specification.update(self.display_surface(selected_local_conn.fk_surface_gid))
             template_specification['no_local_connectivity'] = False
             template_specification['minValue'] = selected_local_conn.matrix_non_zero_min
             template_specification['maxValue'] = selected_local_conn.matrix_non_zero_max
@@ -227,7 +227,7 @@ class LocalConnectivityController(SpatioTemporalController):
         with LocalConnectivityH5(lconn_h5_path) as lconn_h5:
             lconn_h5.load_into(existent_lconn)
 
-        existent_lconn.surface = uuid.UUID(lconn_index.surface_gid)
+        existent_lconn.surface = uuid.UUID(lconn_index.fk_surface_gid)
 
         common.add2session(KEY_LCONN, existent_lconn)
         existent_lconn.display_name = lconn_index.user_tag_1
@@ -279,7 +279,7 @@ class LocalConnectivityController(SpatioTemporalController):
         lconn_index = ABCAdapter.load_entity_by_gid(local_connectivity_gid)
         triangle_index = int(selected_triangle)
 
-        surface_indx = ABCAdapter.load_entity_by_gid(lconn_index.surface_gid)
+        surface_indx = ABCAdapter.load_entity_by_gid(lconn_index.fk_surface_gid)
         surface_h5 = h5.h5_file_for_index(surface_indx)
         assert isinstance(surface_h5, SurfaceH5)
         vertex_index = int(surface_h5.triangles[triangle_index][0])

--- a/framework_tvb/tvb/interfaces/web/controllers/spatial/region_stimulus_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/spatial/region_stimulus_controller.py
@@ -319,7 +319,7 @@ class RegionStimulusController(SpatioTemporalController):
         with StimuliRegionH5(stimuli_region_path) as stimuli_region_h5:
             stimuli_region_h5.load_into(stimuli_region)
 
-        dummy_gid = uuid.UUID(existent_region_stimulus_index.connectivity_gid)
+        dummy_gid = uuid.UUID(existent_region_stimulus_index.fk_connectivity_gid)
         stimuli_region.connectivity = dummy_gid
 
         common.add2session(KEY_REGION_STIMULUS, stimuli_region)

--- a/framework_tvb/tvb/interfaces/web/controllers/spatial/surface_model_parameters_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/spatial/surface_model_parameters_controller.py
@@ -184,7 +184,7 @@ class SurfaceModelParametersController(SpatioTemporalController):
         Main method, to initialize Model-Parameter visual-set.
         """
         model, cortex = self.get_data_from_burst_configuration()
-        surface_gid = cortex.surface_gid
+        surface_gid = cortex.fk_surface_gid
         surface_index = dao.get_datatype_by_gid(surface_gid.hex)
 
         self.model_params_dict = self._prepare_model_params_dict(model)

--- a/framework_tvb/tvb/interfaces/web/controllers/spatial/surface_stimulus_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/spatial/surface_stimulus_controller.py
@@ -308,7 +308,7 @@ class SurfaceStimulusController(SpatioTemporalController):
         with StimuliSurfaceH5(surface_stim_h5_path) as surface_stim_h5:
             surface_stim_h5.load_into(existent_surface_stim)
 
-        existent_surface_stim.surface = uuid.UUID(surface_stim_index.surface_gid)
+        existent_surface_stim.surface = uuid.UUID(surface_stim_index.fk_surface_gid)
 
         common.add2session(KEY_SURFACE_STIMULI, existent_surface_stim)
         common.add2session(KEY_SURFACE_STIMULI_NAME, surface_stim_index.user_tag_1)

--- a/framework_tvb/tvb/tests/framework/adapters/analyzers/bct_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/analyzers/bct_test.py
@@ -68,8 +68,8 @@ class TestBCT(TransactionalTestCase):
         self.test_project = TestFactory.create_project(self.test_user, "BCT-Project")
         # Make sure Connectivity is in DB
         zip_path = os.path.join(os.path.dirname(tvb_data.__file__), 'connectivity', 'connectivity_66.zip')
-        TestFactory.import_zip_connectivity(self.test_user, self.test_project, zip_path)
-        self.connectivity = dao.get_generic_entity(Connectivity, 'John Doe', 'subject')[0]
+        conn_index = TestFactory.import_zip_connectivity(self.test_user, self.test_project, zip_path)
+        self.connectivity = ABCAdapter.load_traited_by_gid(conn_index.gid)
 
         # make weights matrix symmetric, or else some BCT algorithms will run infinitely:
         w = self.connectivity.weights

--- a/framework_tvb/tvb/tests/framework/adapters/analyzers/fft_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/analyzers/fft_test.py
@@ -77,6 +77,6 @@ class TestFFT(TransactionalTestCase):
         memq = adapter.get_required_memory_size(view_model)
         spectra_idx = adapter.launch(view_model)
 
-        assert spectra_idx.source_gid == ts_db.gid
+        assert spectra_idx.fk_source_gid == ts_db.gid
         assert spectra_idx.gid is not None
         assert spectra_idx.segment_length == 1.0  # only 1 sec of signal

--- a/framework_tvb/tvb/tests/framework/adapters/creators/stimulus_creator_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/creators/stimulus_creator_test.py
@@ -84,7 +84,7 @@ class TestStimulusCreator(TransactionalTestCase):
 
         assert region_stimulus_index.temporal_equation == 'TemporalApplicableEquation'
         assert json.loads(region_stimulus_index.temporal_parameters) == {'a': 1.0, 'b': 2.0}
-        assert region_stimulus_index.connectivity_gid == self.connectivity.gid
+        assert region_stimulus_index.fk_connectivity_gid == self.connectivity.gid
 
     def test_create_stimulus_region_with_operation(self):
         weight_array = numpy.zeros(self.connectivity.number_of_regions)
@@ -103,7 +103,7 @@ class TestStimulusCreator(TransactionalTestCase):
 
         assert region_stimulus_index.temporal_equation == 'TemporalApplicableEquation'
         assert json.loads(region_stimulus_index.temporal_parameters) == {'a': 1.0, 'b': 2.0}
-        assert region_stimulus_index.connectivity_gid == self.connectivity.gid
+        assert region_stimulus_index.fk_connectivity_gid == self.connectivity.gid
 
     def test_create_stimulus_surface(self):
         surface_stimulus_creator = SurfaceStimulusCreator()
@@ -123,7 +123,7 @@ class TestStimulusCreator(TransactionalTestCase):
 
         assert surface_stimulus_index.spatial_equation == 'FiniteSupportEquation'
         assert surface_stimulus_index.temporal_equation == 'TemporalApplicableEquation'
-        assert surface_stimulus_index.surface_gid == self.surface.gid
+        assert surface_stimulus_index.fk_surface_gid == self.surface.gid
 
     def test_create_stimulus_surface_with_operation(self):
         surface_stimulus_creator = SurfaceStimulusCreator()
@@ -145,4 +145,4 @@ class TestStimulusCreator(TransactionalTestCase):
 
         assert surface_stimulus_index.spatial_equation == 'FiniteSupportEquation'
         assert surface_stimulus_index.temporal_equation == 'TemporalApplicableEquation'
-        assert surface_stimulus_index.surface_gid == self.surface.gid
+        assert surface_stimulus_index.fk_surface_gid == self.surface.gid

--- a/framework_tvb/tvb/tests/framework/adapters/exporters/exporters_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/exporters/exporters_test.py
@@ -184,7 +184,7 @@ class TestExporters(TransactionalTestCase):
         simulator.connectivity = connectivity_factory(4).gid
 
         burst_configuration = BurstConfiguration(self.test_project.id)
-        burst_configuration.fk_simulation_id = operation.id
+        burst_configuration.fk_simulation = operation.id
         burst_configuration.simulator_gid = simulator.gid.hex
         burst_configuration = dao.store_entity(burst_configuration)
 

--- a/framework_tvb/tvb/tests/framework/adapters/simulator/simulator_adapter_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/simulator/simulator_adapter_test.py
@@ -173,7 +173,7 @@ class TestSimulatorAdapter(TransactionalTestCase):
         region_mapping = TestFactory.import_region_mapping(self.test_user, self.test_project, text_file, surface.gid, connectivity.gid)
 
         cortex_model.region_mapping_data = region_mapping.gid
-        cortex_model.surface_gid = surface.gid
+        cortex_model.fk_surface_gid = surface.gid
         simulator_adapter_model.surface = cortex_model
 
         ## Estimation when the surface input parameter is set

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/nifti_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/nifti_importer_test.py
@@ -126,7 +126,7 @@ class TestNIFTIImporter(TransactionalTestCase):
         assert dimension_labels is not None
         assert 4 == len(json.loads(dimension_labels))
 
-        volume_index = ABCAdapter.load_entity_by_gid(time_series_index.volume_gid)
+        volume_index = ABCAdapter.load_entity_by_gid(time_series_index.fk_volume_gid)
         assert volume_index is not None
 
         volume = h5.load_from_index(volume_index)
@@ -149,7 +149,7 @@ class TestNIFTIImporter(TransactionalTestCase):
         assert 64 == data_shape[1]
         assert 10 == data_shape[2]
 
-        volume_index = ABCAdapter.load_entity_by_gid(structural_mri_index.volume_gid)
+        volume_index = ABCAdapter.load_entity_by_gid(structural_mri_index.fk_volume_gid)
         assert volume_index is not None
 
         volume = h5.load_from_index(volume_index)
@@ -178,9 +178,9 @@ class TestNIFTIImporter(TransactionalTestCase):
 
         assert -1 <= mapping.array_data.min()
         assert mapping.array_data.max() < to_link_conn.number_of_regions
-        assert to_link_conn.gid == mapping_index.connectivity_gid
+        assert to_link_conn.gid == mapping_index.fk_connectivity_gid
 
-        volume_index = ABCAdapter.load_entity_by_gid(mapping_index.volume_gid)
+        volume_index = ABCAdapter.load_entity_by_gid(mapping_index.fk_volume_gid)
         assert volume_index is not None
 
         volume = h5.load_from_index(volume_index)

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/region_mapping_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/region_mapping_importer_test.py
@@ -131,10 +131,10 @@ class TestRegionMappingImporter(TransactionalTestCase):
         """
         region_mapping_index = TestFactory.import_region_mapping(self.test_user, self.test_project, import_file, self.surface.gid, self.connectivity.gid)
 
-        surface_index = ABCAdapter.load_entity_by_gid(region_mapping_index.surface_gid)
+        surface_index = ABCAdapter.load_entity_by_gid(region_mapping_index.fk_surface_gid)
         assert surface_index is not None
 
-        connectivity_index = ABCAdapter.load_entity_by_gid(region_mapping_index.connectivity_gid)
+        connectivity_index = ABCAdapter.load_entity_by_gid(region_mapping_index.fk_connectivity_gid)
         assert connectivity_index is not None
 
         region_mapping = h5.load_from_index(region_mapping_index)

--- a/framework_tvb/tvb/tests/framework/core/factory.py
+++ b/framework_tvb/tvb/tests/framework/core/factory.py
@@ -207,7 +207,7 @@ class TestFactory(object):
             burst.start_time = datetime.datetime.now()
             burst.range1 = '["conduction_speed", {"lo": 50, "step": 1.0, "hi": 100.0}]'
             burst.range2 = '["connectivity", null]'
-            burst.fk_simulation_id = operation.id
+            burst.fk_simulation = operation.id
             burst.simulator_gid = uuid.uuid4().hex
             BurstService().update_burst_configuration_h5(burst)
         return dao.store_entity(burst)

--- a/framework_tvb/tvb/tests/framework/core/services/burst_service_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/burst_service_test.py
@@ -54,7 +54,6 @@ from tvb.core.adapters.abcadapter import ABCAdapter
 from tvb.tests.framework.core.factory import TestFactory
 from tvb.tests.framework.datatypes.datatype1 import Datatype1
 from tvb.tests.framework.datatypes.datatype2 import Datatype2
-# from tvb.tests.framework.datatypes import datatypes_factory
 from tvb.tests.framework.adapters.storeadapter import StoreAdapter
 from tvb.tests.framework.adapters.simulator.simulator_adapter_test import SIMULATOR_PARAMETERS
 import copy
@@ -67,7 +66,7 @@ class TestBurstService(BaseTestCase):
     sessions bounded to the current thread transaction.
     """
     PORTLET_ID = "TA1TA2"
-    ## This should not be present in portlets.xml
+    # This should not be present in portlets.xml
     INVALID_PORTLET_ID = "this_is_not_a_non_existent_test_portlet_ID"
 
     burst_service = BurstService()
@@ -127,7 +126,7 @@ class TestBurstService(BaseTestCase):
         Compare that all important attributes are the same between two bursts. (name, project id and status)
         """
         assert first_burst.name == second_burst.name, "Names not equal for bursts."
-        assert first_burst.project_id == second_burst.project_id, "Projects not equal for bursts."
+        assert first_burst.fk_project == second_burst.fk_project, "Projects not equal for bursts."
         assert first_burst.status == second_burst.status, "Statuses not equal for bursts."
         assert first_burst.range1 == second_burst.range1, "Statuses not equal for bursts."
         assert first_burst.range2 == second_burst.range2, "Statuses not equal for bursts."

--- a/framework_tvb/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
@@ -576,7 +576,7 @@ class TestSimulationController(BaseTransactionalControllerTest, helper.CPWebCase
     def test_export(self):
         op = TestFactory.create_operation(test_user=self.test_user, test_project=self.test_project)
         burst_config = BurstConfiguration(self.test_project.id)
-        burst_config.fk_simulation_id = op.id
+        burst_config.fk_simulation = op.id
         burst_config.simulator_gid = self.session_stored_simulator.gid.hex
         burst_config = dao.store_entity(burst_config)
 
@@ -601,7 +601,7 @@ class TestSimulationController(BaseTransactionalControllerTest, helper.CPWebCase
 
         op = TestFactory.create_operation(test_user=self.test_user, test_project=self.test_project)
         burst_config = BurstConfiguration(self.test_project.id)
-        burst_config.fk_simulation_id = op.id
+        burst_config.fk_simulation = op.id
         burst_config.simulator_gid = self.session_stored_simulator.gid.hex
         burst_config = dao.store_entity(burst_config)
 
@@ -632,7 +632,7 @@ class TestSimulationController(BaseTransactionalControllerTest, helper.CPWebCase
 
         op = TestFactory.create_operation(test_user=self.test_user, test_project=self.test_project)
         burst_config = BurstConfiguration(self.test_project.id)
-        burst_config.fk_simulation_id = op.id
+        burst_config.fk_simulation = op.id
         burst_config.simulator_gid = self.session_stored_simulator.gid.hex
         burst_config = dao.store_entity(burst_config)
 


### PR DESCRIPTION
We want all Foreign Key columns to be named under patter: `fk_...`
The new columns which are Foreign Keys towards a gid will be named `fk_...._gid`.