### PR TITLE
TVB-2555: Fix Loading Parameters When Copying A Simulation

### DIFF
--- a/framework_tvb/tvb/core/entities/storage/burst_dao.py
+++ b/framework_tvb/tvb/core/entities/storage/burst_dao.py
@@ -80,8 +80,8 @@ class BurstDAO(RootDAO):
         try:
             count = self.session.query(BurstConfiguration
                                     ).filter_by(fk_project=project_id
-                                    ).filter(BurstConfiguration.name.like(burst_name + '%')
-                                    ).filter(BurstConfiguration.name.notlike(burst_name + '/_%/_%', escape='/')
+                                    ).filter(BurstConfiguration.name.like(burst_name + '_branch%')
+                                    ).filter(BurstConfiguration.name.notlike(burst_name + '_branch%_branch%', escape='/')
                 ).count()
         except SQLAlchemyError as excep:
             self.logger.exception(excep)

--- a/framework_tvb/tvb/core/operation_async_launcher.py
+++ b/framework_tvb/tvb/core/operation_async_launcher.py
@@ -78,7 +78,7 @@ def do_operation_launch(operation_id):
         OperationService().initiate_prelaunch(curent_operation, adapter_instance)
         if curent_operation.fk_operation_group:
             parent_burst = dao.get_generic_entity(BurstConfiguration, curent_operation.fk_operation_group,
-                                                  'fk_metric_operation_group')[0]
+                                                  'fk_operation_group')[0]
             operations_in_group = dao.get_operations_in_group(curent_operation.fk_operation_group)
             if parent_burst.fk_metric_operation_group:
                 operations_in_group.extend(dao.get_operations_in_group(parent_burst.fk_metric_operation_group))

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
@@ -165,7 +165,8 @@ class SimulatorFragmentRenderingRules(object):
 
     @property
     def hide_previous_button(self):
-        if self.load_readonly and not (self.is_simulation_copy and self.is_launch_fragment):
+        if self.load_readonly and not (self.is_simulation_copy and self.is_launch_fragment and
+                                       self.last_form_url == SimulatorWizzardURLs.SETUP_PSE_URL):
             return True
         return False
 
@@ -191,6 +192,13 @@ class SimulatorFragmentRenderingRules(object):
     def include_launch_button(self):
         if self.is_launch_fragment and (not self.load_readonly or self.is_simulation_copy):
             return True
+        return False
+
+    @property
+    def hide_launch_and_setup_pse_button(self):
+        if self.last_form_url != SimulatorWizzardURLs.SETUP_PSE_URL:
+            return True
+        return False
 
     @property
     def include_branch_button(self):

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
@@ -946,7 +946,7 @@ class SimulatorController(BurstBaseController):
         else:
             burst_config_to_store = session_burst_config.clone()
             count = dao.count_bursts_with_name(session_burst_config.name, session_burst_config.project_id)
-            burst_config_to_store.name = session_burst_config.name + "_" + launch_mode + str(count)
+            burst_config_to_store.name = session_burst_config.name + "_" + launch_mode + str(count + 1)
             simulation_state_index = dao.get_generic_entity(SimulationHistoryIndex,
                                                             session_burst_config.id, "fk_parent_burst")
             if simulation_state_index is None or len(simulation_state_index) < 1:

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
@@ -695,7 +695,7 @@ class SimulatorController(BurstBaseController):
                                                               is_simulator_copy, is_simulator_load,
                                                               self.last_loaded_form_url, cherrypy.request.method,
                                                               is_launch_fragment=True,
-                                                              is_pse_launch=session_stored_burst.is_pse_launch())
+                                                              is_pse_launch=session_stored_burst.is_pse_burst())
         else:
             rendering_rules = SimulatorFragmentRenderingRules(form, SimulatorWizzardURLs.SET_MONITOR_PARAMS_URL,
                                                               SimulatorWizzardURLs.SET_MONITORS_URL, is_simulator_copy,
@@ -811,7 +811,7 @@ class SimulatorController(BurstBaseController):
                                                           is_simulator_copy, is_simulator_load,
                                                           self.last_loaded_form_url, cherrypy.request.method,
                                                           is_launch_fragment=True,
-                                                          is_pse_launch=session_stored_burst.is_pse_launch())
+                                                          is_pse_launch=session_stored_burst.is_pse_burst())
         return rendering_rules.to_dict()
 
     @cherrypy.expose

--- a/framework_tvb/tvb/interfaces/web/static/js/bursts.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/bursts.js
@@ -678,6 +678,7 @@ function previousWizzardStep(currentForm, previous_action, div_id = 'div-simulat
     var config_launch_button = previous_form.elements.namedItem('launch_simulation');
     var config_pse_button = previous_form.elements.namedItem('setup_pse');
     var config_launch_pse_button = previous_form.elements.namedItem('launch_pse');
+    var config_branch_button = previous_form.elements.namedItem('branch_simulation');
     var fieldset = previous_form.elements[0];
 
     if (next_button != null) {
@@ -704,6 +705,9 @@ function previousWizzardStep(currentForm, previous_action, div_id = 'div-simulat
     if (config_launch_pse_button != null){
         config_launch_pse_button.style.visibility = 'visible';
     }
+    if (config_branch_button != null){
+        config_branch_button.style.visibility = 'visible';
+    }
     fieldset.disabled = false;
 }
 
@@ -720,6 +724,7 @@ function wizzard_submit(currentForm, success_function = null, div_id = 'div-simu
     var config_launch_button = currentForm.elements.namedItem('launch_simulation');
     var config_pse_button = currentForm.elements.namedItem('setup_pse');
     var config_launch_pse_button = currentForm.elements.namedItem('launch_pse');
+    var config_branch_button = currentForm.elements.namedItem('branch_simulation');
     var fieldset = currentForm.elements[0];
 
     $.ajax({
@@ -753,6 +758,9 @@ function wizzard_submit(currentForm, success_function = null, div_id = 'div-simu
                 }
                 if(config_launch_pse_button != null){
                     config_launch_pse_button.style.visibility = 'hidden';
+                }
+                if(config_branch_button != null){
+                    config_branch_button.style.visibility = 'hidden';
                 }
                 fieldset.disabled = true;
                 var t = document.createRange().createContextualFragment(response);

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/simulator_fragment.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/simulator_fragment.html
@@ -59,17 +59,17 @@
         </button>
     {% endif %}
 
-    {% if renderer.include_branch_button %}
-        <button id="branch_simulation" name="branch_simulation" type="button" class="btn btn-primary"
-                onclick="launchNewBurst(this.parentElement, 'branch')"
-                {% if renderer.load_readonly %} style="visibility: hidden" {% endif %}>Branch
-        </button>
-    {% endif %}
-
     {% if renderer.include_setup_pse %}
         <button id="setup_pse" name="setup_pse" type="button" class="btn btn-primary"
                 onclick="wizzard_submit(this.parentElement)"
                 {% if renderer.hide_launch_and_setup_pse_button %} style="visibility: hidden" {% endif %}>Setup PSE
+        </button>
+    {% endif %}
+
+    {% if renderer.include_branch_button %}
+        <button id="branch_simulation" name="branch_simulation" type="button" class="btn btn-primary"
+                onclick="launchNewBurst(this.parentElement, 'branch')"
+                {% if renderer.load_readonly %} style="visibility: hidden" {% endif %}>Branch
         </button>
     {% endif %}
 

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/simulator_fragment.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/simulator_fragment.html
@@ -54,17 +54,23 @@
 
     {% if renderer.include_launch_button %}
         <button id="launch_simulation" name="launch_simulation" type="button" class="btn btn-primary"
-                onclick="launchNewBurst(this.parentElement, 'new')">Launch</button>
+                onclick="launchNewBurst(this.parentElement, 'new')"
+                {% if renderer.hide_launch_and_setup_pse_button %} style="visibility: hidden" {% endif %}>Launch
+        </button>
     {% endif %}
 
     {% if renderer.include_branch_button %}
         <button id="branch_simulation" name="branch_simulation" type="button" class="btn btn-primary"
-                onclick="launchNewBurst(this.parentElement, 'branch')">Branch</button>
+                onclick="launchNewBurst(this.parentElement, 'branch')"
+                {% if renderer.load_readonly %} style="visibility: hidden" {% endif %}>Branch
+        </button>
     {% endif %}
 
     {% if renderer.include_setup_pse %}
         <button id="setup_pse" name="setup_pse" type="button" class="btn btn-primary"
-                onclick="wizzard_submit(this.parentElement)">Setup PSE</button>
+                onclick="wizzard_submit(this.parentElement)"
+                {% if renderer.hide_launch_and_setup_pse_button %} style="visibility: hidden" {% endif %}>Setup PSE
+        </button>
     {% endif %}
 
     {% if renderer.include_launch_pse_button %}

--- a/framework_tvb/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
@@ -324,6 +324,7 @@ class TestSimulationController(BaseTransactionalControllerTest, helper.CPWebCase
 
         with patch('cherrypy.session', self.sess_mock, create=True):
             common.add2session(common.KEY_SIMULATOR_CONFIG, self.session_stored_simulator)
+            common.add2session(common.KEY_BURST_CONFIG, BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitor_params(**self.sess_mock._data)
 
         assert self.session_stored_simulator.monitors[0].period == 0.8, "Period was not set correctly."
@@ -370,6 +371,7 @@ class TestSimulationController(BaseTransactionalControllerTest, helper.CPWebCase
 
         with patch('cherrypy.session', self.sess_mock, create=True):
             common.add2session(common.KEY_SIMULATOR_CONFIG, self.session_stored_simulator)
+            common.add2session(common.KEY_BURST_CONFIG, BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitor_params(**self.sess_mock._data)
 
         assert self.session_stored_simulator.monitors[0].period == 0.75, "Period was not set correctly."
@@ -410,6 +412,7 @@ class TestSimulationController(BaseTransactionalControllerTest, helper.CPWebCase
 
         with patch('cherrypy.session', self.sess_mock, create=True):
             common.add2session(common.KEY_SIMULATOR_CONFIG, self.session_stored_simulator)
+            common.add2session(common.KEY_BURST_CONFIG, BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitor_params(**self.sess_mock._data)
 
         assert self.session_stored_simulator.monitors[0].period == 0.75, "Period was not set correctly."
@@ -450,6 +453,7 @@ class TestSimulationController(BaseTransactionalControllerTest, helper.CPWebCase
 
         with patch('cherrypy.session', self.sess_mock, create=True):
             common.add2session(common.KEY_SIMULATOR_CONFIG, self.session_stored_simulator)
+            common.add2session(common.KEY_BURST_CONFIG, BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitor_params(**self.sess_mock._data)
 
         assert self.session_stored_simulator.monitors[0].period == 0.75, "Period was not set correctly."
@@ -491,6 +495,7 @@ class TestSimulationController(BaseTransactionalControllerTest, helper.CPWebCase
 
         with patch('cherrypy.session', self.sess_mock, create=True):
             common.add2session(common.KEY_SIMULATOR_CONFIG, self.session_stored_simulator)
+            common.add2session(common.KEY_BURST_CONFIG, BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitor_equation(**self.sess_mock._data)
 
         assert self.session_stored_simulator.monitors[0].equation.parameters[

--- a/framework_tvb/tvb/tests/framework/interfaces/web/jinja2_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/web/jinja2_test.py
@@ -182,7 +182,8 @@ class TestJinja2Simulator(Jinja2Test):
         assert len(hidden_buttons) == 1
 
     def test_buttons_last_fragment(self):
-        rendering_rules = SimulatorFragmentRenderingRules(form_action_url='dummy_url', last_form_url='dummy_url',
+        rendering_rules = SimulatorFragmentRenderingRules(form_action_url=SimulatorWizzardURLs.SETUP_PSE_URL,
+                                                          last_form_url=SimulatorWizzardURLs.SETUP_PSE_URL,
                                                           is_launch_fragment=True)
         soup = self.prepare_simulator_form_for_search(rendering_rules)
 
@@ -192,7 +193,9 @@ class TestJinja2Simulator(Jinja2Test):
         assert len(hidden_buttons) == 0
 
     def test_buttons_last_fragment_copy(self):
-        rendering_rules = SimulatorFragmentRenderingRules(is_launch_fragment=True, is_simulation_copy=True)
+        rendering_rules = SimulatorFragmentRenderingRules(is_launch_fragment=True, is_simulation_copy=True,
+                                                          form_action_url=SimulatorWizzardURLs.SETUP_PSE_URL,
+                                                          last_form_url=SimulatorWizzardURLs.SETUP_PSE_URL)
         soup = self.prepare_simulator_form_for_search(rendering_rules)
 
         all_buttons = soup.find_all('button')


### PR DESCRIPTION
About those "is_simulator_copy = False" deletions. I understood that branching has to be possible even if you've done for example Copy -> Previous -> Next -> Branch (and that we will deal with this case in another task). With those there, this won't be possible cause if is_simulator_copy is False, the button won't show up and in case of normal simulation launching that variable will be False regardless of this statement.

The buttons all show up fine, but there is a problem that I receive an error when trying to PSE launch a copied simulation (same error for both simulation types):
Traceback (most recent call last):
  File "d:\tvb\tvb-root\framework_tvb\tvb\interfaces\web\controllers\decorators.py", line 147, in deco
    return func(*a, **b)
  File "d:\tvb\tvb-root\framework_tvb\tvb\interfaces\web\controllers\decorators.py", line 193, in deco
    return func(*a, **b)
  File "d:\tvb\tvb-root\framework_tvb\tvb\interfaces\web\controllers\simulator_controller.py", line 904, in launch_pse
    burst_config.operation_group = operation_group
  File "C:\Users\Robert.Vincze\Anaconda3\envs\tvb-root-p3\lib\site-packages\sqlalchemy\orm\attributes.py", line 224, in __set__
    instance_dict(instance), value, None)
  File "C:\Users\Robert.Vincze\Anaconda3\envs\tvb-root-p3\lib\site-packages\sqlalchemy\orm\attributes.py", line 797, in set
    LOAD_AGAINST_COMMITTED)
  File "C:\Users\Robert.Vincze\Anaconda3\envs\tvb-root-p3\lib\site-packages\sqlalchemy\orm\attributes.py", line 584, in get
    value = self.callable_(state, passive)
  File "C:\Users\Robert.Vincze\Anaconda3\envs\tvb-root-p3\lib\site-packages\sqlalchemy\orm\strategies.py", line 530, in _load_for_state
    (orm_util.state_str(state), self.key)
sqlalchemy.orm.exc.DetachedInstanceError: Parent instance <BurstConfiguration at 0x165e13cfa08> is not bound to a Session; lazy load operation of attribute 'operation_group' cannot proceed.

Should I solve it in this task or is this going to be another one?

Also, a smaller problem regarding the simulation name... for example if I just launch a copied simulation without doing anything else, it will have the same name. Shouldn't we do something like "originalname_copy1"?