### PR TITLE
TVB-2655. Fixes for REST part

### DIFF
--- a/framework_tvb/tvb/interfaces/rest/client/operation/operation_api.py
+++ b/framework_tvb/tvb/interfaces/rest/client/operation/operation_api.py
@@ -84,7 +84,7 @@ class OperationApi(MainApi):
         form = adapter_class().get_form()()
 
         post_data = self._prepare_post_data(datatype_gid, form)
-        form.fill_from_post(post_data)
+        form.fill_from_post_plus_defaults(post_data)
 
         view_model = form.get_view_model()()
         form.fill_trait(view_model)

--- a/framework_tvb/tvb/interfaces/rest/server/facades/datatype_facade.py
+++ b/framework_tvb/tvb/interfaces/rest/server/facades/datatype_facade.py
@@ -44,7 +44,7 @@ class DatatypeFacade:
         return h5_file_for_index(index).path
 
     def get_datatype_operations(self, datatype_gid):
-        categories = dao.get_launchable_categories()
+        categories = dao.get_launchable_categories(elimin_viewers=True)
         datatype = dao.get_datatype_by_gid(datatype_gid)
         _, filtered_adapters, _ = self.flow_service.get_launchable_algorithms_for_datatype(datatype, categories)
         return [AlgorithmDto(algorithm) for algorithm in filtered_adapters]


### PR DESCRIPTION
Filter out visualizers from get_operations_for_datatype. 
Fix quick_launch_operation to work for analyzers with more than the datatype GID input.