### PR TITLE
TVB-2678: Worked on fixing the simulation default name in case of simulation copy

### DIFF
--- a/framework_tvb/tvb/core/entities/storage/burst_dao.py
+++ b/framework_tvb/tvb/core/entities/storage/burst_dao.py
@@ -72,20 +72,16 @@ class BurstDAO(RootDAO):
             self.logger.exception(excep)
         return 0
 
-    def count_bursts_with_name(self, burst_name, project_id, prefix=None):
+    def count_bursts_with_name(self, burst_name, project_id):
         """
         Return the number of burst already named 'custom_b%' and NOT 'custom_b%_%' in current project.
         """
         count = 0
-        if prefix in burst_name:
-            name = burst_name.replace(prefix, '')
-        else:
-            name = burst_name
         try:
             count = self.session.query(BurstConfiguration
                                     ).filter_by(fk_project=project_id
-                                    ).filter(BurstConfiguration.name.like(name + '_branch%')
-                                    ).filter(BurstConfiguration.name.notlike(name + '_branch%_branch%', escape='/')
+                                    ).filter(BurstConfiguration.name.like(burst_name + '_branch%')
+                                    ).filter(BurstConfiguration.name.notlike(burst_name + '_branch%_branch%', escape='/')
                 ).count()
         except SQLAlchemyError as excep:
             self.logger.exception(excep)

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
@@ -965,9 +965,9 @@ class SimulatorController(BurstBaseController):
                 burst_config_to_store = session_burst_config.clone()
         else:
             burst_config_to_store = session_burst_config.clone()
-            count = dao.count_bursts_with_name(session_burst_config.name, session_burst_config.fk_project, prefix=self.DEFAULT_COPY_PREFIX)
             if self.DEFAULT_COPY_PREFIX in session_burst_config.name:
                 session_burst_config.name = session_burst_config.name.replace(self.DEFAULT_COPY_PREFIX, '')
+            count = dao.count_bursts_with_name(session_burst_config.name, session_burst_config.fk_project)
             burst_config_to_store.name = session_burst_config.name + "_" + launch_mode + str(count + 1)
             simulation_state_index = dao.get_generic_entity(SimulationHistoryIndex,
                                                             session_burst_config.id, "fk_parent_burst")


### PR DESCRIPTION
If you copy a simulation named, let's say "robert" then the name of the copy will be "copy_of_robert" and if you wish to launch a branch that, it will be "robert_branch1" and not "copy_of_robert_branch1".
However, if you change the default name from "copy_of_robert" to "bogdan", it will be "bogdan_branch1". I strongly think that there is no point in being able to change the copy name for branching, in the demo you also couldn't do it, but I guess we will work on this in the future.