### PR TITLE
TVB-2606: cache metadata

### DIFF
--- a/framework_tvb/tvb/core/neotraits/_h5accessors.py
+++ b/framework_tvb/tvb/core/neotraits/_h5accessors.py
@@ -93,9 +93,10 @@ class Scalar(Accessor):
         # type: () -> typing.Union[str, int, float]
         # assuming here that the h5 will return the type we stored.
         # if paranoid do self.trait_attribute.field_type(value)
-        metadata = self.owner.storage_manager.get_metadata()
-        if self.field_name in metadata:
-            return metadata[self.field_name]
+        if self.owner.metadata_cache is None:
+            self.owner.metadata_cache = self.owner.storage_manager.get_metadata()
+        if self.field_name in self.owner.metadata_cache:
+            return self.owner.metadata_cache[self.field_name]
         else:
             raise MissingDataSetException(self.field_name)
 

--- a/framework_tvb/tvb/core/neotraits/_h5core.py
+++ b/framework_tvb/tvb/core/neotraits/_h5core.py
@@ -78,6 +78,7 @@ class H5File(object):
         self.user_tag_4 = Scalar(Attr(str), self, name='user_tag_4')
         self.user_tag_5 = Scalar(Attr(str), self, name='user_tag_5')
         self.visible = Scalar(Attr(bool), self, name='visible')
+        self.metadata_cache = None
 
         if not self.storage_manager.is_valid_hdf5_file():
             self.written_by.store(self.__class__.__module__ + '.' + self.__class__.__name__)


### PR DESCRIPTION
Currently, with every HasTraits scalar, we re-read all H5 metadata.
It is not really visible in tvb web GUI as a performance drop, but we could do it smarter