### PR TITLE
TVB-2684 TVB-2679 Review FlowService, add ValueWrapper, unit-tests fixes

### DIFF
--- a/framework_tvb/tvb/adapters/datatypes/db/mapped_value.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/mapped_value.py
@@ -35,8 +35,9 @@
 import json
 from sqlalchemy.orm import relationship
 from sqlalchemy import Column, String, Integer, ForeignKey
-from tvb.core.entities.model.model_datatype import DataType
 from tvb.adapters.datatypes.db.time_series import TimeSeriesIndex
+from tvb.adapters.datatypes.h5.mapped_value_h5 import ValueWrapper
+from tvb.core.entities.model.model_datatype import DataType
 
 
 class ValueWrapperIndex(DataType):
@@ -52,6 +53,13 @@ class ValueWrapperIndex(DataType):
     def display_name(self):
         """ Simple String to be used for display in UI."""
         return "Value Wrapper - " + self.data_name + " : " + str(self.data_value) + " (" + str(self.data_type) + ")"
+
+    def fill_from_has_traits(self, datatype):
+        # type: (ValueWrapper)  -> None
+        super(ValueWrapperIndex, self).fill_from_has_traits(datatype)
+        self.data_value = datatype.data_value
+        self.data_type = datatype.data_type
+        self.data_name = datatype.data_name
 
 
 class DatatypeMeasureIndex(DataType):

--- a/framework_tvb/tvb/adapters/datatypes/h5/mapped_value_h5.py
+++ b/framework_tvb/tvb/adapters/datatypes/h5/mapped_value_h5.py
@@ -28,18 +28,24 @@
 #
 #
 
-from tvb.basic.neotraits.api import Attr
+from tvb.basic.neotraits.api import Attr, HasTraits
 from tvb.datatypes.time_series import TimeSeries
 from tvb.core.neotraits.h5 import H5File, Scalar, Json, Reference
+
+
+class ValueWrapper(HasTraits):
+    data_value = Attr(str)
+    data_type = Attr(str)
+    data_name = Attr(str)
 
 
 class ValueWrapperH5(H5File):
 
     def __init__(self, path):
         super(ValueWrapperH5, self).__init__(path)
-        self.data_value = Scalar(Attr(str), self, name='data_value')
-        self.data_type = Scalar(Attr(str), self, name='data_type')
-        self.data_name = Scalar(Attr(str), self, name='data_name')
+        self.data_value = Scalar(ValueWrapper.data_value, self)
+        self.data_type = Scalar(ValueWrapper.data_type, self)
+        self.data_name = Scalar(ValueWrapper.data_name, self)
 
 
 class DatatypeMeasureH5(H5File):

--- a/framework_tvb/tvb/config/init/datatypes_registry.py
+++ b/framework_tvb/tvb/config/init/datatypes_registry.py
@@ -52,7 +52,7 @@ from tvb.adapters.datatypes.h5.connectivity_h5 import ConnectivityH5
 from tvb.adapters.datatypes.h5.fcd_h5 import FcdH5
 from tvb.adapters.datatypes.h5.graph_h5 import ConnectivityMeasureH5, CorrelationCoefficientsH5, CovarianceH5
 from tvb.adapters.datatypes.h5.local_connectivity_h5 import LocalConnectivityH5
-from tvb.adapters.datatypes.h5.mapped_value_h5 import DatatypeMeasureH5, ValueWrapperH5
+from tvb.adapters.datatypes.h5.mapped_value_h5 import DatatypeMeasureH5, ValueWrapperH5, ValueWrapper
 from tvb.adapters.datatypes.h5.mode_decompositions_h5 import PrincipalComponentsH5, IndependentComponentsH5
 from tvb.adapters.datatypes.h5.patterns_h5 import StimuliRegionH5, StimuliSurfaceH5
 from tvb.adapters.datatypes.h5.projections_h5 import ProjectionMatrixH5
@@ -132,5 +132,5 @@ def populate_datatypes_registry():
     REGISTRY.register_datatype(StimuliSurface, StimuliSurfaceH5, StimuliSurfaceIndex)
     REGISTRY.register_datatype(None, DatatypeMeasureH5, DatatypeMeasureIndex)
     REGISTRY.register_datatype(ConnectivityAnnotations, ConnectivityAnnotationsH5, ConnectivityAnnotationsIndex)
-    REGISTRY.register_datatype(None, ValueWrapperH5, ValueWrapperIndex)
+    REGISTRY.register_datatype(ValueWrapper, ValueWrapperH5, ValueWrapperIndex)
     REGISTRY.register_datatype(Cortex, CortexH5, None)

--- a/framework_tvb/tvb/core/entities/model/model_datatype.py
+++ b/framework_tvb/tvb/core/entities/model/model_datatype.py
@@ -75,7 +75,6 @@ FILTER_CATEGORIES = {'DataType.subject': {'display': 'Subject', 'type': 'string'
                                                    'operations': ['!=', '<', '>']}}
 
 
-
 class DataType(HasTraitsIndex):
     """ 
     Base class for DB storage of Types.
@@ -128,7 +127,6 @@ class DataType(HasTraitsIndex):
             LOG.warning('Could not perform __initdb__: %r', exc)
         super(DataType, self).__init__()
 
-
     def __initdb__(self, subject='', state=None, operation_id=None, fk_parent_burst=None, disk_size=None,
                    user_tag_1=None, user_tag_2=None, user_tag_3=None, user_tag_4=None, user_tag_5=None, **_):
         """Set attributes"""
@@ -142,7 +140,6 @@ class DataType(HasTraitsIndex):
         self.user_tag_5 = user_tag_5
         self.disk_size = disk_size
         self.fk_parent_burst = fk_parent_burst
-
 
     @property
     def display_type(self):
@@ -160,13 +157,11 @@ class DataType(HasTraitsIndex):
                 display_name += " - " + str(tag)
         return display_name
 
-
     def __repr__(self):
         msg = "<DataType(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)>"
         return msg % (str(self.id), self.gid, self.type, self.module,
                       self.subject, self.state, str(self.fk_parent_burst),
                       self.user_tag_1, self.user_tag_2, self.user_tag_3, self.user_tag_4, self.user_tag_5)
-
 
     @staticmethod
     def accepted_filters():
@@ -174,14 +169,6 @@ class DataType(HasTraitsIndex):
         Return accepted UI filters for current DataType.
         """
         return copy(FILTER_CATEGORIES)
-
-
-    def persist_full_metadata(self):
-        """
-        Do nothing here. We will implement this only in MappedType.
-        """
-        pass
-
 
     def fill_from_has_traits(self, has_traits):
         # type: (HasTraits) -> None

--- a/framework_tvb/tvb/core/neotraits/_h5core.py
+++ b/framework_tvb/tvb/core/neotraits/_h5core.py
@@ -149,10 +149,11 @@ class H5File(object):
             else:
                 setattr(datatype, f_name, value)
 
-    def store_generic_attributes(self, generic_attributes):
-        # type: (GenericAttributes) -> None
+    def store_generic_attributes(self, generic_attributes, create=True):
+        # type: (GenericAttributes, bool) -> None
         # write_metadata  creation time, serializer class name, etc
-        self.create_date.store(date2string(datetime.now()))
+        if create:
+            self.create_date.store(date2string(datetime.now()))
 
         self.generic_attributes.fill_from(generic_attributes)
         self.invalid.store(self.generic_attributes.invalid)

--- a/framework_tvb/tvb/core/services/flow_service.py
+++ b/framework_tvb/tvb/core/services/flow_service.py
@@ -125,8 +125,6 @@ class FlowService:
             self.logger.exception('Not found:' + adapter_name + ' in:' + adapter_module)
             raise OperationException("Could not prepare " + adapter_name)
 
-
-    
     @staticmethod
     def get_algorithm_by_module_and_class(module, classname):
         """
@@ -134,16 +132,6 @@ class FlowService:
         class.
         """
         return dao.get_algorithm_by_module(module, classname)
-    
-    
-    @staticmethod
-    def get_available_datatypes(project_id, data_type_cls, filters=None):
-        """
-        Return all dataTypes that match a given name and some filters.
-        :param data_type_cls: either a fully qualified class name or a class object
-        """
-        return get_filtered_datatypes(project_id, data_type_cls, filters)
-
 
     @staticmethod
     def create_link(data_ids, project_id):

--- a/framework_tvb/tvb/core/services/project_service.py
+++ b/framework_tvb/tvb/core/services/project_service.py
@@ -45,6 +45,7 @@ from tvb.core.entities.model.model_datatype import Links, DataType, DataTypeGrou
 from tvb.core.entities.model.model_operation import Operation, OperationGroup
 from tvb.core.entities.model.model_project import Project
 from tvb.core.neocom import h5
+from tvb.core.neotraits.h5 import H5File
 from tvb.core.services.flow_service import FlowService
 from tvb.core.utils import string2date, date2string, format_timedelta, format_bytes_human
 from tvb.core.removers_factory import get_remover
@@ -698,17 +699,11 @@ class ProjectService:
             raise StructureException(str(excep))
 
     def _edit_data(self, datatype, new_data, from_group=False):
+        # type: (DataType, dict, bool) -> None
         """
         Private method, used for editing a meta-data XML file and a DataType row
         for a given custom DataType entity with new dictionary of data from UI.
         """
-        from tvb.basic.traits.types_mapped import MappedType
-
-        if isinstance(datatype, MappedType) and not os.path.exists(datatype.get_storage_file_path()):
-            if not datatype.invalid:
-                datatype.invalid = True
-                dao.store_entity(datatype)
-            return
         # 1. First update Operation fields:
         #    Update group field if possible
         new_group_name = new_data[CommonDetails.CODE_OPERATION_TAG]
@@ -730,27 +725,32 @@ class ProjectService:
             operation.user_group = new_group_name
             dao.store_entity(operation)
 
-        # 2. Update dateType fields:
-        datatype.subject = new_data[DataTypeOverlayDetails.DATA_SUBJECT]
-        datatype.state = new_data[DataTypeOverlayDetails.DATA_STATE]
-        if DataTypeOverlayDetails.DATA_TAG_1 in new_data:
-            datatype.user_tag_1 = new_data[DataTypeOverlayDetails.DATA_TAG_1]
-        if DataTypeOverlayDetails.DATA_TAG_2 in new_data:
-            datatype.user_tag_2 = new_data[DataTypeOverlayDetails.DATA_TAG_2]
-        if DataTypeOverlayDetails.DATA_TAG_3 in new_data:
-            datatype.user_tag_3 = new_data[DataTypeOverlayDetails.DATA_TAG_3]
-        if DataTypeOverlayDetails.DATA_TAG_4 in new_data:
-            datatype.user_tag_4 = new_data[DataTypeOverlayDetails.DATA_TAG_4]
-        if DataTypeOverlayDetails.DATA_TAG_5 in new_data:
-            datatype.user_tag_5 = new_data[DataTypeOverlayDetails.DATA_TAG_5]
+        # 2. Update GenericAttributes on DataType index and in the associated H5 files:
+        h5_path = h5.path_for_stored_index(datatype)
+        with H5File.from_file(h5_path) as f:
+            ga = f.load_generic_attributes()
 
+        ga.subject = new_data[DataTypeOverlayDetails.DATA_SUBJECT]
+        ga.state = new_data[DataTypeOverlayDetails.DATA_STATE]
+        if DataTypeOverlayDetails.DATA_TAG_1 in new_data:
+            ga.user_tag_1 = new_data[DataTypeOverlayDetails.DATA_TAG_1]
+        if DataTypeOverlayDetails.DATA_TAG_2 in new_data:
+            ga.user_tag_2 = new_data[DataTypeOverlayDetails.DATA_TAG_2]
+        if DataTypeOverlayDetails.DATA_TAG_3 in new_data:
+            ga.user_tag_3 = new_data[DataTypeOverlayDetails.DATA_TAG_3]
+        if DataTypeOverlayDetails.DATA_TAG_4 in new_data:
+            ga.user_tag_4 = new_data[DataTypeOverlayDetails.DATA_TAG_4]
+        if DataTypeOverlayDetails.DATA_TAG_5 in new_data:
+            ga.user_tag_5 = new_data[DataTypeOverlayDetails.DATA_TAG_5]
+
+        datatype.fill_from_generic_attributes(ga)
         datatype = dao.store_entity(datatype)
-        # 3. Update MetaData in H5 as well.
-        datatype.persist_full_metadata()
+        # 3. Update MetaData in DT H5 as well.
+        with H5File.from_file(h5_path) as f:
+            f.store_generic_attributes(ga, False)
+
         # 4. Update the group_name/user_group into the operation meta-data file
-        operation = dao.get_operation_by_id(datatype.fk_from_operation)
-        self.structure_helper.update_operation_metadata(operation.project.name, new_group_name,
-                                                        str(datatype.fk_from_operation), from_group)
+        #  TODO update ViewModel of the operation H5
 
     def get_datatype_and_datatypegroup_inputs_for_operation(self, operation_gid, selected_filter):
         """
@@ -890,7 +890,10 @@ class ProjectService:
             """ set visibility flag, persist in db and h5"""
             dt.visible = is_visible
             dt = dao.store_entity(dt)
-            dt.persist_full_metadata()
+
+            h5_path = h5.path_for_stored_index(dt)
+            with H5File.from_file(h5_path) as f:
+                f.visible.store(is_visible)
 
         def set_group_descendants_visibility(datatype_group_id):
             datatypes_in_group = dao.get_datatypes_from_datatype_group(datatype_group_id)

--- a/framework_tvb/tvb/core/services/project_service.py
+++ b/framework_tvb/tvb/core/services/project_service.py
@@ -642,7 +642,7 @@ class ProjectService:
                     operations_set.append(adata.fk_from_operation)
 
             datatype_group = dao.get_datatype_group_by_gid(datatype.gid)
-            dao.remove_datatype(datatype_gid)
+            dao.remove_entity(DataTypeGroup, datatype.id)
             correct = correct and dao.remove_entity(OperationGroup, datatype_group.fk_operation_group)
         else:
             self.logger.debug("Removing datatype %s" % datatype)
@@ -785,6 +785,7 @@ class ProjectService:
         :returns: A list of DataTypes that are used as input parameters for the specified operation.
                  And a dictionary will all operation parameters different then the default ones.
         """
+        # todo rewrite after neotraits TVB-2687
         operation = dao.get_operation_by_gid(operation_gid)
         parameters = json.loads(operation.parameters)
         try:

--- a/framework_tvb/tvb/core/services/project_service.py
+++ b/framework_tvb/tvb/core/services/project_service.py
@@ -904,13 +904,17 @@ class ProjectService:
 
         if isinstance(datatype, DataTypeGroup):  # datatype is a group
             set_group_descendants_visibility(datatype.id)
+            datatype.visible = is_visible
+            dao.store_entity(datatype)
         elif datatype.fk_datatype_group is not None:  # datatype is member of a group
             set_group_descendants_visibility(datatype.fk_datatype_group)
             # the datatype to be updated is the parent datatype group
-            datatype = dao.get_datatype_by_id(datatype.fk_datatype_group)
-
-        # update the datatype or datatype group.
-        set_visibility(datatype)
+            parent = dao.get_datatype_by_id(datatype.fk_datatype_group)
+            parent.visible = is_visible
+            dao.store_entity(parent)
+        else:
+            # update the single datatype.
+            set_visibility(datatype)
 
     @staticmethod
     def is_datatype_group(datatype_gid):

--- a/framework_tvb/tvb/tests/framework/conftest.py
+++ b/framework_tvb/tvb/tests/framework/conftest.py
@@ -527,6 +527,6 @@ def test_adapter_factory():
         if inst_from_db is not None:
             stored_adapter.id = inst_from_db.id
 
-        dao.store_entity(stored_adapter, inst_from_db is not None)
+        return dao.store_entity(stored_adapter, inst_from_db is not None)
 
     return build

--- a/framework_tvb/tvb/tests/framework/conftest.py
+++ b/framework_tvb/tvb/tests/framework/conftest.py
@@ -399,8 +399,8 @@ def value_wrapper_factory():
         view_model = BaseBCTModel()
         view_model.connectivity = get_filtered_datatypes(test_project.id, ConnectivityIndex, page_size=1)[0][0][2]
 
-        importer = ABCAdapter.build_adapter_from_class(TransitivityBinaryDirected)
-        op = FlowService().fire_operation(importer, test_user, test_project.id, view_model=view_model)[0]
+        adapter = ABCAdapter.build_adapter_from_class(TransitivityBinaryDirected)
+        op = FlowService().fire_operation(adapter, test_user, test_project.id, view_model=view_model)[0]
         # wait for the operation to finish
         tries = 5
         while not op.has_finished and tries > 0:

--- a/framework_tvb/tvb/tests/framework/conftest.py
+++ b/framework_tvb/tvb/tests/framework/conftest.py
@@ -28,6 +28,7 @@
 #
 #
 import json
+from time import sleep
 import numpy
 import pytest
 import os.path
@@ -35,17 +36,23 @@ import os
 import datetime
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from tvb.adapters.datatypes.db.mapped_value import DatatypeMeasureIndex
+from tvb.adapters.analyzers.bct_adapters import BaseBCTModel
+from tvb.adapters.analyzers.bct_clustering_adapters import TransitivityBinaryDirected
+from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
+from tvb.adapters.datatypes.db.mapped_value import DatatypeMeasureIndex, ValueWrapperIndex
 from tvb.adapters.datatypes.h5.time_series_h5 import TimeSeriesH5, TimeSeriesRegionH5
 from tvb.adapters.datatypes.db.time_series import TimeSeriesIndex, TimeSeriesRegionIndex
 from tvb.basic.profile import TvbProfile
 from tvb.config.init.introspector_registry import IntrospectionRegistry
+from tvb.core.adapters.abcadapter import ABCAdapter
 from tvb.core.entities.file.files_helper import FilesHelper
+from tvb.core.entities.load import get_filtered_datatypes, try_get_last_datatype
 from tvb.core.entities.model.model_operation import STATUS_FINISHED, Operation, AlgorithmCategory, Algorithm
 from tvb.core.entities.model.model_project import User, Project
 from tvb.core.entities.storage import dao
 from tvb.core.entities.transient.structure_entities import DataTypeMetaData
 from tvb.core.neocom import h5
+from tvb.core.services.flow_service import FlowService
 from tvb.core.services.project_service import ProjectService
 from tvb.datatypes.connectivity import Connectivity
 from tvb.datatypes.region_mapping import RegionMapping
@@ -58,7 +65,6 @@ from tvb.tests.framework.core.base_testcase import Base, OperationGroup, DataTyp
 from tvb.tests.framework.datatypes.dummy_datatype import DummyDataType
 from tvb.tests.framework.datatypes.dummy_datatype_h5 import DummyDataTypeH5
 from tvb.tests.framework.datatypes.dummy_datatype_index import DummyDataTypeIndex
-from tvb.tests.framework.datatypes.dummy_datatype2_index import DummyDataType2Index
 
 
 def pytest_addoption(parser):
@@ -364,25 +370,9 @@ def time_series_region_index_factory(operation_factory):
 
 
 @pytest.fixture()
-def dummy_datatype_factory():
-    def build():
-        return DummyDataType()
-
-    return build
-
-
-@pytest.fixture()
-def dummy_datatype2_index_factory():
-    def build(subject=None, state=None):
-        return DummyDataType2Index(subject=subject, state=state)
-
-    return build
-
-
-@pytest.fixture()
-def dummy_datatype_index_factory(dummy_datatype_factory, operation_factory):
+def dummy_datatype_index_factory(operation_factory):
     def build(row1=None, row2=None, project=None, operation=None, subject=None, state=None):
-        data_type = dummy_datatype_factory()
+        data_type = DummyDataType()
         data_type.row1 = row1
         data_type.row2 = row2
 
@@ -399,6 +389,29 @@ def dummy_datatype_index_factory(dummy_datatype_factory, operation_factory):
 
         data_type_index = dao.store_entity(data_type_index)
         return data_type_index
+
+    return build
+
+
+@pytest.fixture()
+def value_wrapper_factory():
+    def build(test_user, test_project):
+        view_model = BaseBCTModel()
+        view_model.connectivity = get_filtered_datatypes(test_project.id, ConnectivityIndex, page_size=1)[0][0][2]
+
+        importer = ABCAdapter.build_adapter_from_class(TransitivityBinaryDirected)
+        op = FlowService().fire_operation(importer, test_user, test_project.id, view_model=view_model)[0]
+        # wait for the operation to finish
+        tries = 5
+        while not op.has_finished and tries > 0:
+            sleep(5)
+            tries = -1
+            op = dao.get_operation_by_id(op.id)
+
+        value_wrapper = try_get_last_datatype(test_project.id, ValueWrapperIndex)
+        count = dao.count_datatypes(test_project.id, ValueWrapperIndex)
+        assert 1 == count
+        return value_wrapper
 
     return build
 

--- a/framework_tvb/tvb/tests/framework/core/factory.py
+++ b/framework_tvb/tvb/tests/framework/core/factory.py
@@ -45,6 +45,7 @@ import tvb_data
 from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
 from tvb.adapters.datatypes.db.projections import ProjectionMatrixIndex
 from tvb.adapters.datatypes.db.region_mapping import RegionMappingIndex
+from tvb.adapters.datatypes.h5.mapped_value_h5 import ValueWrapper
 from tvb.adapters.uploaders.projection_matrix_importer import ProjectionMatrixImporterModel
 from tvb.adapters.uploaders.projection_matrix_importer import ProjectionMatrixSurfaceEEGImporter
 from tvb.adapters.uploaders.region_mapping_importer import RegionMappingImporterModel, RegionMappingImporter
@@ -55,8 +56,10 @@ from tvb.adapters.uploaders.zip_connectivity_importer import ZIPConnectivityImpo
 from tvb.adapters.uploaders.zip_surface_importer import ZIPSurfaceImporter, ZIPSurfaceImporterModel
 from tvb.adapters.datatypes.db.sensors import SensorsIndex
 from tvb.adapters.datatypes.db.surface import SurfaceIndex
+from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.entities.load import try_get_last_datatype
 from tvb.core.entities.model.model_burst import BurstConfiguration
+from tvb.core.neocom import h5
 from tvb.core.services.burst_service import BurstService
 from tvb.core.neotraits.view_model import ViewModel
 from tvb.core.utils import hash_password
@@ -185,6 +188,20 @@ class TestFactory(object):
 
         resulted_dts = dao.get_datatype_in_group(operation_group_id=operations[0].fk_operation_group)
         return resulted_dts, operations[0].fk_operation_group
+
+    @staticmethod
+    def create_value_wrapper(test_user, test_project=None):
+        """
+        Creates a ValueWrapper dataType, and the associated parent Operation.
+        This is also used in ProjectStructureTest.
+        """
+        if test_project is None:
+            test_project = TestFactory.create_project(test_user, 'test_proj')
+        operation = TestFactory.create_operation(test_user=test_user, test_project=test_project)
+        value_wrapper = ValueWrapper(data_value="5.0", data_name="my_value", data_type="float")
+        op_dir = FilesHelper().get_project_folder(test_project, str(operation.id))
+        vw_idx = h5.store_complete(value_wrapper, op_dir)
+        return test_project, vw_idx.gid, operation.gid
 
     @staticmethod
     def create_adapter(module='tvb.tests.framework.adapters.ndimensionarrayadapter',

--- a/framework_tvb/tvb/tests/framework/core/factory.py
+++ b/framework_tvb/tvb/tests/framework/core/factory.py
@@ -201,7 +201,9 @@ class TestFactory(object):
         value_wrapper = ValueWrapper(data_value="5.0", data_name="my_value", data_type="float")
         op_dir = FilesHelper().get_project_folder(test_project, str(operation.id))
         vw_idx = h5.store_complete(value_wrapper, op_dir)
-        return test_project, vw_idx.gid, operation.gid
+        vw_idx.fk_from_operation = operation.id
+        vw_idx = dao.store_entity(vw_idx)
+        return test_project, vw_idx.gid, operation
 
     @staticmethod
     def create_adapter(module='tvb.tests.framework.adapters.ndimensionarrayadapter',

--- a/framework_tvb/tvb/tests/framework/core/services/flow_service_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/flow_service_test.py
@@ -33,30 +33,20 @@
 .. moduleauthor:: Lia Domide <lia.domide@codemart.ro>
 """
 
-import os
-import numpy
 import pytest
-from datetime import datetime
 from tvb.tests.framework.adapters.testadapter1 import TestAdapter1Form, TestAdapter1, TestModel
 from tvb.tests.framework.core.base_testcase import TransactionalTestCase
 from tvb.config.init.introspector_registry import IntrospectionRegistry
 from tvb.core.adapters.exceptions import IntrospectionException
 from tvb.core.adapters.abcadapter import ABCAdapter, ABCSynchronous
-from tvb.core.entities.filters.chain import FilterChain
 from tvb.core.entities.model import model_operation
 from tvb.core.entities.storage import dao
-from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.services.flow_service import FlowService
-from tvb.tests.framework.datatypes.datatype1 import Datatype1
 from tvb.tests.framework.core.factory import TestFactory
-from tvb.tests.framework.datatypes.dummy_datatype_index import DummyDataTypeIndex
 
 TEST_ADAPTER_VALID_MODULE = "tvb.tests.framework.adapters.testadapter1"
 TEST_ADAPTER_VALID_CLASS = "TestAdapter1"
 TEST_ADAPTER_INVALID_CLASS = "InvalidTestAdapter"
-
-CATEGORY1 = 1
-CATEGORY2 = 2
 
 
 class InvalidTestAdapter(object):
@@ -81,12 +71,10 @@ class TestFlowService(TransactionalTestCase):
         """ Prepare some entities to work with during tests:"""
 
         self.flow_service = FlowService()
-        self.test_user = TestFactory.create_user()
-        self.test_project = TestFactory.create_project(admin=self.test_user)
 
         category = dao.get_uploader_categories()[0]
         self.algorithm = dao.store_entity(model_operation.Algorithm(TEST_ADAPTER_VALID_MODULE,
-                                                          TEST_ADAPTER_VALID_CLASS, category.id))
+                                                                    TEST_ADAPTER_VALID_CLASS, category.id))
 
     def transactional_teardown_method(self):
         dao.remove_entity(model_operation.Algorithm, self.algorithm)
@@ -121,12 +109,13 @@ class TestFlowService(TransactionalTestCase):
         assert IntrospectionRegistry.ISOCLINE_PSE_ADAPTER_CLASS in result_classnames
         assert IntrospectionRegistry.DISCRETE_PSE_ADAPTER_CLASS in result_classnames
 
-    def test_get_launchable_algorithms(self, time_series_region_index_factory, connectivity_factory, region_mapping_factory):
+    def test_get_launchable_algorithms(self, time_series_region_index_factory, connectivity_factory,
+                                       region_mapping_factory):
 
         conn = connectivity_factory()
         rm = region_mapping_factory()
         ts = time_series_region_index_factory(connectivity=conn, region_mapping=rm)
-        result,  has_operations_warning = self.flow_service.get_launchable_algorithms(ts.gid)
+        result, has_operations_warning = self.flow_service.get_launchable_algorithms(ts.gid)
         assert 'Analyze' in result
         assert 'View' in result
         assert has_operations_warning is False
@@ -168,118 +157,14 @@ class TestFlowService(TransactionalTestCase):
         assert adapter.get_form_class() == TestAdapter1Form
         assert adapter.get_view_model() == TestModel
 
-
     def test_fire_operation(self):
         """
         Test preparation of an adapter and launch mechanism.
         """
         adapter = TestFactory.create_adapter(TEST_ADAPTER_VALID_MODULE, TEST_ADAPTER_VALID_CLASS)
-        result = self.flow_service.fire_operation(adapter, self.test_user, self.test_project.id, view_model=adapter.get_view_model()())
+        test_user = TestFactory.create_user()
+        test_project = TestFactory.create_project(admin=test_user)
+
+        result = self.flow_service.fire_operation(adapter, test_user, test_project.id,
+                                                  view_model=adapter.get_view_model()())
         assert result.endswith("has finished."), "Operation fail"
-
-    def test_get_filtered_by_column(self):
-        """
-        Test the filter function when retrieving dataTypes with a filter
-        after a column from a class specific table (e.g. DATA_arraywrapper).
-        """
-        operation_1 = TestFactory.create_operation(test_user=self.test_user, test_project=self.test_project)
-        operation_2 = TestFactory.create_operation(test_user=self.test_user, test_project=self.test_project)
-
-        one_dim_array = numpy.arange(5)
-        two_dim_array = numpy.array([[1, 2], [2, 3], [1, 4]])
-        self._store_float_array(one_dim_array, "John Doe 1", operation_1.id)
-        self._store_float_array(one_dim_array, "John Doe 2", operation_1.id)
-        self._store_float_array(two_dim_array, "John Doe 3", operation_2.id)
-
-        count = self.flow_service.get_available_datatypes(self.test_project.id, "tvb.datatypes.arrays.MappedArray")[1]
-        assert count, 3 == "Problems with inserting data"
-        first_filter = FilterChain(fields=[FilterChain.datatype + '._nr_dimensions'], operations=["=="], values=[1])
-        count = self.flow_service.get_available_datatypes(self.test_project.id,
-                                                          "tvb.datatypes.arrays.MappedArray", first_filter)[1]
-        assert count, 2 == "Data was not filtered"
-
-        second_filter = FilterChain(fields=[FilterChain.datatype + '._nr_dimensions'], operations=["=="], values=[2])
-        filtered_data = self.flow_service.get_available_datatypes(self.test_project.id,
-                                                                  "tvb.datatypes.arrays.MappedArray", second_filter)[0]
-        assert len(filtered_data), 1 == "Data was not filtered"
-        assert filtered_data[0][3] == "John Doe 3"
-
-        third_filter = FilterChain(fields=[FilterChain.datatype + '._length_1d'], operations=["=="], values=[3])
-        filtered_data = self.flow_service.get_available_datatypes(self.test_project.id,
-                                                                  "tvb.datatypes.arrays.MappedArray", third_filter)[0]
-        assert len(filtered_data), 1 == "Data was not filtered correct"
-        assert filtered_data[0][3] == "John Doe 3"
-        try:
-            if os.path.exists('One_dim.txt'):
-                os.remove('One_dim.txt')
-            if os.path.exists('Two_dim.txt'):
-                os.remove('Two_dim.txt')
-            if os.path.exists('One_dim-1.txt'):
-                os.remove('One_dim-1.txt')
-        except Exception:
-            pass
-
-    @staticmethod
-    def _store_float_array(array_data, subject_name, operation_id):
-        """Create Float Array and DB persist it"""
-        datatype_inst = MappedArray(user_tag_1=subject_name)
-        datatype_inst.set_operation_id(operation_id)
-        datatype_inst.array_data = array_data
-        datatype_inst.type = "MappedArray"
-        datatype_inst.module = "tvb.datatypes.arrays"
-        datatype_inst.subject = subject_name
-        datatype_inst.state = "RAW"
-        dao.store_entity(datatype_inst)
-
-    def test_get_filtered_datatypes(self, dummy_datatype_index_factory):
-        """
-        Test the filter function when retrieving dataTypes.
-        """
-        #Create some test operations
-        start_dates = [datetime.now(),
-                       datetime.strptime("08-06-2010", "%m-%d-%Y"),
-                       datetime.strptime("07-21-2010", "%m-%d-%Y"),
-                       datetime.strptime("05-06-2010", "%m-%d-%Y"),
-                       datetime.strptime("07-21-2011", "%m-%d-%Y")]
-        end_dates = [datetime.now(),
-                     datetime.strptime("08-12-2010", "%m-%d-%Y"),
-                     datetime.strptime("08-12-2010", "%m-%d-%Y"),
-                     datetime.strptime("08-12-2011", "%m-%d-%Y"),
-                     datetime.strptime("08-12-2011", "%m-%d-%Y")]
-        for i in range(5):
-            operation = model_operation.Operation(self.test_user.id, self.test_project.id, self.algorithm.id, 'test params',
-                                        status=model_operation.STATUS_FINISHED, start_date=start_dates[i],
-                                        completion_date=end_dates[i])
-            operation = dao.store_entity(operation)
-            storage_path = FilesHelper().get_project_folder(self.test_project, str(operation.id))
-            if i < 4:
-                datatype_inst = dummy_datatype_index_factory()
-                datatype_inst.type = "DummyDataTypeIndex"
-                datatype_inst.subject = "John Doe" + str(i)
-                datatype_inst.state = "RAW"
-                datatype_inst.fk_from_operation = operation.id
-                dao.store_entity(datatype_inst)
-            else:
-                for _ in range(2):
-                    datatype_inst = dummy_datatype_index_factory()
-                    datatype_inst.storage_path = storage_path
-                    datatype_inst.type = "DummyDataTypeIndex"
-                    datatype_inst.subject = "John Doe" + str(i)
-                    datatype_inst.state = "RAW"
-                    datatype_inst.string_data = ["data"]
-                    datatype_inst.fk_from_operation = operation.id
-                    dao.store_entity(datatype_inst)
-
-        returned_data = self.flow_service.get_available_datatypes(self.test_project.id, DummyDataTypeIndex)[0]
-        for row in returned_data:
-            if row[1] != 'DummyDataTypeIndex':
-                raise AssertionError("Some invalid data was returned!")
-        assert 4 == len(returned_data), "Invalid length of result"
-
-        filter_op = FilterChain(fields=[FilterChain.datatype + ".state", FilterChain.operation + ".start_date"],
-                                values=["RAW", datetime.strptime("08-01-2010", "%m-%d-%Y")], operations=["==", ">"])
-        returned_data = self.flow_service.get_available_datatypes(self.test_project.id, Datatype1, filter_op)[0]
-        returned_subjects = [one_data[3] for one_data in returned_data]
-
-        if "John Doe0" not in returned_subjects or "John Doe1" not in returned_subjects or len(returned_subjects) != 2:
-            raise AssertionError("DataTypes were not filtered properly!")

--- a/framework_tvb/tvb/tests/framework/core/services/flow_service_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/flow_service_test.py
@@ -38,7 +38,7 @@ from tvb.tests.framework.adapters.testadapter1 import TestAdapter1Form, TestAdap
 from tvb.tests.framework.core.base_testcase import TransactionalTestCase
 from tvb.config.init.introspector_registry import IntrospectionRegistry
 from tvb.core.adapters.exceptions import IntrospectionException
-from tvb.core.adapters.abcadapter import ABCAdapter, ABCSynchronous
+from tvb.core.adapters.abcadapter import ABCAdapter
 from tvb.core.entities.model import model_operation
 from tvb.core.entities.storage import dao
 from tvb.core.services.flow_service import FlowService
@@ -129,14 +129,6 @@ class TestFlowService(TransactionalTestCase):
         assert algo_ret.module == self.algorithm.module, "Modules are different!"
         assert algo_ret.fk_category == self.algorithm.fk_category, "Categories are different!"
         assert algo_ret.classname == self.algorithm.classname, "Class names are different!"
-
-    def test_build_adapter_instance(self, test_adapter_factory):
-        """
-        Test standard flow for building an adapter instance.
-        """
-        test_adapter_factory()
-        adapter = TestFactory.create_adapter(TEST_ADAPTER_VALID_MODULE, TEST_ADAPTER_VALID_CLASS)
-        assert isinstance(adapter, ABCSynchronous), "Something went wrong with valid data!"
 
     def test_build_adapter_invalid(self):
         """

--- a/framework_tvb/tvb/tests/framework/core/services/import_service_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/import_service_test.py
@@ -36,168 +36,133 @@ import os
 import tvb_data
 import shutil
 import pytest
-import numpy
-from tvb.tests.framework.core.base_testcase import TransactionalTestCase
-from tvb.basic.profile import TvbProfile
-from tvb.core.entities.storage import dao
-from tvb.core.entities.file.files_helper import FilesHelper
-from tvb.core.services.import_service import ImportService
-from tvb.core.services.flow_service import FlowService
-from tvb.core.services.project_service import ProjectService
-from tvb.core.services.operation_service import OperationService
-from tvb.core.services.exceptions import ProjectImportException
-from tvb.core.adapters.abcadapter import ABCAdapter
+from time import sleep
+from tvb.adapters.analyzers.bct_adapters import BaseBCTModel
+from tvb.adapters.analyzers.bct_clustering_adapters import TransitivityBinaryDirected
+from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
+from tvb.adapters.datatypes.db.mapped_value import ValueWrapperIndex
 from tvb.adapters.exporters.export_manager import ExportManager
-from tvb.datatypes.time_series import TimeSeries
+from tvb.basic.profile import TvbProfile
+from tvb.core.adapters.abcadapter import ABCAdapter
+from tvb.core.entities.storage import dao
+from tvb.core.entities.load import try_get_last_datatype, get_filtered_datatypes
+from tvb.core.services.flow_service import FlowService
+from tvb.core.services.import_service import ImportService
+from tvb.core.services.project_service import ProjectService
+from tvb.core.services.exceptions import ProjectImportException
 from tvb.tests.framework.core.factory import TestFactory
-from tvb.tests.framework.adapters.storeadapter import StoreAdapter
+from tvb.tests.framework.core.base_testcase import BaseTestCase
 
 
-
-class TestImportService(TransactionalTestCase):
+class TestImportService(BaseTestCase):
     """
     This class contains tests for the tvb.core.services.import_service module.
-    """  
-    
-    def transactional_setup_method(self):
+    """
+
+    def setup_method(self):
         """
         Reset the database before each test.
         """
         self.import_service = ImportService()
-        self.flow_service = FlowService()
         self.project_service = ProjectService()
-        
-        self.test_user = TestFactory.create_user()
-        self.test_project = TestFactory.create_project(self.test_user, name="GeneratedProject", description="test_desc")
-        self.operation = TestFactory.create_operation(test_user=self.test_user, test_project=self.test_project)
-        self.adapter_instance = TestFactory.create_adapter()
-        zip_path = os.path.join(os.path.dirname(tvb_data.__file__), 'connectivity', 'connectivity_66.zip')
-        TestFactory.import_zip_connectivity(self.test_user, self.test_project, zip_path)
-        self.zip_path = None 
-        
+        self.zip_path = None
 
-    def transactional_teardown_method(self):
+    def teardown_method(self):
         """
         Reset the database when test is done.
         """
-        ### Delete TEMP folder
+        # Delete TEMP folder
         if os.path.exists(TvbProfile.current.TVB_TEMP_FOLDER):
             shutil.rmtree(TvbProfile.current.TVB_TEMP_FOLDER)
-        
-        ### Delete folder where data was exported
+
+        # Delete folder where data was exported
         if self.zip_path and os.path.exists(self.zip_path):
             shutil.rmtree(os.path.split(self.zip_path)[0])
-            
+
         self.delete_project_folders()
 
-            
-    def test_import_export(self):
+    def test_import_export(self, user_factory, project_factory):
         """
         Test the import/export mechanism for a project structure.
         The project contains the following data types: Connectivity, Surface, MappedArray and ValueWrapper.
         """
+        test_user = user_factory()
+        test_project = project_factory(test_user, "TestImportExport")
+        zip_path = os.path.join(os.path.dirname(tvb_data.__file__), 'connectivity', 'connectivity_66.zip')
+        TestFactory.import_zip_connectivity(test_user, test_project, zip_path)
+        value_wrapper = self._create_value_wrapper(test_user, test_project)
+
         result = self.get_all_datatypes()
         expected_results = {}
         for one_data in result:
             expected_results[one_data.gid] = (one_data.module, one_data.type)
-        
-        #create an array mapped in DB
-        data = {'param_1': 'some value'}
-        OperationService().initiate_prelaunch(self.operation, self.adapter_instance, {}, **data)
-        inserted = self.flow_service.get_available_datatypes(self.test_project.id,
-                                                             "tvb.datatypes.arrays.MappedArray")[1]
-        assert 1 == inserted, "Problems when inserting data"
-        
-        #create a value wrapper
-        value_wrapper = self._create_value_wrapper()
-        count_operations = dao.get_filtered_operations(self.test_project.id, None, is_count=True)
-        assert 2 == count_operations, "Invalid ops number before export!"
 
         # Export project as ZIP
-        self.zip_path = ExportManager().export_project(self.test_project)
+        self.zip_path = ExportManager().export_project(test_project)
         assert self.zip_path is not None, "Exported file is none"
-        
+
         # Remove the original project
-        self.project_service.remove_project(self.test_project.id)
-        result, lng_ = self.project_service.retrieve_projects_for_user(self.test_user.id)
+        self.project_service.remove_project(test_project.id)
+        result, lng_ = self.project_service.retrieve_projects_for_user(test_user.id)
         assert 0 == len(result), "Project Not removed!"
         assert 0 == lng_, "Project Not removed!"
-        
+
         # Now try to import again project
-        self.import_service.import_project_structure(self.zip_path, self.test_user.id)
-        result = self.project_service.retrieve_projects_for_user(self.test_user.id)[0]
+        self.import_service.import_project_structure(self.zip_path, test_user.id)
+        result = self.project_service.retrieve_projects_for_user(test_user.id)[0]
         assert len(result) == 1, "There should be only one project."
         assert result[0].name == "GeneratedProject", "The project name is not correct."
         assert result[0].description == "test_desc", "The project description is not correct."
-        self.test_project = result[0]
-        
-        count_operations = dao.get_filtered_operations(self.test_project.id, None, is_count=True)
-        
-        #1 op. - import cff; 2 op. - save the array wrapper;
+        test_project = result[0]
+
+        count_operations = dao.get_filtered_operations(test_project.id, None, is_count=True)
+
+        # 1 op. - import conn; 2 op. - BCT Analyzer
         assert 2 == count_operations, "Invalid ops number after export and import !"
         for gid in expected_results:
             datatype = dao.get_datatype_by_gid(gid)
             assert datatype.module == expected_results[gid][0], 'DataTypes not imported correctly'
             assert datatype.type == expected_results[gid][1], 'DataTypes not imported correctly'
-        #check the value wrapper
-        new_val = self.flow_service.get_available_datatypes(self.test_project.id, 
-                                                            "tvb.datatypes.mapped_values.ValueWrapper")[0]
-        assert 1 == len(new_val), "One !=" + str(len(new_val))
-        new_val = ABCAdapter.load_entity_by_gid(new_val[0][2])
+        # check the value wrapper
+        new_val = try_get_last_datatype(test_project.id, ValueWrapperIndex)
         assert value_wrapper.data_value == new_val.data_value, "Data value incorrect"
         assert value_wrapper.data_type == new_val.data_type, "Data type incorrect"
         assert value_wrapper.data_name == new_val.data_name, "Data name incorrect"
-        
 
-    def test_import_export_existing(self):
+    def test_import_export_existing(self, user_factory, project_factory):
         """
         Test the import/export mechanism for a project structure.
         The project contains the following data types: Connectivity, Surface, MappedArray and ValueWrapper.
         """
-        count_operations = dao.get_filtered_operations(self.test_project.id, None, is_count=True)
-        assert 2 == count_operations, "Invalid ops before export!"
+        test_user = user_factory()
+        test_project = project_factory(test_user, "TestImportExport2")
+        zip_path = os.path.join(os.path.dirname(tvb_data.__file__), 'connectivity', 'connectivity_66.zip')
+        TestFactory.import_zip_connectivity(test_user, test_project, zip_path)
 
-        self.zip_path = ExportManager().export_project(self.test_project)
+        count_operations = dao.get_filtered_operations(test_project.id, None, is_count=True)
+        assert 1 == count_operations, "Invalid ops before export!"
+
+        self.zip_path = ExportManager().export_project(test_project)
         assert self.zip_path is not None, "Exported file is none"
 
         with pytest.raises(ProjectImportException):
-            self.import_service.import_project_structure(self.zip_path, self.test_user.id)
+            self.import_service.import_project_structure(self.zip_path, test_user.id)
 
+    def _create_value_wrapper(self, test_user, test_project):
 
-    def _create_timeseries(self):
-        """Launch adapter to persist a TimeSeries entity"""
-        activity_data = numpy.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]])
-        time_data = numpy.array([1, 2, 3])
-        storage_path = FilesHelper().get_project_folder(self.test_project)
-        time_series = TimeSeries(time_files=None, activity_files=None, 
-                                 max_chunk=10, maxes=None, mins=None, data_shape=numpy.shape(activity_data), 
-                                 storage_path=storage_path, label_y="Time", time_data=time_data, data_name='TestSeries',
-                                 activity_data=activity_data, sample_period=10.0)
-        self._store_entity(time_series, "TimeSeries", "tvb.datatypes.time_series")
-        timeseries_count = self.flow_service.get_available_datatypes(self.test_project.id,
-                                                                     "tvb.datatypes.time_series.TimeSeries")[1]
-        assert timeseries_count == 1, "Should be only one TimeSeries"
+        view_model = BaseBCTModel()
+        view_model.connectivity = get_filtered_datatypes(test_project.id, ConnectivityIndex, page_size=1)[0][0][2]
 
+        importer = ABCAdapter.build_adapter_from_class(TransitivityBinaryDirected)
+        op = FlowService().fire_operation(importer, test_user, test_project.id, view_model=view_model)[0]
+        # wait for the operation to finish
+        tries = 5
+        while not op.has_finished and tries > 0:
+            sleep(5)
+            tries = -1
+            op = dao.get_operation_by_id(op.id)
 
-    def _create_value_wrapper(self):
-        """Persist ValueWrapper"""
-        value_ = ValueWrapper(data_value=5.0, data_name="my_value")
-        self._store_entity(value_, "ValueWrapper", "tvb.datatypes.mapped_values")
-        valuew = self.flow_service.get_available_datatypes(self.test_project.id,
-                                                           "tvb.datatypes.mapped_values.ValueWrapper")[0]
-        assert len(valuew) == 1, "Should be only one value wrapper"
-        return ABCAdapter.load_entity_by_gid(valuew[0][2])
-
-
-    def _store_entity(self, entity, type_, module):
-        """Launch adapter to store a create a persistent DataType."""
-        entity.type = type_
-        entity.module = module
-        entity.subject = "John Doe"
-        entity.state = "RAW_STATE"
-        entity.set_operation_id(self.operation.id)
-        adapter_instance = StoreAdapter([entity])
-        OperationService().initiate_prelaunch(self.operation, adapter_instance, {})
-
-
-
+        value_wrapper = try_get_last_datatype(test_project.id, ValueWrapperIndex)
+        count = dao.count_datatypes(test_project.id, ValueWrapperIndex)
+        assert count == 1
+        return value_wrapper

--- a/framework_tvb/tvb/tests/framework/core/services/operation_service_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/operation_service_test.py
@@ -93,8 +93,7 @@ class TestOperationService(BaseTestCase):
         all_operations = dao.get_filtered_operations(self.test_project.id, None)
         assert len(all_operations) == 0, "There should be no operation"
 
-        test_adapter_factory(TestAdapter3)
-        algo = dao.get_algorithm_by_module('tvb.tests.framework.adapters.testadapter3', 'TestAdapter3')
+        algo = test_adapter_factory(TestAdapter3)
         adapter_instance = ABCAdapter.build_adapter(algo)
         data = {model_burst.RANGE_PARAMETER_1: 'param_5', 'param_5': [1, 2]}
         ## Create Group of operations

--- a/framework_tvb/tvb/tests/framework/core/services/project_service_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/project_service_test.py
@@ -367,7 +367,7 @@ class TestProjectService(TransactionalTestCase):
                 else:
                     assert value == new_datatype.parent_operation.user_group
 
-    def test_remove_project_node(self, test_adapter_factory):
+    def test_remove_project_node(self):
         """
         Test removing of a node from a project.
         """

--- a/framework_tvb/tvb/tests/framework/core/services/project_service_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/project_service_test.py
@@ -36,22 +36,19 @@ import shutil
 import pytest
 import tvb_data
 from tvb.basic.profile import TvbProfile
-from tvb.core.adapters.abcadapter import ABCAdapter
 from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.entities.file.xml_metadata_handlers import XMLReader
 from tvb.core.entities.model import model_datatype, model_project, model_operation
 from tvb.core.entities.storage import dao
 from tvb.core.entities.transient.context_overlay import DataTypeOverlayDetails
 from tvb.core.entities.transient.structure_entities import DataTypeMetaData
+from tvb.core.neocom import h5
 from tvb.core.services.exceptions import ProjectServiceException
 from tvb.core.services.flow_service import FlowService
-from tvb.core.services.operation_service import OperationService
 from tvb.core.services.project_service import ProjectService, PROJECTS_PAGE_SIZE
-from tvb.tests.framework.adapters.storeadapter import StoreAdapter
 from tvb.tests.framework.core.base_testcase import TransactionalTestCase
 from tvb.tests.framework.core.factory import TestFactory, ExtremeTestFactory
 from tvb.tests.framework.datatypes.datatype1 import Datatype1
-
 
 NR_USERS = 20
 MAX_PROJ_PER_USER = 8
@@ -355,30 +352,6 @@ class TestProjectService(TransactionalTestCase):
         with pytest.raises(ProjectServiceException):
             self.project_service.remove_project(99)
 
-    @staticmethod
-    def _create_value_wrapper(test_user, test_project=None):
-        """
-        Creates a ValueWrapper dataType, and the associated parent Operation.
-        This is also used in ProjectStructureTest.
-        """
-        if test_project is None:
-            test_project = TestFactory.create_project(test_user, 'test_proj')
-        operation = TestFactory.create_operation(test_user=test_user, test_project=test_project)
-        value_wrapper = ValueWrapper(data_value=5.0, data_name="my_value")
-        value_wrapper.type = "ValueWrapper"
-        value_wrapper.module = "tvb.datatypes.mapped_values"
-        value_wrapper.subject = "John Doe"
-        value_wrapper.state = "RAW_STATE"
-        value_wrapper.set_operation_id(operation.id)
-        adapter_instance = StoreAdapter([value_wrapper])
-        OperationService().initiate_prelaunch(operation, adapter_instance, {})
-        all_value_wrappers = FlowService().get_available_datatypes(test_project.id,
-                                                                   "tvb.datatypes.mapped_values.ValueWrapper")[0]
-        if len(all_value_wrappers) != 1:
-            raise Exception("Should be only one value wrapper.")
-        result_vw = ABCAdapter.load_entity_by_gid(all_value_wrappers[0][2])
-        return test_project, result_vw.gid, operation.gid
-
     def __check_meta_data(self, expected_meta_data, new_datatype):
         """Validate Meta-Data"""
         mapp_keys = {DataTypeMetaData.KEY_SUBJECT: "subject", DataTypeMetaData.KEY_STATE: "state"}
@@ -398,44 +371,38 @@ class TestProjectService(TransactionalTestCase):
         """
         Test removing of a node from a project.
         """
-        inserted_project, gid, gid_op = self._create_value_wrapper(self.test_user)
+        inserted_project, gid, op = TestFactory.create_value_wrapper(self.test_user)
         project_to_link = model_project.Project("Link", self.test_user.id, "descript")
         project_to_link = dao.store_entity(project_to_link)
         exact_data = dao.get_datatype_by_gid(gid)
+        assert exact_data is not None, "Initialization problem!"
         dao.store_entity(model_datatype.Links(exact_data.id, project_to_link.id))
-        assert dao.get_datatype_by_gid(gid) is not None, "Initialization problem!"
 
-        operation_id = dao.get_generic_entity(model_operation.Operation, gid_op, 'gid')[0].id
-        op_folder = self.structure_helper.get_project_folder("test_proj", str(operation_id))
-        assert os.path.exists(op_folder)
-        sub_files = os.listdir(op_folder)
-        assert 2 == len(sub_files)
-        ### Validate that no more files are created than needed.
+        vw_h5_path = h5.path_for_stored_index(exact_data)
+        assert os.path.exists(vw_h5_path)
 
-        if (dao.get_system_user() is None):
+        if dao.get_system_user() is None:
             dao.store_entity(model_operation.User(TvbProfile.current.web.admin.SYSTEM_USER_NAME,
                                                   TvbProfile.current.web.admin.SYSTEM_USER_NAME, None, None, True,
                                                   None))
-        self.project_service._remove_project_node_files(inserted_project.id, gid)
-        sub_files = os.listdir(op_folder)
-        assert 1 == len(sub_files)
-        ### operation.xml file should still be there
 
-        op_folder = self.structure_helper.get_project_folder("Link", str(operation_id + 1))
-        sub_files = os.listdir(op_folder)
-        assert 2 == len(sub_files)
-        assert dao.get_datatype_by_gid(gid) is not None, "Data should still be in DB, because of links"
+        self.project_service._remove_project_node_files(inserted_project.id, gid)
+
+        assert not os.path.exists(vw_h5_path)
+        exact_data = dao.get_datatype_by_gid(gid)
+        assert exact_data  is not None, "Data should still be in DB, because of links"
+        vw_h5_path_new = h5.path_for_stored_index(exact_data)
+        assert os.path.exists(vw_h5_path_new)
+        assert vw_h5_path_new != vw_h5_path
+
         self.project_service._remove_project_node_files(project_to_link.id, gid)
         assert dao.get_datatype_by_gid(gid) is None
-        sub_files = os.listdir(op_folder)
-        assert 1 == len(sub_files)
-        ### operation.xml file should still be there
 
     def test_update_meta_data_simple(self):
         """
         Test the new update metaData for a simple data that is not part of a group.
         """
-        inserted_project, gid, _ = self._create_value_wrapper(self.test_user)
+        inserted_project, gid, _ = TestFactory.create_value_wrapper(self.test_user)
         new_meta_data = {DataTypeOverlayDetails.DATA_SUBJECT: "new subject",
                          DataTypeOverlayDetails.DATA_STATE: "second_state",
                          DataTypeOverlayDetails.CODE_GID: gid,

--- a/framework_tvb/tvb/tests/framework/core/services/project_service_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/project_service_test.py
@@ -412,6 +412,7 @@ class TestProjectService(TransactionalTestCase):
         new_datatype = dao.get_datatype_by_gid(gid)
         self.__check_meta_data(new_meta_data, new_datatype)
 
+        # TODO Change bellow to check the Operation ViewModel H5 instead of the old Operation.xml
         op_path = FilesHelper().get_operation_meta_file_path(inserted_project.name, new_datatype.parent_operation.id)
         op_meta = XMLReader(op_path).read_metadata()
         assert op_meta['user_group'] == 'new user group', 'UserGroup not updated!'

--- a/framework_tvb/tvb/tests/framework/core/services/project_structure_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/project_structure_test.py
@@ -34,7 +34,6 @@
 """
 import numpy
 import pytest
-from tvb.adapters.datatypes.h5.mapped_value_h5 import ValueWrapper
 from tvb.core.entities.load import get_filtered_datatypes
 from tvb.core.neocom import h5
 from tvb.core.entities.model.model_operation import *
@@ -550,20 +549,6 @@ class TestProjectStructure(TransactionalTestCase):
                               meta=json.dumps(meta), status=STATUS_FINISHED)
         return dao.store_entity(operation)
 
-    @staticmethod
-    def _create_value_wrapper(test_user, test_project=None):
-        """
-        Creates a ValueWrapper dataType, and the associated parent Operation.
-        This is also used in ProjectStructureTest.
-        """
-        if test_project is None:
-            test_project = TestFactory.create_project(test_user, 'test_proj')
-        operation = TestFactory.create_operation(test_user=test_user, test_project=test_project)
-        value_wrapper = ValueWrapper(data_value="5.0", data_name="my_value", data_type="float")
-        op_dir = FilesHelper().get_project_folder(test_project, str(operation.id))
-        vw_idx = h5.store_complete(value_wrapper, op_dir)
-        return test_project, vw_idx.gid, operation.gid
-
     def _create_operations_with_inputs(self, datatype_group, is_group_parent=False):
         """
         Method used for creating a complex tree of operations.
@@ -575,7 +560,7 @@ class TestProjectStructure(TransactionalTestCase):
         if is_group_parent:
             datatype_gid = group_dts[0].gid
         else:
-            datatype_gid = self._create_value_wrapper(self.test_user, self.test_project)[1]
+            datatype_gid = TestFactory.create_value_wrapper(self.test_user, self.test_project)[1]
 
         parameters = json.dumps({"param_name": datatype_gid})
 

--- a/framework_tvb/tvb/tests/framework/core/services/project_structure_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/project_structure_test.py
@@ -316,8 +316,7 @@ class TestProjectStructure(TransactionalTestCase):
         Tests method get_datatype_and_datatypegroup_inputs_for_operation.
         Verifies filters' influence over results is as expected
         """
-        test_adapter_factory(adapter_class=TestAdapter3)
-        algo = dao.get_algorithm_by_module('tvb.tests.framework.adapters.testadapter3', 'TestAdapter3')
+        algo = test_adapter_factory(adapter_class=TestAdapter3)
         array_wrappers = array_factory(self.test_project)
         ids = []
         for datatype in array_wrappers:
@@ -381,9 +380,7 @@ class TestProjectStructure(TransactionalTestCase):
         params_1 = json.dumps({"param_5": "1", "param_1": datatypes[0].gid, "param_6": "2"})
         params_2 = json.dumps({"param_5": "1", "param_4": datatypes[1].gid, "param_6": "5"})
 
-        test_adapter_factory(adapter_class=TestAdapter3)
-        algo = dao.get_algorithm_by_module('tvb.tests.framework.adapters.testadapter3', 'TestAdapter3')
-
+        algo = test_adapter_factory(adapter_class=TestAdapter3)
         op1 = Operation(self.test_user.id, self.test_project.id, algo.id, params_1, op_group_id=op_group.id)
         op2 = Operation(self.test_user.id, self.test_project.id, algo.id, params_2, op_group_id=op_group.id)
         dao.store_entities([op1, op2])
@@ -434,9 +431,7 @@ class TestProjectStructure(TransactionalTestCase):
         params_2 = json.dumps({"param_5": "5", "param_3": array_wrappers[2][2],
                                "param_2": array_wrappers[1][2], "param_6": "6"})
 
-        test_adapter_factory(adapter_class=TestAdapter3)
-        algo = dao.get_algorithm_by_module('tvb.tests.framework.adapters.testadapter3', 'TestAdapter3')
-
+        algo = test_adapter_factory(adapter_class=TestAdapter3)
         op1 = Operation(self.test_user.id, self.test_project.id, algo.id, params_1, op_group_id=op_group.id)
         op2 = Operation(self.test_user.id, self.test_project.id, algo.id, params_2, op_group_id=op_group.id)
         dao.store_entities([op1, op2])

--- a/framework_tvb/tvb/tests/framework/core/services/remove_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/remove_test.py
@@ -32,35 +32,30 @@
 .. moduleauthor:: Bogdan Neacsa <bogdan.neacsa@codemart.ro>
 .. moduleauthor:: Ionel Ortelecan <ionel.ortelecan@codemart.ro>
 """
-
-import numpy
-from tvb.tests.framework.core.base_testcase import TransactionalTestCase
+from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
+from tvb.adapters.datatypes.db.local_connectivity import LocalConnectivityIndex
+from tvb.adapters.datatypes.db.mapped_value import ValueWrapperIndex
+from tvb.adapters.datatypes.db.region_mapping import RegionMappingIndex
+from tvb.adapters.datatypes.db.surface import SurfaceIndex
+from tvb.adapters.datatypes.db.time_series import TimeSeriesRegionIndex
+from tvb.core.entities.filters.chain import FilterChain
+from tvb.core.entities.load import try_get_last_datatype, get_filtered_datatypes
 from tvb.core.entities.storage import dao
 from tvb.core.entities.model.model_datatype import DataType, Project
-from tvb.core.entities.file.files_helper import FilesHelper
+from tvb.core.neocom import h5
 from tvb.core.services.import_service import ImportService
 from tvb.core.services.flow_service import FlowService
 from tvb.core.services.project_service import ProjectService
-from tvb.core.services.operation_service import OperationService
 from tvb.core.services.exceptions import RemoveDataTypeException
-from tvb.core.adapters.abcadapter import ABCAdapter
-#from tvb.datatypes.arrays import MappedArray
-#from tvb.datatypes.mapped_values import ValueWrapper
-from tvb.datatypes.time_series import TimeSeries
-from tvb.datatypes.connectivity import Connectivity
-from tvb.datatypes.surfaces import Surface
-from tvb.datatypes.region_mapping import RegionMapping
-from tvb.datatypes.local_connectivity import LocalConnectivity
+from tvb.datatypes.surfaces import CORTICAL
 from tvb.tests.framework.core.factory import TestFactory
-from tvb.tests.framework.adapters.storeadapter import StoreAdapter
-
+from tvb.tests.framework.core.base_testcase import TransactionalTestCase
 
 
 class TestRemove(TransactionalTestCase):
     """
     This class contains tests for the service layer related to remove of DataTypes.
     """
-
 
     def transactional_setup_method(self):
         """
@@ -79,8 +74,6 @@ class TestRemove(TransactionalTestCase):
 
         self.test_project = TestFactory.import_default_project(self.test_user)
         self.operation = TestFactory.create_operation(test_user=self.test_user, test_project=self.test_project)
-        self.adapter_instance = TestFactory.create_adapter()
-
 
     def transactional_teardown_method(self):
         """
@@ -88,61 +81,64 @@ class TestRemove(TransactionalTestCase):
         """
         self.delete_project_folders()
 
-
     def test_remove_used_connectivity(self):
         """
         Tests the remove of a connectivity which is used by other data types
+        TODO: TVB-2688
         """
-        conn, conn_count = self.flow_service.get_available_datatypes(self.test_project.id, Connectivity)
-        count_rm = self.count_all_entities(RegionMapping)
-        assert 1 == conn_count
+        conn = try_get_last_datatype(self.test_project.id, ConnectivityIndex)
+        assert conn is not None
+        conn_gid = conn.gid
+        count_rm = self.count_all_entities(RegionMappingIndex)
         assert 1 == count_rm
 
-        conn_gid = conn[0][2]
         try:
-            self.project_service.remove_datatype(self.test_project.id, conn_gid)
-            raise AssertionError("The connectivity is still used. It should not be possible to remove it." + str(conn_gid))
+            self.project_service.remove_datatype(self.test_project.id, conn.gid)
+            raise AssertionError(
+                "The connectivity is still used. It should not be possible to remove it." + str(conn_gid))
         except RemoveDataTypeException:
-            #OK, do nothing
+            # OK, do nothing
             pass
 
         res = dao.get_datatype_by_gid(conn_gid)
         assert conn[0].id == res.id, "Used connectivity removed"
 
-
     def test_remove_used_surface(self):
         """
         Tries to remove an used surface
         """
-        mapping, mapping_count = self.flow_service.get_available_datatypes(self.test_project.id, RegionMapping)
-        assert 1 == mapping_count, "There should be one Mapping."
-        mapping_gid = mapping[0][2]
-        mapping = ABCAdapter.load_entity_by_gid(mapping_gid)
-        surface = dao.get_datatype_by_gid(mapping.surface.gid)
-        assert surface.gid == mapping.surface.gid, "The surfaces should have the same GID"
+        filter = FilterChain(fields=[FilterChain.datatype + '.surface_type'], operations=["=="],
+                             values=[CORTICAL])
+        mapping = try_get_last_datatype(self.test_project.id, RegionMappingIndex)
+        surface = try_get_last_datatype(self.test_project.id, SurfaceIndex, filter)
+        assert mapping is not None, "There should be one Mapping."
+        assert surface is not None, "There should be one Costical Surface."
+        assert surface.gid == mapping.fk_surface_gid, "The surfaces should have the same GID"
+
         try:
             self.project_service.remove_datatype(self.test_project.id, surface.gid)
             raise AssertionError("The surface should still be used by a RegionMapping " + str(surface.gid))
         except RemoveDataTypeException:
-            #OK, do nothing
+            # OK, do nothing
             pass
 
         res = dao.get_datatype_by_gid(surface.gid)
         assert surface.id == res.id, "A used surface was deleted"
 
-
     def _remove_entity(self, data_class, before_number):
         """
         Try to remove entity. Fail otherwise.
         """
-        dts, count = self.flow_service.get_available_datatypes(self.test_project.id, data_class)
+        dts, count = get_filtered_datatypes(self.test_project.id, data_class)
         assert count == before_number
         for dt in dts:
             data_gid = dt[2]
             self.project_service.remove_datatype(self.test_project.id, data_gid)
             res = dao.get_datatype_by_gid(data_gid)
-            assert None == res, "The entity was not deleted"
+            assert res is None, "The entity was not deleted"
 
+        _, count = get_filtered_datatypes(self.test_project.id, data_class)
+        assert 0 == count
 
     def test_happyflow_removedatatypes(self):
         """
@@ -150,90 +146,44 @@ class TestRemove(TransactionalTestCase):
         They are tested together because they depend on each other and they
         have to be removed in a certain order.
         """
-        self._remove_entity(LocalConnectivity, 1)
-        self._remove_entity(RegionMapping, 1)
-        ### Remove Surfaces
+        self._remove_entity(LocalConnectivityIndex, 1)
+        self._remove_entity(RegionMappingIndex, 1)
+        # Remove Surfaces
         # SqlAlchemy has no uniform way to retrieve Surface as base (wild-character for polymorphic_identity)
-        self._remove_entity(Surface, 6)
-        ### Remove a Connectivity
-        self._remove_entity(Connectivity, 1)
+        self._remove_entity(SurfaceIndex, 6)
+        # Remove a Connectivity
+        self._remove_entity(ConnectivityIndex, 1)
 
-
-    def test_remove_time_series(self):
+    def test_remove_time_series(self, time_series_region_index_factory):
         """
         Tests the happy flow for the deletion of a time series.
         """
-        count_ts = self.count_all_entities(TimeSeries)
+        count_ts = self.count_all_entities(TimeSeriesRegionIndex)
         assert 0 == count_ts, "There should be no time series"
-        self._create_timeseries()
-        series = self.get_all_entities(TimeSeries)
+        conn = try_get_last_datatype(self.test_project.id, ConnectivityIndex)
+        conn = h5.load_from_index(conn)
+        rm = try_get_last_datatype(self.test_project.id, RegionMappingIndex)
+        rm = h5.load_from_index(rm)
+        time_series_region_index_factory(conn, rm)
+        series = self.get_all_entities(TimeSeriesRegionIndex)
         assert 1 == len(series), "There should be only one time series"
+
         self.project_service.remove_datatype(self.test_project.id, series[0].gid)
+
         res = dao.get_datatype_by_gid(series[0].gid)
-        assert None == res, "The time series was not deleted."
-
-
-    def test_remove_array_wrapper(self):
-        """
-        Tests the happy flow for the deletion of an array wrapper.
-        """
-        count_array = self.count_all_entities(MappedArray)
-        assert 1 == count_array
-        data = {'param_1': 'some value'}
-        OperationService().initiate_prelaunch(self.operation, self.adapter_instance, {}, **data)
-        array_wrappers = self.get_all_entities(MappedArray)
-        assert 2 == len(array_wrappers)
-        array_gid = array_wrappers[0].gid
-        self.project_service.remove_datatype(self.test_project.id, array_gid)
-        res = dao.get_datatype_by_gid(array_gid)
-        assert None == res, "The array wrapper was not deleted."
-
+        assert res is None, "The time series was not deleted."
 
     def test_remove_value_wrapper(self):
         """
         Test the deletion of a value wrapper dataType
         """
-        count_vals = self.count_all_entities(ValueWrapper)
+        count_vals = self.count_all_entities(ValueWrapperIndex)
         assert 0 == count_vals, "There should be no value wrapper"
-        value_wrapper = self._create_value_wrapper()
-        self.project_service.remove_datatype(self.test_project.id, value_wrapper.gid)
-        res = dao.get_datatype_by_gid(value_wrapper.gid)
-        assert None == res, "The value wrapper was not deleted."
+        value_wrapper_gid = TestFactory.create_value_wrapper(self.test_user, self.test_project)[1]
+        res = dao.get_datatype_by_gid(value_wrapper_gid)
+        assert res is not None, "The value wrapper was not created."
 
+        self.project_service.remove_datatype(self.test_project.id, value_wrapper_gid)
 
-    def _create_timeseries(self):
-        """Launch adapter to persist a TimeSeries entity"""
-        storage_path = FilesHelper().get_project_folder(self.test_project, str(self.operation.id))
-
-        time_series = TimeSeries()
-        time_series.sample_period = 10.0
-        time_series.start_time = 0.0
-        time_series.storage_path = storage_path
-        time_series.write_data_slice(numpy.array([1.0, 2.0, 3.0]))
-        time_series.close_file()
-        time_series.sample_period_unit = 'ms'
-
-        self._store_entity(time_series, "TimeSeries", "tvb.datatypes.time_series")
-        count_ts = self.count_all_entities(TimeSeries)
-        assert 1 == count_ts, "Should be only one TimeSeries"
-
-
-    def _create_value_wrapper(self):
-        """Persist ValueWrapper"""
-        value_ = ValueWrapper(data_value=5.0, data_name="my_value")
-        self._store_entity(value_, "ValueWrapper", "tvb.datatypes.mapped_values")
-        valuew = self.get_all_entities(ValueWrapper)
-        assert 1 == len(valuew), "Should be one value wrapper"
-        return ABCAdapter.load_entity_by_gid(valuew[0].gid)
-
-
-    def _store_entity(self, entity, type_, module):
-        """Launch adapter to store a create a persistent DataType."""
-        entity.type = type_
-        entity.module = module
-        entity.subject = "John Doe"
-        entity.state = "RAW_STATE"
-        entity.set_operation_id(self.operation.id)
-        adapter_instance = StoreAdapter([entity])
-        OperationService().initiate_prelaunch(self.operation, adapter_instance, {})
-
+        res = dao.get_datatype_by_gid(value_wrapper_gid)
+        assert res is None, "The value wrapper was not deleted."

--- a/framework_tvb/tvb/tests/framework/interfaces/web/controllers/flow_controller_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/web/controllers/flow_controller_test.py
@@ -161,10 +161,9 @@ class TestFlowController(BaseControllersTest):
         assert returned_data.replace('"', '') == " ".join(str(x) for x in range(101))
 
     def test_get_simple_adapter_interface(self, test_adapter_factory):
-        test_adapter_factory()
+        algo = test_adapter_factory()
         form = TestAdapter1Form()
         adapter = TestFactory.create_adapter('tvb.tests.framework.adapters.testadapter1', 'TestAdapter1')
-        algo = adapter.stored_adapter
         adapter.submit_form(form)
         result = self.flow_c.get_simple_adapter_interface(algo.id)
         expected_interface = adapter.get_form()


### PR DESCRIPTION
Starting from `FlowService.get_available_datatypes` method (which is only used in unit-tests, thus it can be removed), I looked into linked unit-tests (and fixed where the unit-test was deprecated), then in the problems revealed by those unit-test still failing (and reported as extra task, or directly fix, where fast)