### PR TITLE
TVB-2676: Solved problem with display_name 

### DIFF
--- a/framework_tvb/tvb/adapters/creators/stimulus_creator.py
+++ b/framework_tvb/tvb/adapters/creators/stimulus_creator.py
@@ -41,7 +41,7 @@ from tvb.core.entities.filters.chain import FilterChain
 from tvb.core.neocom import h5
 from tvb.core.neotraits.forms import DataTypeSelectField, FormField, SimpleStrField, TraitDataTypeSelectField, \
     SelectField
-from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
+from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr, Str
 from tvb.datatypes.connectivity import Connectivity
 from tvb.datatypes.equations import Sigmoid, PulseTrain
 from tvb.datatypes.patterns import StimuliSurface, StimuliRegion
@@ -209,6 +209,11 @@ class RegionStimulusCreatorModel(ViewModel, StimuliRegion):
         label="Connectivity"
     )
 
+    display_name = Str(
+        label='Display name',
+        required=False
+    )
+
 
 class RegionStimulusCreatorForm(ABCAdapterForm):
     NAME_TEMPORAL_PARAMS_DIV = 'temporal_params'
@@ -278,6 +283,7 @@ class RegionStimulusCreator(ABCSynchronous):
 
         stimuli_region_idx = StimuliRegionIndex()
         stimuli_region_idx.fill_from_has_traits(stimuli_region)
+        self.generic_attributes.user_tag_1 = view_model.display_name
 
         h5.store_complete(stimuli_region, self.storage_path)
         return stimuli_region_idx

--- a/framework_tvb/tvb/interfaces/web/controllers/spatial/region_stimulus_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/spatial/region_stimulus_controller.py
@@ -261,6 +261,8 @@ class RegionStimulusController(SpatioTemporalController):
         Creates a stimulus from the given data.
         """
         current_stimulus_region = common.get_from_session(KEY_REGION_STIMULUS)
+        display_name = common.get_from_session(KEY_REGION_STIMULUS_NAME)
+        current_stimulus_region.display_name = display_name
         region_stimulus_creator = ABCAdapter.build_adapter_from_class(RegionStimulusCreator)
         self.flow_service.fire_operation(region_stimulus_creator, common.get_logged_user(),
                                          common.get_current_project().id, view_model=current_stimulus_region)


### PR DESCRIPTION
I solved this problem by looking at how it's done in Local Connectivity Creator, which also has a display_name. So I put a display_name parameter on the ViewModel and then assigned it to generic_attributes.user_tag1.

I want to mention that this is not the only problem regarding this creator. The equation parameters are also not updated and saved to the DB (this applies to Local Connectivity Creator as well) and if I go forward to set scaling and then go back, the equation is kept, but the parameters not (let's say I changed it to Alpha, when I go back the equation will still be Alpha but it will have PulseTrain's parameters).