### PR TITLE
TVB-2689: add summary_info to DataType indexes

### DIFF
--- a/framework_tvb/tvb/core/entities/model/model_datatype.py
+++ b/framework_tvb/tvb/core/entities/model/model_datatype.py
@@ -113,19 +113,18 @@ class DataType(HasTraitsIndex):
     fk_from_operation = Column(Integer, ForeignKey('OPERATIONS.id', ondelete="CASCADE"))
     parent_operation = relationship(Operation, backref=backref("DATA_TYPES", order_by=id, cascade="all,delete"))
 
+    @property
     def summary_info(self):
         # type: () -> typing.Dict[str, str]
 
-        cls = type(self)
-        ret = {'Type': cls.__name__}
+        ret = {}
         if self.title:
             ret['title'] = str(self.title)
 
-        for attribute in cls.__dict__:
+        for attribute in self.__mapper__.column_attrs.keys():
             try:
                 attr_field = getattr(self, attribute)
-                if attr_field is not None:
-                    ret[attribute] = attr_field
+                ret[attribute] = str(attr_field)
             except Exception:
                 ""
         return ret

--- a/framework_tvb/tvb/core/entities/model/model_datatype.py
+++ b/framework_tvb/tvb/core/entities/model/model_datatype.py
@@ -121,14 +121,31 @@ class DataType(HasTraitsIndex):
         if self.title:
             ret['Title'] = str(self.title)
 
-        for attribute in self.__table__.columns.keys():
+        columns = self.get_base_table_columns
+        for attribute in columns:
             try:
                 attr_field = getattr(self, attribute)
-                attr_name = attribute.title().replace("_", " ")
-                ret[attr_name] = str(attr_field)
+                attr_name = self.get_attribute_name(attribute)
+                if attr_name is not None:
+                    ret[attr_name] = str(attr_field)
             except Exception:
                 pass
         return ret
+
+    @property
+    def get_base_table_columns(self):
+        columns = self.__table__.columns.keys()
+        if type(self).__bases__[0] is DataType:
+            return columns
+        base_table_columns = type(self).__bases__[0].__table__.columns.keys()
+        columns.extend(base_table_columns)
+        return columns
+
+    def get_attribute_name(self, attr_name):
+        #don't display fk_ attributes or id(dispayed in generic)
+        if "fk_" in attr_name or "id" in attr_name:
+            return None
+        return attr_name.title().replace("_", " ")
 
     def __init__(self, gid=None, **kwargs):
 

--- a/framework_tvb/tvb/core/entities/model/model_datatype.py
+++ b/framework_tvb/tvb/core/entities/model/model_datatype.py
@@ -119,7 +119,7 @@ class DataType(HasTraitsIndex):
 
         ret = {}
         if self.title:
-            ret['title'] = str(self.title)
+            ret['Title'] = str(self.title)
 
         for attribute in self.__table__.columns.keys():
             try:
@@ -127,7 +127,7 @@ class DataType(HasTraitsIndex):
                 attr_name = attribute.title().replace("_", " ")
                 ret[attr_name] = str(attr_field)
             except Exception:
-                ""
+                pass
         return ret
 
     def __init__(self, gid=None, **kwargs):

--- a/framework_tvb/tvb/core/entities/model/model_datatype.py
+++ b/framework_tvb/tvb/core/entities/model/model_datatype.py
@@ -36,6 +36,7 @@ Entities for Generic DataTypes, Links and Groups of DataTypes are defined here.
 .. moduleauthor:: Yann Gordon <yann@tvb.invalid>
 """
 import json
+import typing
 from datetime import datetime
 from copy import copy
 from sqlalchemy.orm import relationship, backref
@@ -121,31 +122,29 @@ class DataType(HasTraitsIndex):
         if self.title:
             ret['Title'] = str(self.title)
 
-        columns = self.get_base_table_columns
-        for attribute in columns:
+        columns = self._get_table_columns()
+        for attr_name in columns:
             try:
-                attr_field = getattr(self, attribute)
-                attr_name = self.get_attribute_name(attribute)
-                if attr_name is not None:
-                    ret[attr_name] = str(attr_field)
+                if attr_name.startswith("fk_") or "id" == attr_name:
+                    continue
+                name = attr_name.title().replace("_", " ")
+                attr_value = getattr(self, attr_name)
+                ret[name] = str(attr_value)
             except Exception:
                 pass
         return ret
 
-    @property
-    def get_base_table_columns(self):
+    def _get_table_columns(self):
         columns = self.__table__.columns.keys()
         if type(self).__bases__[0] is DataType:
             return columns
+        # Consider the immediate superclass only, as for now we have
+        # - most of *Index classes directly inheriting from DataType
+        # - except the ones with one intermediate: DataTypeMatrix or TimeSeriesIndex
         base_table_columns = type(self).__bases__[0].__table__.columns.keys()
         columns.extend(base_table_columns)
         return columns
 
-    def get_attribute_name(self, attr_name):
-        #don't display fk_ attributes or id(dispayed in generic)
-        if "fk_" in attr_name or "id" in attr_name:
-            return None
-        return attr_name.title().replace("_", " ")
 
     def __init__(self, gid=None, **kwargs):
 

--- a/framework_tvb/tvb/core/entities/model/model_datatype.py
+++ b/framework_tvb/tvb/core/entities/model/model_datatype.py
@@ -124,7 +124,8 @@ class DataType(HasTraitsIndex):
         for attribute in self.__table__.columns.keys():
             try:
                 attr_field = getattr(self, attribute)
-                ret[attribute] = str(attr_field)
+                attr_name = attribute.title().replace("_", " ")
+                ret[attr_name] = str(attr_field)
             except Exception:
                 ""
         return ret

--- a/framework_tvb/tvb/core/entities/model/model_datatype.py
+++ b/framework_tvb/tvb/core/entities/model/model_datatype.py
@@ -113,6 +113,23 @@ class DataType(HasTraitsIndex):
     fk_from_operation = Column(Integer, ForeignKey('OPERATIONS.id', ondelete="CASCADE"))
     parent_operation = relationship(Operation, backref=backref("DATA_TYPES", order_by=id, cascade="all,delete"))
 
+    def summary_info(self):
+        # type: () -> typing.Dict[str, str]
+
+        cls = type(self)
+        ret = {'Type': cls.__name__}
+        if self.title:
+            ret['title'] = str(self.title)
+
+        for attribute in cls.__dict__:
+            try:
+                attr_field = getattr(self, attribute)
+                if attr_field is not None:
+                    ret[attribute] = attr_field
+            except Exception:
+                ""
+        return ret
+
     def __init__(self, gid=None, **kwargs):
 
         # if gid is None:

--- a/framework_tvb/tvb/core/entities/model/model_datatype.py
+++ b/framework_tvb/tvb/core/entities/model/model_datatype.py
@@ -121,7 +121,7 @@ class DataType(HasTraitsIndex):
         if self.title:
             ret['title'] = str(self.title)
 
-        for attribute in self.__mapper__.column_attrs.keys():
+        for attribute in self.__table__.columns.keys():
             try:
                 attr_field = getattr(self, attribute)
                 ret[attribute] = str(attr_field)

--- a/framework_tvb/tvb/core/entities/transient/context_overlay.py
+++ b/framework_tvb/tvb/core/entities/transient/context_overlay.py
@@ -291,4 +291,4 @@ class DataTypeOverlayDetails(CommonDetails):
 
         ### Populate Scientific attributes
         if hasattr(datatype_result, 'summary_info') and datatype_result.summary_info is not None:
-            self.add_scientific_fields(datatype_result.summary_info())
+            self.add_scientific_fields(datatype_result.summary_info)

--- a/framework_tvb/tvb/core/entities/transient/context_overlay.py
+++ b/framework_tvb/tvb/core/entities/transient/context_overlay.py
@@ -291,4 +291,4 @@ class DataTypeOverlayDetails(CommonDetails):
 
         ### Populate Scientific attributes
         if hasattr(datatype_result, 'summary_info') and datatype_result.summary_info is not None:
-            self.add_scientific_fields(datatype_result.summary_info)
+            self.add_scientific_fields(datatype_result.summary_info())


### PR DESCRIPTION
After the split in multiple layers on datatypes, we no longer had "scientific Details" in a DataType overlay. We need to add something similar with the previous summary_info on DataType indexes.