### PR TITLE
TVB-2698: Fixed launching simulations with stimuli

### DIFF
--- a/framework_tvb/tvb/adapters/datatypes/db/patterns.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/patterns.py
@@ -30,19 +30,31 @@
 import json
 from sqlalchemy import Column, Integer, ForeignKey, String
 from sqlalchemy.orm import relationship
-from tvb.datatypes.patterns import StimuliRegion, StimuliSurface
+from tvb.datatypes.patterns import StimuliRegion, StimuliSurface, SpatioTemporalPattern
 from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
 from tvb.adapters.datatypes.db.surface import SurfaceIndex
 from tvb.core.entities.model.model_datatype import DataType
 
 
-class StimuliRegionIndex(DataType):
+class SpatioTemporalPatternIndex(DataType):
     id = Column(Integer, ForeignKey(DataType.id), primary_key=True)
 
     spatial_equation = Column(String, nullable=False)
     spatial_parameters = Column(String)
     temporal_equation = Column(String, nullable=False)
     temporal_parameters = Column(String)
+
+    def fill_from_has_traits(self, datatype):
+        # type: (SpatioTemporalPattern) -> None
+        super(SpatioTemporalPatternIndex, self).fill_from_has_traits(datatype)
+        self.spatial_equation = datatype.spatial.__class__.__name__
+        self.spatial_parameters = json.dumps(datatype.spatial.parameters)
+        self.temporal_equation = datatype.temporal.__class__.__name__
+        self.temporal_parameters = json.dumps(datatype.temporal.parameters)
+
+
+class StimuliRegionIndex(SpatioTemporalPatternIndex):
+    id = Column(Integer, ForeignKey(SpatioTemporalPatternIndex.id), primary_key=True)
 
     fk_connectivity_gid = Column(String(32), ForeignKey(ConnectivityIndex.gid),
                                  nullable=not StimuliRegion.connectivity.required)
@@ -52,20 +64,11 @@ class StimuliRegionIndex(DataType):
     def fill_from_has_traits(self, datatype):
         # type: (StimuliRegion)  -> None
         super(StimuliRegionIndex, self).fill_from_has_traits(datatype)
-        self.spatial_equation = datatype.spatial.__class__.__name__
-        self.spatial_parameters = json.dumps(datatype.spatial.parameters)
-        self.temporal_equation = datatype.temporal.__class__.__name__
-        self.temporal_parameters = json.dumps(datatype.temporal.parameters)
         self.fk_connectivity_gid = datatype.connectivity.gid.hex
 
 
-class StimuliSurfaceIndex(DataType):
-    id = Column(Integer, ForeignKey(DataType.id), primary_key=True)
-
-    spatial_equation = Column(String, nullable=False)
-    spatial_parameters = Column(String)
-    temporal_equation = Column(String, nullable=False)
-    temporal_parameters = Column(String)
+class StimuliSurfaceIndex(SpatioTemporalPatternIndex):
+    id = Column(Integer, ForeignKey(SpatioTemporalPatternIndex.id), primary_key=True)
 
     fk_surface_gid = Column(String(32), ForeignKey(SurfaceIndex.gid), nullable=not StimuliSurface.surface.required)
     surface = relationship(SurfaceIndex, foreign_keys=fk_surface_gid, primaryjoin=SurfaceIndex.gid == fk_surface_gid)
@@ -73,8 +76,4 @@ class StimuliSurfaceIndex(DataType):
     def fill_from_has_traits(self, datatype):
         # type: (StimuliSurface)  -> None
         super(StimuliSurfaceIndex, self).fill_from_has_traits(datatype)
-        self.spatial_equation = datatype.spatial.__class__.__name__
-        self.spatial_parameters = json.dumps(datatype.spatial.parameters)
-        self.temporal_equation = datatype.temporal.__class__.__name__
-        self.temporal_parameters = json.dumps(datatype.temporal.parameters)
         self.fk_surface_gid = datatype.surface.gid.hex

--- a/framework_tvb/tvb/adapters/simulator/simulator_adapter.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_adapter.py
@@ -198,6 +198,8 @@ class SimulatorAdapter(ABCAsynchronous):
         simulator.conduction_speed = view_model.conduction_speed
         simulator.coupling = view_model.coupling
 
+        rm_surface = None
+
         if view_model.surface:
             simulator.surface = Cortex()
             rm_index = self.load_entity_by_gid(view_model.surface.region_mapping_data.hex)
@@ -219,6 +221,11 @@ class SimulatorAdapter(ABCAsynchronous):
             stimulus_index = self.load_entity_by_gid(view_model.stimulus.hex)
             stimulus = h5.load_from_index(stimulus_index)
             simulator.stimulus = stimulus
+
+            if simulator.is_surface_simulation:
+                simulator.stimulus.surface = rm_surface
+            else:
+                simulator.stimulus.connectivity = simulator.connectivity
 
         simulator.model = view_model.model
         simulator.integrator = view_model.integrator

--- a/framework_tvb/tvb/adapters/simulator/simulator_adapter.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_adapter.py
@@ -46,7 +46,7 @@ from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
 from tvb.datatypes.connectivity import Connectivity
 from tvb.datatypes.cortex import Cortex
 from tvb.datatypes.local_connectivity import LocalConnectivity
-from tvb.datatypes.patterns import SpatioTemporalPattern
+from tvb.datatypes.patterns import SpatioTemporalPattern, StimuliSurface
 from tvb.datatypes.region_mapping import RegionMapping
 from tvb.datatypes.surfaces import CorticalSurface
 from tvb.simulator.coupling import Coupling
@@ -222,7 +222,7 @@ class SimulatorAdapter(ABCAsynchronous):
             stimulus = h5.load_from_index(stimulus_index)
             simulator.stimulus = stimulus
 
-            if simulator.is_surface_simulation:
+            if isinstance(stimulus, StimuliSurface):
                 simulator.stimulus.surface = rm_surface
             else:
                 simulator.stimulus.connectivity = simulator.connectivity

--- a/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
@@ -46,7 +46,7 @@ from tvb.adapters.simulator.monitor_forms import get_ui_name_to_monitor_dict, ge
 from tvb.adapters.simulator.range_parameter import RangeParameter
 from tvb.core.adapters.abcadapter import ABCAdapterForm
 from tvb.adapters.datatypes.db.local_connectivity import LocalConnectivityIndex
-from tvb.adapters.datatypes.db.patterns import StimuliSurfaceIndex, StimuliRegionIndex
+from tvb.adapters.datatypes.db.patterns import StimuliSurfaceIndex, StimuliRegionIndex, SpatioTemporalPatternIndex
 from tvb.adapters.datatypes.db.region_mapping import RegionMappingIndex
 from tvb.adapters.datatypes.db.surface import SurfaceIndex
 from tvb.core.neotraits.forms import DataTypeSelectField, ScalarField, ArrayField, SimpleFloatField, \
@@ -104,7 +104,7 @@ class SimulatorStimulusFragment(ABCAdapterForm):
     def __init__(self, prefix='', project_id=None, is_surface_simulation=False):
         super(SimulatorStimulusFragment, self).__init__(prefix, project_id)
         if is_surface_simulation:
-            stimuli_index_class = StimuliSurfaceIndex
+            stimuli_index_class = SpatioTemporalPatternIndex
         else:
             stimuli_index_class = StimuliRegionIndex
         self.stimulus = DataTypeSelectField(stimuli_index_class, self, name='region_stimuli', required=False,

--- a/framework_tvb/tvb/config/init/datatypes_registry.py
+++ b/framework_tvb/tvb/config/init/datatypes_registry.py
@@ -33,7 +33,7 @@ from tvb.datatypes.fcd import Fcd
 from tvb.datatypes.graph import ConnectivityMeasure, CorrelationCoefficients, Covariance
 from tvb.datatypes.local_connectivity import LocalConnectivity
 from tvb.datatypes.mode_decompositions import PrincipalComponents, IndependentComponents
-from tvb.datatypes.patterns import StimuliRegion, StimuliSurface
+from tvb.datatypes.patterns import StimuliRegion, StimuliSurface, SpatioTemporalPattern
 from tvb.datatypes.projections import ProjectionMatrix
 from tvb.datatypes.region_mapping import RegionVolumeMapping, RegionMapping
 from tvb.datatypes.sensors import Sensors
@@ -77,7 +77,7 @@ from tvb.adapters.datatypes.db.graph import CovarianceIndex
 from tvb.adapters.datatypes.db.local_connectivity import LocalConnectivityIndex
 from tvb.adapters.datatypes.db.mapped_value import DatatypeMeasureIndex, ValueWrapperIndex
 from tvb.adapters.datatypes.db.mode_decompositions import PrincipalComponentsIndex, IndependentComponentsIndex
-from tvb.adapters.datatypes.db.patterns import StimuliRegionIndex, StimuliSurfaceIndex
+from tvb.adapters.datatypes.db.patterns import StimuliRegionIndex, StimuliSurfaceIndex, SpatioTemporalPatternIndex
 from tvb.adapters.datatypes.db.projections import ProjectionMatrixIndex
 from tvb.adapters.datatypes.db.region_mapping import RegionVolumeMappingIndex, RegionMappingIndex
 from tvb.adapters.datatypes.db.sensors import SensorsIndex
@@ -128,6 +128,7 @@ def populate_datatypes_registry():
     REGISTRY.register_datatype(CorrelationCoefficients, CorrelationCoefficientsH5, CorrelationCoefficientsIndex)
     REGISTRY.register_datatype(Covariance, CovarianceH5, CovarianceIndex)
     REGISTRY.register_datatype(Fcd, FcdH5, FcdIndex)
+    REGISTRY.register_datatype(SpatioTemporalPattern, None, SpatioTemporalPatternIndex)
     REGISTRY.register_datatype(StimuliRegion, StimuliRegionH5, StimuliRegionIndex)
     REGISTRY.register_datatype(StimuliSurface, StimuliSurfaceH5, StimuliSurfaceIndex)
     REGISTRY.register_datatype(None, DatatypeMeasureH5, DatatypeMeasureIndex)

--- a/framework_tvb/tvb/core/services/simulator_serializer.py
+++ b/framework_tvb/tvb/core/services/simulator_serializer.py
@@ -96,6 +96,6 @@ class SimulatorSerializer(object):
                 simulator_in.surface.local_connectivity = cortex_h5.local_connectivity.load()
                 simulator_in.surface.region_mapping_data = cortex_h5.region_mapping_data.load()
                 rm_index = dao.get_datatype_by_gid(simulator_in.surface.region_mapping_data.hex)
-                simulator_in.surface.fk_surface_gid = uuid.UUID(rm_index.fk_surface_gid)
+                simulator_in.surface.surface_gid = uuid.UUID(rm_index.fk_surface_gid)
 
         return simulator_in


### PR DESCRIPTION
I fixed simulation launching with both kinds of stimuli. I went with the assumption that if you have a surface chosen, then only surface stimuli can be chosen, otherwise only region stimuli, based on the code in SimulatorStimulusFragment.

I suggest to merge TVB-2651 first, so I can make a rebase and test each visualizer with these type of surfaces to make sure they are okay.