### PR TITLE
TVB-2545 migrate_version table removed on reset_db

### DIFF
--- a/framework_tvb/tvb/config/init/model_manager.py
+++ b/framework_tvb/tvb/config/init/model_manager.py
@@ -46,7 +46,6 @@ import tvb.core.entities.model.db_update_scripts as scripts
 LOGGER = get_logger(__name__)
 
 
-
 def initialize_startup():
     """ Force DB tables create, in case no data is already found."""
     is_db_empty = False
@@ -79,7 +78,6 @@ def initialize_startup():
     return is_db_empty
 
 
-
 def reset_database():
     """
     Remove all tables in DB.
@@ -99,13 +97,13 @@ def reset_database():
                 except Exception as excep1:
                     LOGGER.error("Could no drop table %s", table)
                     LOGGER.exception(excep1)
+        migratesqlapi.drop_version_control(TvbProfile.current.db.DB_URL, TvbProfile.current.db.DB_VERSIONING_REPO)
         session.commit()
         LOGGER.info("Database was cleanup!")
     except Exception as excep:
         LOGGER.warning(excep)
     finally:
         session.close()
-
 
 
 def _update_sql_scripts():
@@ -118,4 +116,3 @@ def _update_sql_scripts():
         shutil.rmtree(versions_folder)
     ignore_patters = shutil.ignore_patterns('.svn')
     shutil.copytree(scripts_folder, versions_folder, ignore=ignore_patters)
-

--- a/framework_tvb/tvb/tests/framework/core/entities/amodel_manager_test.py
+++ b/framework_tvb/tvb/tests/framework/core/entities/amodel_manager_test.py
@@ -40,17 +40,14 @@ from tvb.core.entities.storage import dao
 from tvb.config.init.model_manager import initialize_startup, reset_database
 
 
-
 class TestsModelManager(BaseTestCase):
     """
-    This class contains tests for the tvb.core.entities.modelmanager module.
+    This class contains tests for tvb.config.init.model_manager module.
     """
 
-    @pytest.mark.skipif
     def teardown_method(self):
         init_test_env()
 
-    @pytest.mark.skipif
     def test_initialize_startup(self):
         """
         Test "reset_database" and "initialize_startup" calls.
@@ -58,11 +55,10 @@ class TestsModelManager(BaseTestCase):
         reset_database()
         # Table USERS should not exist:
         with pytest.raises(Exception): dao.get_all_users()
-        
+
         initialize_startup()
         # Table exists, but no rows
         assert 0 == len(dao.get_all_users())
-        assert None == dao.get_system_user()
+        assert dao.get_system_user() is None
         # DB revisions folder should exist:
         assert os.path.exists(TvbProfile.current.db.DB_VERSIONING_REPO)
-    


### PR DESCRIPTION
This miss was making tests fail, but I think it is a good practice also for the production env.
Still to be tested more.