### PR TITLE
TVB-2692: Fixed problem with Kuramoto model

### DIFF
--- a/framework_tvb/tvb/adapters/simulator/model_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/model_forms.py
@@ -332,7 +332,8 @@ class JansenRitModelForm(FormWithRanges):
         self.p_min = ArrayField(ModelsEnum.JANSEN_RIT.get_class().p_min, self)
         self.p_max = ArrayField(ModelsEnum.JANSEN_RIT.get_class().p_max, self)
         self.mu = ArrayField(ModelsEnum.JANSEN_RIT.get_class().mu, self)
-        self.variables_of_interest = ArrayField(ModelsEnum.JANSEN_RIT.get_class().variables_of_interest, self)
+        self.variables_of_interest = MultiSelectField(ModelsEnum.JANSEN_RIT.get_class().variables_of_interest,
+                                                      self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():

--- a/framework_tvb/tvb/adapters/simulator/model_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/model_forms.py
@@ -263,8 +263,8 @@ class EpileptorCodim3SlowModModelForm(FormWithRanges):
         self.Ks = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().Ks, self)
         self.N = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().N, self)
         self.modification = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().modification, self)
-        self.variables_of_interest = ArrayField(ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().variables_of_interest,
-                                                self)
+        self.variables_of_interest = MultiSelectField(
+            ModelsEnum.EPILEPTOR_CODIM_3_SLOW.get_class().variables_of_interest, self)
 
     @staticmethod
     def get_params_configurable_in_phase_plane():

--- a/scientific_library/tvb/simulator/models/jansen_rit.py
+++ b/scientific_library/tvb/simulator/models/jansen_rit.py
@@ -459,6 +459,7 @@ class ZetterbergJansen(Model):
         it is also provides the default range of phase-plane plots.""")
 
     variables_of_interest = List(
+        of=str,
         label="Variables watched by Monitors",
         choices=("v1", "y1", "v2", "y2", "v3", "y3", "v4", "y4", "v5", "y5", "v6", "v7"),
         default=("v6", "v7", "v2", "v3", "v4", "v5"),

--- a/scientific_library/tvb/simulator/models/oscillator.py
+++ b/scientific_library/tvb/simulator/models/oscillator.py
@@ -444,6 +444,7 @@ class Kuramoto(Model):
             history, it is also provides the default range of phase-plane plots.""")
 
     variables_of_interest = List(
+        of=str,
         label="Variables watched by Monitors",
         choices=("theta",),
         default=("theta",),

--- a/scientific_library/tvb/simulator/models/zerlaut.py
+++ b/scientific_library/tvb/simulator/models/zerlaut.py
@@ -622,6 +622,7 @@ class ZerlautAdaptationSecondOrder(ZerlautAdaptationFirstOrder):
         """)
 
     variables_of_interest = List(
+        of=str,
         label="Variables watched by Monitors",
         choices=("E", "I", "C_ee", "C_ei", "C_ii", "W_e", "W_i"),
         default=("E",),


### PR DESCRIPTION
Luckily, the issue was just the fact that a line `"of=str"` was missing from this model, sadly it requires a change in the library and I know we don't really like that.

As a so called bonus, I have noticed the Janset Rit and Zerlaut were having the same problem so I fixed those too and the Janset Rit model were also not having its variables of interest as a MultiSelectField so I changed that as well.