### PR TITLE
TVB-2701: Fix Spatial Average Monitor Launching 

### DIFF
--- a/framework_tvb/tvb/adapters/datatypes/db/connectivity.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/connectivity.py
@@ -49,6 +49,7 @@ class ConnectivityIndex(DataType):
     tract_lengths_mean = Column(Float)
 
     cortical_mask = Column(Boolean)
+    hemispheres_mask = Column(Boolean)
 
     # TODO: keep these metadata?
     # weights_non_zero_id = Column(Integer, ForeignKey('narrays.id'), nullable=False)
@@ -67,6 +68,10 @@ class ConnectivityIndex(DataType):
         self.cortical_mask = True
         if datatype.cortical is None or len(set(datatype.cortical)) != 2:
             self.cortical_mask = False
+
+        self.hemispheres_mask = True
+        if datatype.hemispheres is None or len(set(datatype.hemispheres)) != 2:
+            self.hemispheres_mask = False
 
         self.number_of_regions = datatype.number_of_regions
         self.number_of_connections = datatype.number_of_connections

--- a/framework_tvb/tvb/adapters/datatypes/db/connectivity.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/connectivity.py
@@ -48,8 +48,8 @@ class ConnectivityIndex(DataType):
     tract_lengths_max = Column(Float)
     tract_lengths_mean = Column(Float)
 
-    cortical_mask = Column(Boolean)
-    hemispheres_mask = Column(Boolean)
+    has_cortical_mask = Column(Boolean)
+    has_hemispheres_mask = Column(Boolean)
 
     # TODO: keep these metadata?
     # weights_non_zero_id = Column(Integer, ForeignKey('narrays.id'), nullable=False)
@@ -65,13 +65,13 @@ class ConnectivityIndex(DataType):
         # type: (Connectivity)  -> None
         super(ConnectivityIndex, self).fill_from_has_traits(datatype)
 
-        self.cortical_mask = True
+        self.has_cortical_mask = True
         if datatype.cortical is None or len(set(datatype.cortical)) != 2:
-            self.cortical_mask = False
+            self.has_cortical_mask = False
 
-        self.hemispheres_mask = True
+        self.has_hemispheres_mask = True
         if datatype.hemispheres is None or len(set(datatype.hemispheres)) != 2:
-            self.hemispheres_mask = False
+            self.has_hemispheres_mask = False
 
         self.number_of_regions = datatype.number_of_regions
         self.number_of_connections = datatype.number_of_connections

--- a/framework_tvb/tvb/adapters/datatypes/db/connectivity.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/connectivity.py
@@ -65,14 +65,8 @@ class ConnectivityIndex(DataType):
         # type: (Connectivity)  -> None
         super(ConnectivityIndex, self).fill_from_has_traits(datatype)
 
-        self.has_cortical_mask = True
-        if datatype.cortical is None or len(set(datatype.cortical)) != 2:
-            self.has_cortical_mask = False
-
-        self.has_hemispheres_mask = True
-        if datatype.hemispheres is None or len(set(datatype.hemispheres)) != 2:
-            self.has_hemispheres_mask = False
-
+        self.has_cortical_mask = datatype.cortical is not None
+        self.has_hemispheres_mask = datatype.hemispheres is not None
         self.number_of_regions = datatype.number_of_regions
         self.number_of_connections = datatype.number_of_connections
         self.undirected = datatype.undirected

--- a/framework_tvb/tvb/adapters/datatypes/db/connectivity.py
+++ b/framework_tvb/tvb/adapters/datatypes/db/connectivity.py
@@ -48,6 +48,8 @@ class ConnectivityIndex(DataType):
     tract_lengths_max = Column(Float)
     tract_lengths_mean = Column(Float)
 
+    cortical_mask = Column(Boolean)
+
     # TODO: keep these metadata?
     # weights_non_zero_id = Column(Integer, ForeignKey('narrays.id'), nullable=False)
     # weights_non_zero = relationship(NArrayIndex, foreign_keys=weights_non_zero_id, primaryjoin=NArrayIndex.id == weights_non_zero_id)
@@ -61,11 +63,17 @@ class ConnectivityIndex(DataType):
     def fill_from_has_traits(self, datatype):
         # type: (Connectivity)  -> None
         super(ConnectivityIndex, self).fill_from_has_traits(datatype)
+
+        self.cortical_mask = True
+        if datatype.cortical is None or len(set(datatype.cortical)) != 2:
+            self.cortical_mask = False
+
         self.number_of_regions = datatype.number_of_regions
         self.number_of_connections = datatype.number_of_connections
         self.undirected = datatype.undirected
         self.weights_min, self.weights_max, self.weights_mean = from_ndarray(datatype.weights)
         self.tract_lengths_min, self.tract_lengths_max, self.tract_lengths_mean = from_ndarray(datatype.tract_lengths)
+
         # self.weights_non_zero = NArrayIndex.from_ndarray(datatype.weights[datatype.weights.nonzero()])
         # self.tract_lengths_non_zero = NArrayIndex.from_ndarray(datatype.tract_lengths[datatype.tract_lengths.nonzero()])
         # self.tract_lengths_connections = NArrayIndex.from_ndarray(datatype.tract_lengths[datatype.weights.nonzero()])

--- a/framework_tvb/tvb/adapters/simulator/monitor_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/monitor_forms.py
@@ -148,10 +148,10 @@ class SpatialAverageMonitorForm(MonitorForm):
         connectivity_index = ABCAdapter.load_entity_by_gid(self.session_stored_simulator.connectivity)
 
         if self.session_stored_simulator.is_surface_simulation is False:
-            if connectivity_index.cortical_mask is False:
+            if connectivity_index.has_cortical_mask is False:
                 self.default_mask.choices.pop(SpatialAverage.CORTICAL)
 
-            if connectivity_index.hemispheres_mask is False:
+            if connectivity_index.has_hemispheres_mask is False:
                 self.default_mask.choices.pop(SpatialAverage.HEMISPHERES)
 
 class GlobalAverageMonitorForm(MonitorForm):

--- a/framework_tvb/tvb/adapters/simulator/monitor_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/monitor_forms.py
@@ -155,6 +155,7 @@ class SpatialAverageMonitorForm(MonitorForm):
         self.spatial_mask = ArrayField(SpatialAverage.spatial_mask, self)
         self.default_mask = ScalarField(SpatialAverage.default_mask,  self)
 
+
     def fill_from_trait(self, trait):
         super(SpatialAverageMonitorForm, self).fill_from_trait(trait)
         connectivity_index = ABCAdapter.load_entity_by_gid(self.session_stored_simulator.connectivity)
@@ -165,6 +166,10 @@ class SpatialAverageMonitorForm(MonitorForm):
 
             if connectivity_index.has_hemispheres_mask is False:
                 self.default_mask.choices.pop(SpatialAverage.HEMISPHERES)
+
+        else:
+            self.default_mask.data = SpatialAverage.REGION_MAPPING
+            self.default_mask.disabled = True
 
 class GlobalAverageMonitorForm(MonitorForm):
 

--- a/framework_tvb/tvb/adapters/simulator/monitor_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/monitor_forms.py
@@ -143,16 +143,16 @@ class SpatialAverageMonitorForm(MonitorForm):
         self.spatial_mask = ArrayField(SpatialAverage.spatial_mask, self)
         self.default_mask = ScalarField(SpatialAverage.default_mask,  self)
 
-    def fill_from_post(self, form_data):
-        super(SpatialAverageMonitorForm, self).fill_from_post(form_data)
-        self.default_mask.data = "hemispheres"
-
     def fill_from_trait(self, trait):
         super(SpatialAverageMonitorForm, self).fill_from_trait(trait)
         connectivity_index = ABCAdapter.load_entity_by_gid(self.session_stored_simulator.connectivity)
 
-        if self.session_stored_simulator.is_surface_simulation is False and connectivity_index.cortical_mask is False:
-            self.default_mask.disabled = True
+        if self.session_stored_simulator.is_surface_simulation is False:
+            if connectivity_index.cortical_mask is False:
+                self.default_mask.choices.pop(SpatialAverage.CORTICAL)
+
+            if connectivity_index.hemispheres_mask is False:
+                self.default_mask.choices.pop(SpatialAverage.HEMISPHERES)
 
 class GlobalAverageMonitorForm(MonitorForm):
 

--- a/framework_tvb/tvb/adapters/simulator/monitor_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/monitor_forms.py
@@ -26,6 +26,7 @@
 #       The Virtual Brain: a simulator of primate brain network dynamics.
 #   Frontiers in Neuroinformatics (7:10. doi: 10.3389/fninf.2013.00010)
 #
+from tvb.core.adapters.abcadapter import ABCAdapter
 from tvb.core.entities.file.simulator.view_model import *
 from tvb.core.entities.filters.chain import FilterChain
 from tvb.datatypes.projections import ProjectionsType
@@ -84,10 +85,24 @@ def get_form_for_monitor(monitor_class):
 
 class MonitorForm(Form):
 
-    def __init__(self, variables_of_interest_indexes={}, prefix='', project_id=None):
+    def __init__(self, session_stored_simulator=None, prefix='', project_id=None):
         super(MonitorForm, self).__init__(prefix, project_id)
+        self.session_stored_simulator = session_stored_simulator
         self.project_id = project_id
         self.period = ScalarField(Monitor.period, self)
+
+        variables_of_interest_indexes = {}
+
+        if session_stored_simulator is not None:
+            all_variables = session_stored_simulator.model.__class__.variables_of_interest.element_choices
+            chosen_variables = session_stored_simulator.model.variables_of_interest
+
+            if not isinstance(chosen_variables, (list, tuple)):
+                chosen_variables = [chosen_variables]
+
+            for variable in chosen_variables:
+                variables_of_interest_indexes[variable] = all_variables.index(variable)
+
         self.variables_of_interest_indexes = variables_of_interest_indexes
         self.variables_of_interest = MultiSelectField(List(of=str, label='Model Variables to watch',
                                                            choices=tuple(self.variables_of_interest_indexes.keys())),
@@ -111,47 +126,57 @@ class MonitorForm(Form):
 
 class RawMonitorForm(Form):
 
-    def __init__(self, variables_of_interest_indexes={}, prefix='', project_id=None):
+    def __init__(self, prefix='', project_id=None):
         super(RawMonitorForm, self).__init__(prefix, project_id)
 
 
 class SubSampleMonitorForm(MonitorForm):
 
-    def __init__(self, variables_of_interest_indexes={}, prefix='', project_id=None):
-        super(SubSampleMonitorForm, self).__init__(variables_of_interest_indexes, prefix, project_id)
+    def __init__(self, session_stored_simulator=None, prefix='', project_id=None):
+        super(SubSampleMonitorForm, self).__init__(session_stored_simulator, prefix, project_id)
 
 
 class SpatialAverageMonitorForm(MonitorForm):
 
-    def __init__(self, variables_of_interest_indexes={}, prefix='', project_id=None):
-        super(SpatialAverageMonitorForm, self).__init__(variables_of_interest_indexes, prefix, project_id)
+    def __init__(self, session_stored_simulator=None, prefix='', project_id=None):
+        super(SpatialAverageMonitorForm, self).__init__(session_stored_simulator, prefix, project_id)
         self.spatial_mask = ArrayField(SpatialAverage.spatial_mask, self)
         self.default_mask = ScalarField(SpatialAverage.default_mask,  self)
 
+    def fill_from_post(self, form_data):
+        super(SpatialAverageMonitorForm, self).fill_from_post(form_data)
+        self.default_mask.data = "hemispheres"
+
+    def fill_from_trait(self, trait):
+        super(SpatialAverageMonitorForm, self).fill_from_trait(trait)
+        connectivity_index = ABCAdapter.load_entity_by_gid(self.session_stored_simulator.connectivity)
+
+        if self.session_stored_simulator.is_surface_simulation is False and connectivity_index.cortical_mask is False:
+            self.default_mask.disabled = True
 
 class GlobalAverageMonitorForm(MonitorForm):
 
-    def __init__(self, variables_of_interest_indexes={}, prefix='', project_id=None):
-        super(GlobalAverageMonitorForm, self).__init__(variables_of_interest_indexes, prefix, project_id)
+    def __init__(self, session_stored_simulator=None, prefix='', project_id=None):
+        super(GlobalAverageMonitorForm, self).__init__(session_stored_simulator, prefix, project_id)
 
 
 class TemporalAverageMonitorForm(MonitorForm):
 
-    def __init__(self, variables_of_interest_indexes={}, prefix='', project_id=None):
-        super(TemporalAverageMonitorForm, self).__init__(variables_of_interest_indexes, prefix, project_id)
+    def __init__(self, session_stored_simulator=None, prefix='', project_id=None):
+        super(TemporalAverageMonitorForm, self).__init__(session_stored_simulator, prefix, project_id)
 
 
 class ProjectionMonitorForm(MonitorForm):
 
-    def __init__(self, variables_of_interest_indexes={}, prefix='', project_id=None):
-        super(ProjectionMonitorForm, self).__init__(variables_of_interest_indexes, prefix, project_id)
+    def __init__(self, session_stored_simulator=None, prefix='', project_id=None):
+        super(ProjectionMonitorForm, self).__init__(session_stored_simulator, prefix, project_id)
         self.region_mapping = TraitDataTypeSelectField(ProjectionViewModel.region_mapping, self, name='region_mapping')
 
 
 class EEGMonitorForm(ProjectionMonitorForm):
 
-    def __init__(self, variables_of_interest_indexes={}, prefix='', project_id=None):
-        super(EEGMonitorForm, self).__init__(variables_of_interest_indexes, prefix, project_id)
+    def __init__(self, session_stored_simulator=None, prefix='', project_id=None):
+        super(EEGMonitorForm, self).__init__(session_stored_simulator, prefix, project_id)
 
         sensor_filter = FilterChain(fields=[FilterChain.datatype + '.sensors_type'], operations=["=="],
                                     values=[SensorTypes.TYPE_EEG.value])
@@ -168,8 +193,8 @@ class EEGMonitorForm(ProjectionMonitorForm):
 
 class MEGMonitorForm(ProjectionMonitorForm):
 
-    def __init__(self, variables_of_interest_indexes={}, prefix='', project_id=None):
-        super(MEGMonitorForm, self).__init__(variables_of_interest_indexes, prefix, project_id)
+    def __init__(self, session_stored_simulator=None, prefix='', project_id=None):
+        super(MEGMonitorForm, self).__init__(session_stored_simulator, prefix, project_id)
 
         sensor_filter = FilterChain(fields=[FilterChain.datatype + '.sensors_type'], operations=["=="],
                                     values=[SensorTypes.TYPE_MEG.value])
@@ -184,8 +209,8 @@ class MEGMonitorForm(ProjectionMonitorForm):
 
 class iEEGMonitorForm(ProjectionMonitorForm):
 
-    def __init__(self, variables_of_interest_indexes={}, prefix='', project_id=None):
-        super(iEEGMonitorForm, self).__init__(variables_of_interest_indexes, prefix, project_id)
+    def __init__(self, session_stored_simulator=None, prefix='', project_id=None):
+        super(iEEGMonitorForm, self).__init__(session_stored_simulator, prefix, project_id)
 
         sensor_filter = FilterChain(fields=[FilterChain.datatype + '.sensors_type'], operations=["=="],
                                     values=[SensorTypes.TYPE_INTERNAL.value])
@@ -201,8 +226,8 @@ class iEEGMonitorForm(ProjectionMonitorForm):
 
 class BoldMonitorForm(MonitorForm):
 
-    def __init__(self, variables_of_interest_indexes={}, prefix='', project_id=None):
-        super(BoldMonitorForm, self).__init__(variables_of_interest_indexes, prefix, project_id)
+    def __init__(self, session_stored_simulator=None, prefix='', project_id=None):
+        super(BoldMonitorForm, self).__init__(session_stored_simulator, prefix, project_id)
         self.hrf_kernel_choices = get_ui_name_to_monitor_equation_dict()
         default_hrf_kernel = list(self.hrf_kernel_choices.values())[0]
 
@@ -223,5 +248,5 @@ class BoldMonitorForm(MonitorForm):
 
 class BoldRegionROIMonitorForm(BoldMonitorForm):
 
-    def __init__(self, variables_of_interest_indexes={}, prefix='', project_id=None):
-        super(BoldRegionROIMonitorForm, self).__init__(variables_of_interest_indexes, prefix, project_id)
+    def __init__(self, session_stored_simulator=None, prefix='', project_id=None):
+        super(BoldRegionROIMonitorForm, self).__init__(session_stored_simulator, prefix, project_id)

--- a/framework_tvb/tvb/adapters/simulator/monitor_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/monitor_forms.py
@@ -170,7 +170,14 @@ class ProjectionMonitorForm(MonitorForm):
 
     def __init__(self, session_stored_simulator=None, prefix='', project_id=None):
         super(ProjectionMonitorForm, self).__init__(session_stored_simulator, prefix, project_id)
-        self.region_mapping = TraitDataTypeSelectField(ProjectionViewModel.region_mapping, self, name='region_mapping')
+
+        rm_filter = None
+        if session_stored_simulator.is_surface_simulation:
+            rm_filter = FilterChain(fields=[FilterChain.datatype + '.gid'], operations=['=='],
+                                    values=[session_stored_simulator.surface.region_mapping_data.hex])
+
+        self.region_mapping = TraitDataTypeSelectField(ProjectionViewModel.region_mapping, self,
+                                                       name='region_mapping', conditions=rm_filter)
 
 
 class EEGMonitorForm(ProjectionMonitorForm):

--- a/framework_tvb/tvb/adapters/simulator/monitor_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/monitor_forms.py
@@ -161,6 +161,8 @@ class SpatialAverageMonitorForm(MonitorForm):
         connectivity_index = ABCAdapter.load_entity_by_gid(self.session_stored_simulator.connectivity)
 
         if self.session_stored_simulator.is_surface_simulation is False:
+            self.default_mask.choices.pop(SpatialAverage.REGION_MAPPING)
+
             if connectivity_index.has_cortical_mask is False:
                 self.default_mask.choices.pop(SpatialAverage.CORTICAL)
 

--- a/framework_tvb/tvb/adapters/simulator/monitor_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/monitor_forms.py
@@ -126,7 +126,7 @@ class SpatialAverageMonitorForm(MonitorForm):
     def __init__(self, variables_of_interest_indexes={}, prefix='', project_id=None):
         super(SpatialAverageMonitorForm, self).__init__(variables_of_interest_indexes, prefix, project_id)
         self.spatial_mask = ArrayField(SpatialAverage.spatial_mask, self)
-        self.default_mask = ScalarField(SpatialAverage.default_mask, self)
+        self.default_mask = ScalarField(SpatialAverage.default_mask,  self)
 
 
 class GlobalAverageMonitorForm(MonitorForm):

--- a/framework_tvb/tvb/adapters/simulator/monitor_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/monitor_forms.py
@@ -126,7 +126,7 @@ class MonitorForm(Form):
 
 class RawMonitorForm(Form):
 
-    def __init__(self, prefix='', project_id=None):
+    def __init__(self, session_stored_simulator=None, prefix='', project_id=None):
         super(RawMonitorForm, self).__init__(prefix, project_id)
 
 

--- a/framework_tvb/tvb/adapters/simulator/monitor_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/monitor_forms.py
@@ -90,20 +90,13 @@ class MonitorForm(Form):
         self.session_stored_simulator = session_stored_simulator
         self.project_id = project_id
         self.period = ScalarField(Monitor.period, self)
-
-        variables_of_interest_indexes = {}
+        self.variables_of_interest_indexes = {}
 
         if session_stored_simulator is not None:
             all_variables = session_stored_simulator.model.__class__.variables_of_interest.element_choices
             chosen_variables = session_stored_simulator.model.variables_of_interest
+            self.set_variables_of_interest(all_variables, chosen_variables)
 
-            if not isinstance(chosen_variables, (list, tuple)):
-                chosen_variables = [chosen_variables]
-
-            for variable in chosen_variables:
-                variables_of_interest_indexes[variable] = all_variables.index(variable)
-
-        self.variables_of_interest_indexes = variables_of_interest_indexes
         self.variables_of_interest = MultiSelectField(List(of=str, label='Model Variables to watch',
                                                            choices=tuple(self.variables_of_interest_indexes.keys())),
                                                       self, name='variables_of_interest')
@@ -120,6 +113,25 @@ class MonitorForm(Form):
     def fill_trait(self, datatype):
         super(MonitorForm, self).fill_trait(datatype)
         datatype.variables_of_interest = numpy.array(list(self.variables_of_interest_indexes.values()))
+
+    def fill_from_post(self, form_data):
+        super(MonitorForm, self).fill_from_post(form_data)
+        all_variables = self.session_stored_simulator.model.variables_of_interest
+        chosen_variables = form_data['variables_of_interest']
+        self.set_variables_of_interest(all_variables, chosen_variables)
+
+    def set_variables_of_interest(self, all_variables, chosen_variables):
+        variables_of_interest_indexes = {}
+
+        if not isinstance(chosen_variables, (list, tuple)):
+            chosen_variables = [chosen_variables]
+
+        for variable in chosen_variables:
+            variables_of_interest_indexes[variable] = all_variables.index(variable)
+
+        self.variables_of_interest_indexes = variables_of_interest_indexes
+
+
 
     # TODO: We should review the code here, we could probably reduce the number of  classes that are used here
 

--- a/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
@@ -69,17 +69,31 @@ class SimulatorSurfaceFragment(ABCAdapterForm):
 
 
 class SimulatorRMFragment(ABCAdapterForm):
-    def __init__(self, prefix='', project_id=None, surface_index=None):
+    def __init__(self, prefix='', project_id=None, surface_index=None, connectivity_gid=None):
         super(SimulatorRMFragment, self).__init__(prefix, project_id)
         conditions = None
         if surface_index:
-            conditions = FilterChain(fields=[FilterChain.datatype + '.fk_surface_gid'], operations=["=="],
-                                     values=[str(surface_index.gid)])
+            conditions = FilterChain(fields=[FilterChain.datatype + '.fk_surface_gid',
+                                             FilterChain.datatype + '.fk_connectivity_gid'],
+                                     operations=["==", "=="],
+                                     values=[str(surface_index.gid), connectivity_gid.hex])
         self.rm = TraitDataTypeSelectField(CortexViewModel.region_mapping_data, self, name='region_mapping',
                                            conditions=conditions)
         self.lc = TraitDataTypeSelectField(CortexViewModel.local_connectivity, self, name='local_connectivity',
                                            conditions=conditions)
         self.coupling_strength = ArrayField(CortexViewModel.coupling_strength, self)
+
+    def fill_from_trait(self, trait):
+        # type: (Simulator) -> None
+        self.coupling_strength.data = trait.surface.coupling_strength
+        if hasattr(trait.surface, 'region_mapping_data'):
+            self.rm.data = trait.surface.region_mapping_data.hex
+        else:
+            self.rm.data = None
+        if trait.surface.local_connectivity:
+            self.lc.data = trait.surface.local_connectivity.hex
+        else:
+            self.lc.data = None
 
 
 class SimulatorStimulusFragment(ABCAdapterForm):

--- a/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
@@ -87,18 +87,6 @@ class SimulatorRMFragment(ABCAdapterForm):
                                            conditions=lc_conditions)
         self.coupling_strength = ArrayField(CortexViewModel.coupling_strength, self)
 
-    def fill_from_trait(self, trait):
-        # type: (Simulator) -> None
-        self.coupling_strength.data = trait.coupling_strength
-        if hasattr(trait, 'region_mapping_data'):
-            self.rm.data = trait.region_mapping_data.hex
-        else:
-            self.rm.data = None
-        if trait.local_connectivity:
-            self.lc.data = trait.local_connectivity.hex
-        else:
-            self.lc.data = None
-
 
 class SimulatorStimulusFragment(ABCAdapterForm):
     def __init__(self, prefix='', project_id=None, is_surface_simulation=False):

--- a/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
@@ -71,27 +71,31 @@ class SimulatorSurfaceFragment(ABCAdapterForm):
 class SimulatorRMFragment(ABCAdapterForm):
     def __init__(self, prefix='', project_id=None, surface_index=None, connectivity_gid=None):
         super(SimulatorRMFragment, self).__init__(prefix, project_id)
-        conditions = None
+        rm_conditions = None
+        lc_conditions = None
         if surface_index:
-            conditions = FilterChain(fields=[FilterChain.datatype + '.fk_surface_gid',
+            rm_conditions = FilterChain(fields=[FilterChain.datatype + '.fk_surface_gid',
                                              FilterChain.datatype + '.fk_connectivity_gid'],
                                      operations=["==", "=="],
-                                     values=[str(surface_index.gid), connectivity_gid.hex])
+                                     values=[str(surface_index.gid), str(connectivity_gid.hex)])
+            lc_conditions = FilterChain(fields=[rm_conditions.fields[0]], operations=[rm_conditions.operations[0]],
+                                        values=[rm_conditions.values[0]])
         self.rm = TraitDataTypeSelectField(CortexViewModel.region_mapping_data, self, name='region_mapping',
-                                           conditions=conditions)
+                                           conditions=rm_conditions)
+
         self.lc = TraitDataTypeSelectField(CortexViewModel.local_connectivity, self, name='local_connectivity',
-                                           conditions=conditions)
+                                           conditions=lc_conditions)
         self.coupling_strength = ArrayField(CortexViewModel.coupling_strength, self)
 
     def fill_from_trait(self, trait):
         # type: (Simulator) -> None
-        self.coupling_strength.data = trait.surface.coupling_strength
-        if hasattr(trait.surface, 'region_mapping_data'):
-            self.rm.data = trait.surface.region_mapping_data.hex
+        self.coupling_strength.data = trait.coupling_strength
+        if hasattr(trait, 'region_mapping_data'):
+            self.rm.data = trait.region_mapping_data.hex
         else:
             self.rm.data = None
-        if trait.surface.local_connectivity:
-            self.lc.data = trait.surface.local_connectivity.hex
+        if trait.local_connectivity:
+            self.lc.data = trait.local_connectivity.hex
         else:
             self.lc.data = None
 

--- a/framework_tvb/tvb/core/entities/file/simulator/view_model.py
+++ b/framework_tvb/tvb/core/entities/file/simulator/view_model.py
@@ -204,7 +204,7 @@ class TemporalAverageViewModel(MonitorViewModel, TemporalAverage):
 class ProjectionViewModel(MonitorViewModel, Projection):
     region_mapping = DataTypeGidAttr(
         linked_datatype=RegionMapping,
-        required=Projection.region_mapping.required,
+        required=True,
         label=Projection.region_mapping.label,
         doc=Projection.region_mapping.doc
     )

--- a/framework_tvb/tvb/core/services/simulator_service.py
+++ b/framework_tvb/tvb/core/services/simulator_service.py
@@ -39,6 +39,7 @@ import shutil
 import uuid
 
 import numpy
+from tvb.adapters.simulator.monitor_forms import MonitorForm
 from tvb.basic.logger.builder import get_logger
 from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.entities.file.simulator.view_model import SimulatorAdapterModel
@@ -61,26 +62,9 @@ class SimulatorService(object):
         self.operation_service = OperationService()
         self.files_helper = FilesHelper()
 
-    @staticmethod
-    def get_variables_of_interest_indexes(all_variables, chosen_variables):
-        indexes = {}
-
-        if not isinstance(chosen_variables, (list, tuple)):
-            chosen_variables = [chosen_variables]
-
-        for variable in chosen_variables:
-            indexes[variable] = all_variables.index(variable)
-        return indexes
-
-    def determine_indexes_for_chose_variables_of_interest(self, session_stored_simulator):
-        all_variables = session_stored_simulator.model.__class__.variables_of_interest.element_choices
-        chosen_variables = session_stored_simulator.model.variables_of_interest
-        indexes = self.get_variables_of_interest_indexes(all_variables, chosen_variables)
-        return indexes
-
     def _reset_model(self, session_stored_simulator):
         session_stored_simulator.model = type(session_stored_simulator.model)()
-        vi_indexes = self.determine_indexes_for_chose_variables_of_interest(session_stored_simulator)
+        vi_indexes = MonitorForm.determine_indexes_for_chosen_vars_of_interest(session_stored_simulator)
         vi_indexes = numpy.array(list(vi_indexes.values()))
         for monitor in session_stored_simulator.monitors:
             monitor.variables_of_interest = vi_indexes

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
@@ -366,7 +366,8 @@ class SimulatorController(BurstBaseController):
     @staticmethod
     def _prepare_cortex_fragment(session_stored_simulator, rendering_rules):
         surface_index = ABCAdapter.load_entity_by_gid(session_stored_simulator.surface.surface_gid)
-        rm_fragment = SimulatorRMFragment('', common.get_current_project().id, surface_index)
+        rm_fragment = SimulatorRMFragment('', common.get_current_project().id, surface_index,
+                                          session_stored_simulator.connectivity)
         rm_fragment.fill_from_trait(session_stored_simulator.surface)
 
         rendering_rules.form = rm_fragment
@@ -653,9 +654,8 @@ class SimulatorController(BurstBaseController):
     @staticmethod
     def _check_cortical_for_spatial_average(connectivity, form, is_surface_simulation):
         connectivity_index = ABCAdapter.load_entity_by_gid(connectivity)
-        connectivity = h5.load_from_index(connectivity_index)
 
-        if is_surface_simulation is False and (connectivity.cortical is None or len(set(connectivity.cortical)) != 2):
+        if is_surface_simulation is False and connectivity_index.cortical_mask is False:
             form.default_mask.disabled = True
 
     @staticmethod
@@ -769,7 +769,7 @@ class SimulatorController(BurstBaseController):
             form = get_form_for_monitor(type(monitor))(indexes)
             form.fill_from_post(data)
 
-            if isinstance(form, SpatialAverageMonitorForm) and form.default_mask.data is None:
+            if hasattr(form, 'default_mask') and form.default_mask.data is None:
                 form.default_mask.data = 'hemispheres'
 
             form.fill_trait(monitor)

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
@@ -651,11 +651,11 @@ class SimulatorController(BurstBaseController):
         return first_monitor_index, last_loaded_fragment_url
 
     @staticmethod
-    def _check_cortical_for_spatial_average(connectivity, form):
+    def _check_cortical_for_spatial_average(connectivity, form, is_surface_simulation):
         connectivity_index = ABCAdapter.load_entity_by_gid(connectivity)
         connectivity = h5.load_from_index(connectivity_index)
 
-        if connectivity.cortical is None or len(set(connectivity.cortical)) != 2:
+        if is_surface_simulation is False and (connectivity.cortical is None or len(set(connectivity.cortical)) != 2):
             form.default_mask.disabled = True
 
     @staticmethod
@@ -705,7 +705,8 @@ class SimulatorController(BurstBaseController):
         form.fill_from_trait(monitor)
 
         if isinstance(monitor, SpatialAverageViewModel):
-            self._check_cortical_for_spatial_average(session_stored_simulator.connectivity, form)
+            self._check_cortical_for_spatial_average(session_stored_simulator.connectivity, form,
+                                                     session_stored_simulator.is_surface_simulation)
 
         rendering_rules = SimulatorFragmentRenderingRules(form, last_loaded_fragment_url,
                                                           SimulatorWizzardURLs.SET_MONITORS_URL, is_simulator_copy,

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
@@ -797,6 +797,22 @@ class SimulatorController(BurstBaseController):
                 SimulatorWizzardURLs.SET_MONITOR_PARAMS_URL, current_monitor)
             return rendering_rules.to_dict()
 
+        if isinstance(monitor, Projection) and cherrypy.request.method == 'POST':
+            # load region mapping
+            region_mapping_index = ABCAdapter.load_entity_by_gid(data['region_mapping'])
+            region_mapping = h5.load_from_index(region_mapping_index)
+            monitor.region_mapping = region_mapping.gid
+
+            # load sensors and projection
+            sensors_index = ABCAdapter.load_entity_by_gid(data['sensors'])
+            sensors = h5.load_from_index(sensors_index)
+
+            projection_surface_index = ABCAdapter.load_entity_by_gid(data['projection'])
+            projection = h5.load_from_index(projection_surface_index)
+
+            monitor.sensors = sensors.gid
+            monitor.projection = projection.gid
+
         rendering_rules.previous_form_action_url = self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_PARAMS_URL,
                                                                           type(monitor).__name__)
         return self._handle_next_fragment_for_monitors(session_stored_simulator, next_monitor, rendering_rules)

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
@@ -45,7 +45,7 @@ from tvb.config.init.introspector_registry import IntrospectionRegistry
 from tvb.core.adapters.abcadapter import ABCAdapter
 from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.entities.file.simulator.view_model import SimulatorAdapterModel, IntegratorStochasticViewModel, \
-    AdditiveNoiseViewModel, BoldViewModel, RawViewModel, ProjectionViewModel
+    AdditiveNoiseViewModel, BoldViewModel, RawViewModel
 from tvb.core.entities.model.model_burst import BurstConfiguration
 from tvb.core.entities.storage import dao
 from tvb.core.neocom import h5
@@ -772,22 +772,6 @@ class SimulatorController(BurstBaseController):
             rendering_rules.previous_form_action_url = self.build_monitor_url(
                 SimulatorWizzardURLs.SET_MONITOR_PARAMS_URL, current_monitor)
             return rendering_rules.to_dict()
-
-        if isinstance(monitor, ProjectionViewModel) and cherrypy.request.method == 'POST':
-            # load region mapping
-            region_mapping_index = ABCAdapter.load_entity_by_gid(data['region_mapping'])
-            region_mapping = h5.load_from_index(region_mapping_index)
-            monitor.region_mapping = region_mapping.gid
-
-            # load sensors and projection
-            sensors_index = ABCAdapter.load_entity_by_gid(data['sensors'])
-            sensors = h5.load_from_index(sensors_index)
-
-            projection_surface_index = ABCAdapter.load_entity_by_gid(data['projection'])
-            projection = h5.load_from_index(projection_surface_index)
-
-            monitor.sensors = sensors.gid
-            monitor.projection = projection.gid
 
         rendering_rules.previous_form_action_url = self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_PARAMS_URL,
                                                                           type(monitor).__name__)

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
@@ -745,7 +745,6 @@ class SimulatorController(BurstBaseController):
         is_simulator_load = common.get_from_session(common.KEY_IS_SIMULATOR_LOAD) or False
 
         if cherrypy.request.method == POST_REQUEST:
-            is_simulator_copy = False
             form = get_form_for_monitor(type(monitor))(session_stored_simulator)
             form.fill_from_post(data)
             form.fill_trait(monitor)

--- a/framework_tvb/tvb/tests/framework/core/neocom_test.py
+++ b/framework_tvb/tvb/tests/framework/core/neocom_test.py
@@ -90,10 +90,11 @@ def test_store_simulator_view_model_noise(connectivity_index_factory, operation_
     assert sim_view_model.integrator.noise.noise_seed == loaded_sim_view_model.integrator.noise.noise_seed == 45
 
 
-def test_store_simulator_view_model_eeg(connectivity_index_factory, surface_index_factory, sensors_index_factory,
-                                        operation_factory):
+def test_store_simulator_view_model_eeg(connectivity_index_factory, surface_index_factory, region_mapping_factory,
+                                        sensors_index_factory, operation_factory):
     conn = connectivity_index_factory()
     surface_idx, surface = surface_index_factory(cortical=True)
+    region_mapping = region_mapping_factory()
     sensors_idx, sensors = sensors_index_factory()
     proj = ProjectionSurfaceEEG(sensors=sensors, sources=surface, projection_data=numpy.ones(3))
 
@@ -104,6 +105,7 @@ def test_store_simulator_view_model_eeg(connectivity_index_factory, surface_inde
     dao.store_entity(prj_db_db)
 
     seeg_monitor = EEGViewModel(projection=proj.gid, sensors=sensors.gid)
+    seeg_monitor.region_mapping = region_mapping.gid.hex
     sim_view_model = SimulatorAdapterModel()
     sim_view_model.connectivity = conn.gid
     sim_view_model.monitors = [seeg_monitor]

--- a/framework_tvb/tvb/tests/framework/core/services/hpc_scheduler_client_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/hpc_scheduler_client_test.py
@@ -166,10 +166,10 @@ class TestHPCSchedulerClient(BaseTestCase):
         input_files = hpc_client._prepare_input(op, sim_gid)
         assert len(input_files) == 9
 
-    def test_prepare_inputs_with_eeg_monitor(self, operation_factory, simulator_factory, region_mapping_factory,
+    def test_prepare_inputs_with_eeg_monitor(self, operation_factory, simulator_factory, region_mapping_index_factory,
                                              surface_index_factory, sensors_index_factory):
         surface_idx, surface = surface_index_factory(cortical=True)
-        region_mapping = region_mapping_factory()
+        region_mapping = region_mapping_index_factory()
         sensors_idx, sensors = sensors_index_factory()
         proj = ProjectionSurfaceEEG(sensors=sensors, sources=surface, projection_data=numpy.ones(3))
 
@@ -180,12 +180,12 @@ class TestHPCSchedulerClient(BaseTestCase):
         dao.store_entity(prj_db_db)
 
         eeg_monitor = EEGViewModel(projection=proj.gid, sensors=sensors.gid)
-        eeg_monitor.region_mapping = region_mapping.gid.hex
+        eeg_monitor.region_mapping = region_mapping.gid
 
         sim_folder, sim_gid = simulator_factory(op=op, monitor=eeg_monitor)
         hpc_client = HPCSchedulerClient()
         input_files = hpc_client._prepare_input(op, sim_gid)
-        assert len(input_files) == 10
+        assert len(input_files) == 13
 
     def test_stage_out_to_operation_folder(self, mocker, operation_factory, simulator_factory,
                                            pse_burst_configuration_factory):

--- a/framework_tvb/tvb/tests/framework/core/services/hpc_scheduler_client_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/hpc_scheduler_client_test.py
@@ -166,9 +166,10 @@ class TestHPCSchedulerClient(BaseTestCase):
         input_files = hpc_client._prepare_input(op, sim_gid)
         assert len(input_files) == 9
 
-    def test_prepare_inputs_with_eeg_monitor(self, operation_factory, simulator_factory, surface_index_factory,
-                                             sensors_index_factory):
+    def test_prepare_inputs_with_eeg_monitor(self, operation_factory, simulator_factory, region_mapping_factory,
+                                             surface_index_factory, sensors_index_factory):
         surface_idx, surface = surface_index_factory(cortical=True)
+        region_mapping = region_mapping_factory()
         sensors_idx, sensors = sensors_index_factory()
         proj = ProjectionSurfaceEEG(sensors=sensors, sources=surface, projection_data=numpy.ones(3))
 
@@ -179,6 +180,7 @@ class TestHPCSchedulerClient(BaseTestCase):
         dao.store_entity(prj_db_db)
 
         eeg_monitor = EEGViewModel(projection=proj.gid, sensors=sensors.gid)
+        eeg_monitor.region_mapping = region_mapping.gid.hex
 
         sim_folder, sim_gid = simulator_factory(op=op, monitor=eeg_monitor)
         hpc_client = HPCSchedulerClient()

--- a/scientific_library/tvb/simulator/monitors.py
+++ b/scientific_library/tvb/simulator/monitors.py
@@ -248,14 +248,14 @@ class SpatialAverage(Monitor):
                 self.spatial_mask = simulator.surface.region_mapping
             else:
                 conn = simulator.connectivity
-                if self.default_mask[0] == 'cortical':
+                if self.default_mask == 'cortical':
                     if conn is not None and conn.cortical is not None and conn.cortical.size > 0:
                         ## Use as spatial-mask cortical/non cortical areas
                         self.spatial_mask = numpy.array([int(c) for c in conn.cortical])
                     else:
                         msg = "Must fill Spatial Mask parameter for non-surface simulations when using SpatioTemporal monitor!"
                         raise Exception(msg)
-                if self.default_mask[0] == 'hemispheres':
+                if self.default_mask == 'hemispheres':
                     if conn is not None and conn.hemispheres is not None and conn.hemispheres.size > 0:
                         ## Use as spatial-mask left/right hemisphere
                         self.spatial_mask = numpy.array([int(h) for h in conn.hemispheres])

--- a/scientific_library/tvb/simulator/monitors.py
+++ b/scientific_library/tvb/simulator/monitors.py
@@ -218,6 +218,7 @@ class SpatialAverage(Monitor):
     _ui_name = "Spatial average with temporal sub-sample"
     CORTICAL = "cortical"
     HEMISPHERES = "hemispheres"
+    REGION_MAPPING = "region mapping"
 
     spatial_mask = NArray(  #TODO: Check it's a vector of length Nodes (like region mapping for surface)
         dtype=int,
@@ -230,7 +231,7 @@ class SpatialAverage(Monitor):
 
     default_mask = Attr(
         str,
-        choices=(CORTICAL, HEMISPHERES),
+        choices=(CORTICAL, HEMISPHERES, REGION_MAPPING),
         default=HEMISPHERES,
         label="Default Mask",
         required=False,

--- a/scientific_library/tvb/simulator/monitors.py
+++ b/scientific_library/tvb/simulator/monitors.py
@@ -371,8 +371,7 @@ class Projection(Monitor):
 
     region_mapping = Attr(
         RegionMapping,
-        required=False,
-        label="region mapping",  #order=3,
+        label="Region Mapping",  #order=3,
         doc="A region mapping specifies how vertices of a surface correspond to given regions in the"
             " connectivity. For iEEG/EEG/MEG monitors, this must be specified when performing a region"
             " simulation but is optional for a surface simulation.")

--- a/scientific_library/tvb/simulator/monitors.py
+++ b/scientific_library/tvb/simulator/monitors.py
@@ -222,7 +222,7 @@ class SpatialAverage(Monitor):
     spatial_mask = NArray(  #TODO: Check it's a vector of length Nodes (like region mapping for surface)
         dtype=int,
         label="Spatial Mask",
-        required=False,
+        required=HEMISPHERES,
         doc="""A vector of length==nodes that assigns an index to each node
             specifying the "region" to which it belongs. The default usage is
             for mapping a surface based simulation back to the regions used in 
@@ -368,7 +368,8 @@ class Projection(Monitor):
 
     region_mapping = Attr(
         RegionMapping,
-        label="Region Mapping",  #order=3,
+        label="Region Mapping",
+        required=False,
         doc="A region mapping specifies how vertices of a surface correspond to given regions in the"
             " connectivity. For iEEG/EEG/MEG monitors, this must be specified when performing a region"
             " simulation but is optional for a surface simulation.")
@@ -566,21 +567,21 @@ class EEG(Projection):
 
     projection = Attr(
         projections_module.ProjectionSurfaceEEG,
-        default=None, label='Projection matrix',  #order=2,
+        default=None, label='Projection matrix',
         doc='Projection matrix to apply to sources.')
 
     reference = Attr(
         str, required=False,
-        label="EEG Reference",  #order=5,
+        label="EEG Reference",
         doc='EEG Electrode to be used as reference, or "average" to '
             'apply an average reference. If none is provided, the '
             'produced time-series are the idealized or reference-free.')
 
-    sensors = Attr(sensors_module.SensorsEEG, required=True, label="EEG Sensors",  #order=1,
+    sensors = Attr(sensors_module.SensorsEEG, required=True, label="EEG Sensors",
                    doc='Sensors to use for this EEG monitor')
 
     sigma = Float(
-        default=1.0,  #order=4,
+        default=1.0,
         label="Conductivity (w/o projection)",
         doc='When a projection matrix is not used, this provides '
             'the value of conductivity in the formula for the single '
@@ -649,7 +650,7 @@ class MEG(Projection):
         sensors_module.SensorsMEG,
         label = "MEG Sensors",
         default = None,
-        required = True,  #order=1,
+        required = True,
         doc="The set of MEG sensors for which the forward solution will be calculated.")
 
 
@@ -706,14 +707,14 @@ class iEEG(Projection):
 
     projection = Attr(
         projections_module.ProjectionSurfaceSEEG,
-        default=None, label='Projection matrix',  #order=2,
+        default=None, label='Projection matrix',
         doc='Projection matrix to apply to sources.')
 
     sigma = Float(label="conductivity", default=1.0)  #, order=4)
 
     sensors = Attr(
         sensors_module.SensorsInternal,
-        label="Internal brain sensors", default=None, required=True,  #order=1,
+        label="Internal brain sensors", default=None, required=True,
         doc="The set of SEEG sensors for which the forward solution will be calculated.")
 
 
@@ -804,7 +805,7 @@ class Bold(Monitor):
         label="Duration (ms)",
         default=20000.,
         doc= """Duration of the hrf kernel""",)
-        #order=-1)
+
 
     _interim_period = None
     _interim_istep = None

--- a/scientific_library/tvb/simulator/monitors.py
+++ b/scientific_library/tvb/simulator/monitors.py
@@ -222,7 +222,7 @@ class SpatialAverage(Monitor):
     spatial_mask = NArray(  #TODO: Check it's a vector of length Nodes (like region mapping for surface)
         dtype=int,
         label="Spatial Mask",
-        required=HEMISPHERES,
+        required=False,
         doc="""A vector of length==nodes that assigns an index to each node
             specifying the "region" to which it belongs. The default usage is
             for mapping a surface based simulation back to the regions used in 
@@ -231,7 +231,7 @@ class SpatialAverage(Monitor):
     default_mask = Attr(
         str,
         choices=(CORTICAL, HEMISPHERES),
-        default=None,
+        default=HEMISPHERES,
         label="Default Mask",
         required=False,
         doc=("Fallback in case spatial mask is none and no surface provided" 


### PR DESCRIPTION
So far I have only managed to fix launching with the default mask (Hemispheres), but there are other problems as well:

1. Launching with Cortical default mask gives this error: Areas in the spatial_mask must be specified as a contiguous set of indices starting from zero.
2. Brain Activity 2D and 3D Visualizer as well as Brain Activity Visualizer doesn't work with this monitor, because `NO_OF_MEASURE_POINTS !== activitiesData[0].length ( virtualBrain.js, line 404).`
3. This one is basically the same problem as described in https://req.thevirtualbrain.org/browse/TVB-2707 and that is the fact that the surface attributes only exists in TimeSeriesSurface, not on the TimeSeries superclass, so launching with surface and `SpatialAverage` or with surface and a `Projection Monitor` will try to set the surface from TimeSeriesRegion (in the case of SpatialAverage) or from TimeSeriesEEG (in the case of EEG) but won't have it. Should we add the surface on the superclass?