### PR TITLE
TVB-2659: Make "Next" buttons accessible by keyboard

### DIFF
--- a/framework_tvb/tvb/interfaces/web/static/js/bursts.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/bursts.js
@@ -61,7 +61,7 @@ function resetToNewBurst() {
             displayBurstTree(undefined);
             displayMessage("Completely new configuration loaded!");
             changeBurstHistory(null, false, false, '');
-            document.getElementsByClassName('btn btn-primary next')[0].focus();
+            $("button.btn-next").first().focus();
         },
         error: function () {
             displayMessage("We encountered an error while generating the new simulation. Please try reload and then check the logs!", "errorMessage");
@@ -569,15 +569,14 @@ function launchNewBurst(currentForm, launchMode) {
     });
 }
 
-function setInitialFocusOnButton(simulator_params){
+function setInitialFocusOnButton(simulator_params) {
     const current_url = simulator_params.lastElementChild.action;
-    if(current_url !== undefined && current_url.includes('setup_pse')){
-        document.getElementById('launch_simulation').focus();
-    }else if(current_url !== undefined && current_url.includes('launch_pse')){
-        document.getElementById('launch_pse').focus();
-    }else {
-        const next_buttons = document.getElementsByClassName('btn btn-primary next');
-        next_buttons[next_buttons.length - 1].focus();
+    if (current_url !== undefined && current_url.includes('setup_pse')) {
+        $('#launch_simulation').focus();
+    } else if (current_url !== undefined && current_url.includes('launch_pse')) {
+        $('#launch_pse').focus();
+    } else {
+        $("button.btn-next").last().focus();
     }
 }
 

--- a/framework_tvb/tvb/interfaces/web/static/js/bursts.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/bursts.js
@@ -567,9 +567,29 @@ function launchNewBurst(currentForm, launchMode) {
     });
 }
 
+function setInitialFocusOnButton(current_form){
+    const last_child_action = current_form.lastChild.action;
+
+    if (last_child_action === undefined){
+        document.getElementById('next/burst/set_connectivity').focus();
+    }else{
+        const index = last_child_action.indexOf('/burst');
+        const last_child_simple = last_child_action.substring(index);
+        if(last_child_simple === '/burst/setup_pse'){
+            document.getElementById('launch_simulation').focus();
+        }
+        else if(last_child_simple === '/burst/launch_pse'){
+            document.getElementById('launch_pse').focus();
+        }else {
+            document.getElementById('next' + current_form.lastChild.action.substring(index)).focus();
+        }
+    }
+}
+
 
 function previousWizzardStep(currentForm, previous_action, div_id = 'div-simulator-parameters') {
-    document.getElementById(div_id).removeChild(currentForm);
+    const simulator_form = document.getElementById(div_id);
+    simulator_form.removeChild(currentForm);
 
     var previous_form = document.getElementById(previous_action);
     var next_button = previous_form.elements.namedItem('next');
@@ -611,6 +631,7 @@ function previousWizzardStep(currentForm, previous_action, div_id = 'div-simulat
         config_branch_button.style.visibility = 'visible';
     }
     fieldset.disabled = false;
+    setInitialFocusOnButton(simulator_form);
 }
 
 function wizzard_submit(currentForm, success_function = null, div_id = 'div-simulator-parameters') {
@@ -666,10 +687,9 @@ function wizzard_submit(currentForm, success_function = null, div_id = 'div-simu
                 }
                 fieldset.disabled = true;
                 var t = document.createRange().createContextualFragment(response);
-                const new_form = document.getElementById(div_id);
-                new_form.appendChild(t);
-                const index = new_form.lastChild.action.indexOf('/burst');
-                document.getElementById('next' + new_form.lastChild.action.substring(index)).focus();
+                const simulator_form = document.getElementById(div_id);
+                simulator_form.appendChild(t);
+                setInitialFocusOnButton(simulator_form);
                 MathJax.Hub.Queue(["Typeset", MathJax.Hub, div_id]);
             }
         }

--- a/framework_tvb/tvb/interfaces/web/static/js/bursts.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/bursts.js
@@ -52,6 +52,7 @@ function clone(object_) {
  * When clicking on the New Burst Button reset to defaults for simulator interface and portlets.
  */
 function resetToNewBurst() {
+    document.getElementById('next/burst/set_connectivity').focus();
     doAjaxCall({
         type: "POST",
         url: '/burst/reset_simulator_configuration/',
@@ -199,6 +200,7 @@ function _updateBurstHistoryElapsedTime(result) {
  * If "withFullUpdate" is true, then a full history section replacement happens before the periodical update.
  */
 function scheduleNewUpdate(withFullUpdate, refreshCurrent) {
+    document.getElementById('next/burst/set_connectivity').focus();
     if ($('#burst-history').length !== 0) {
         if (withFullUpdate) {
             loadBurstHistory();
@@ -664,7 +666,10 @@ function wizzard_submit(currentForm, success_function = null, div_id = 'div-simu
                 }
                 fieldset.disabled = true;
                 var t = document.createRange().createContextualFragment(response);
-                document.getElementById(div_id).appendChild(t);
+                const new_form = document.getElementById(div_id);
+                new_form.appendChild(t);
+                const index = new_form.lastChild.action.indexOf('/burst');
+                document.getElementById('next' + new_form.lastChild.action.substring(index)).focus();
                 MathJax.Hub.Queue(["Typeset", MathJax.Hub, div_id]);
             }
         }

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/bool_field.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/bool_field.html
@@ -1,5 +1,5 @@
 <p class="field-data">
-<input type="checkbox" name="{{ field.name }}" id="{{ field.name }}"
+<input type="checkbox" name="{{ field.name }}" id="{{ field.name }}" tabindex="1"
     {{ 'disabled' if field.disabled }} {{ 'checked' if field.value }}
     class="form-control"
 >

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/checkbox_field.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/checkbox_field.html
@@ -1,6 +1,6 @@
 <p class="field-data field-series">
 {% for option in field.options() %}
-    <input type="checkbox" name="{{ field.name }}" id="{{option.id}}"
+    <input type="checkbox" name="{{ field.name }}" id="{{option.id}}" tabindex="1"
            value="{{ option.value }}"
             {{ 'checked' if option.checked}} {{ 'disabled' if field.disabled }}
            class="form-control"

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/datatype_select_field.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/datatype_select_field.html
@@ -1,5 +1,6 @@
 <p class="field-data">
-<select name="{{ field.name }}" id="{{ field.name }}" class="dataset-selector" onchange="updateDivContent('data_time_series', this, ''); updateDatatypeDiv(this)" title="Fully Loaded!">
+<select name="{{ field.name }}" id="{{ field.name }}" class="dataset-selector" tabindex="1"
+        onchange="updateDivContent('data_time_series', this, ''); updateDatatypeDiv(this)" title="Fully Loaded!">
 {% for option in field.options() %}
     <option value="{{ option.value }}" {{ 'selected' if option.checked }} class="form-control">{{ option.label }}</option>
 {% endfor %}

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/hidden_field.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/hidden_field.html
@@ -1,5 +1,5 @@
 <p class="field-data">
-<input type="hidden" name="{{ field.name }}" id="{{ field.name }}"
+<input type="hidden" name="{{ field.name }}" id="{{ field.name }}" tabindex="-1"
     {% if field.value is not none %}
        value="{{ field.value }}"
     {% endif %}}

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/number_field.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/number_field.html
@@ -1,5 +1,5 @@
 <p class="field-data">
-<input type="number" name="{{ field.name }}" id="{{ field.name }}"
+<input type="number" name="{{ field.name }}" id="{{ field.name }}" tabindex="1"
     {{ 'required' if field.required }} {{ 'disabled' if field.disabled }}
     {% if field.value is not none %}
        value="{{ field.value }}"

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/radio_field.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/radio_field.html
@@ -1,6 +1,6 @@
 <p class="field-data field-series">
     {% for option in field.options() %}
-        <input type="radio" name="{{ field.name }}" id="{{ option.id }}"
+        <input type="radio" name="{{ field.name }}" id="{{ option.id }}" tabindex="1"
                value="{{ option.value }}"
                 {{ 'checked' if option.checked }} {{ 'disabled' if field.disabled }}
                class="form-control"

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/select_field.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/select_field.html
@@ -1,5 +1,5 @@
 <p class="field-data field-series">
-    <select name="{{ field.name }}" id="{{ field.name }}" {{ 'disabled' if field.disabled }} class="form-control">
+    <select name="{{ field.name }}" id="{{ field.name }}" tabindex="1" {{ 'disabled' if field.disabled }} class="form-control">
         {% for option in field.options() %}
             <option value="{{ option.value }}" {{ 'selected' if option.checked }}
                     class="form-control">{{ option.label }}</option>

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/str_field.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/str_field.html
@@ -1,5 +1,5 @@
 <p class="field-data">
-<input type="text" name="{{ field.name }}" id="{{ field.name }}"
+<input type="text" name="{{ field.name }}" id="{{ field.name }}" tabindex="1"
     {{ 'required' if field.required }} {{ 'disabled' if field.disabled }}
     {% if field.value is not none %}
        value="{{ field.value }}"

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/simulator_fragment.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/simulator_fragment.html
@@ -49,7 +49,7 @@
     {% endif %}
 
     {% if renderer.include_next_button %}
-        <button name="next" type="button" class="btn btn-primary next" tabindex="1"
+        <button name="next" type="button" class="btn btn-primary btn-next" tabindex="1"
                 onclick="wizzard_submit(this.parentElement)"
                 {% if renderer.load_readonly %} style="visibility: hidden" {% endif %}>Next
         </button>

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/simulator_fragment.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/simulator_fragment.html
@@ -26,58 +26,58 @@
     </fieldset>
 
     {% if renderer.include_setup_region_model %}
-        <button type="button" title="Set up model parameters for region-based simulations" class="btn btn-primary"
+        <button type="button" title="Set up model parameters for region-based simulations" class="btn btn-primary" tabindex="1"
            onclick="configureModelParamsOnRegions();" id="configRegionModelParam" name="configRegionModelParam"
            {% if renderer.load_readonly %} style="visibility: hidden" {% endif %}>Set up region Model</button>
     {% endif %}
     {% if renderer.include_setup_surface_model %}
-            <button type="button" title="Set up model parameters for surface-based simulations" class="btn btn-primary"
+            <button type="button" title="Set up model parameters for surface-based simulations" class="btn btn-primary" tabindex="1"
                onclick="wizzard_submit(this.parentElement, configureModelParamsOnSurface);" id="configSurfaceModelParam" name="configSurfaceModelParam"
                {% if renderer.load_readonly %} style="visibility: hidden" {% endif %}>Set up surface model</button>
     {% endif %}
     {% if renderer.include_setup_noise %}
-            <button type="button" title="Configure noise for region-based simulations" class="btn btn-primary"
+            <button type="button" title="Configure noise for region-based simulations" class="btn btn-primary" tabindex="1"
                onclick="configureNoiseParameters();" id="configNoiseValues" name="configNoiseValues"
                {% if renderer.load_readonly %} style="visibility: hidden" {% endif %}>Configure noise</button>
     {% endif %}
 
     {% if renderer.include_previous_button %}
-        <button id='previous' name="previous" type="button" class="btn btn-primary"
+        <button name="previous" type="button" class="btn btn-primary" tabindex="1"
                 onclick="previousWizzardStep(this.parentElement, '{{ renderer.previous_form_action_url }}')"
                 {% if renderer.hide_previous_button %} style="visibility: hidden" {% endif %}>Previous
         </button>
     {% endif %}
 
     {% if renderer.include_next_button %}
-        <button id={{ 'next' ~ renderer.form_action_url }} name="next" type="button" class="btn btn-primary"
+        <button name="next" type="button" class="btn btn-primary next" tabindex="1"
                 onclick="wizzard_submit(this.parentElement)"
                 {% if renderer.load_readonly %} style="visibility: hidden" {% endif %}>Next
         </button>
     {% endif %}
 
     {% if renderer.include_launch_button %}
-        <button id="launch_simulation" name="launch_simulation" type="button" class="btn btn-primary"
+        <button id="launch_simulation" name="launch_simulation" type="button" class="btn btn-primary" tabindex="1"
                 onclick="launchNewBurst(this.parentElement, 'new')"
                 {% if renderer.hide_launch_and_setup_pse_button %} style="visibility: hidden" {% endif %}>Launch
         </button>
     {% endif %}
 
     {% if renderer.include_setup_pse %}
-        <button id="setup_pse" name="setup_pse" type="button" class="btn btn-primary"
+        <button id="setup_pse" name="setup_pse" type="button" class="btn btn-primary" tabindex="1"
                 onclick="wizzard_submit(this.parentElement)"
                 {% if renderer.hide_launch_and_setup_pse_button %} style="visibility: hidden" {% endif %}>Setup PSE
         </button>
     {% endif %}
 
     {% if renderer.include_branch_button %}
-        <button id="branch_simulation" name="branch_simulation" type="button" class="btn btn-primary"
+        <button id="branch_simulation" name="branch_simulation" type="button" class="btn btn-primary" tabindex="1"
                 onclick="launchNewBurst(this.parentElement, 'branch')"
                 {% if renderer.load_readonly %} style="visibility: hidden" {% endif %}>Branch
         </button>
     {% endif %}
 
     {% if renderer.include_launch_pse_button %}
-        <button id="launch_pse" name="launch_pse" type="button" class="btn btn-primary"
+        <button id="launch_pse" name="launch_pse" type="button" class="btn btn-primary" tabindex="1"
                 onclick="launchNewPSEBurst(this.parentElement)">Launch PSE</button>
     {% endif %}
 </form>

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/simulator_fragment.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/simulator_fragment.html
@@ -49,7 +49,7 @@
     {% endif %}
 
     {% if renderer.include_next_button %}
-        <button id='next' name="next" type="button" class="btn btn-primary"
+        <button id={{ 'next' ~ renderer.form_action_url }} name="next" type="button" class="btn btn-primary"
                 onclick="wizzard_submit(this.parentElement)"
                 {% if renderer.load_readonly %} style="visibility: hidden" {% endif %}>Next
         </button>


### PR DESCRIPTION
So far I have made possible to run a simulation with default parameters by setting initial focus on the next buttons or on the launch/launch_pse in their respective fragments. When the focus is not on any active element (in that case the focus is by default on the body element) at the press of any arrow key, the focus will be restored to the next or launch buttons. Also, using left and right arrows it is possible to navigate through the buttons. 

My first problem was that all the next buttons in every fragment have the same id, so I renamed them to "next/burst/{current_fragment_name}".

I don't like that I have a little hardcoded things there, so I'll try to find a better solution to get the initial fragment or to get only the fragment url out of the one having "localhost....". Besides these, should the select fields also be accessible by keyboards? Maybe we could use left-right only on the buttons and up-down on the data fields?