### PR TITLE
TVB-2644: Fix AnimatedViewer on TS obtained with Global Average Monitor

### DIFF
--- a/framework_tvb/tvb/adapters/datatypes/h5/time_series_h5.py
+++ b/framework_tvb/tvb/adapters/datatypes/h5/time_series_h5.py
@@ -158,7 +158,7 @@ class TimeSeriesH5(H5File):
                 slices.append(slice(specific_slices[i], min(specific_slices[i] + 1, overall_shape[i]), 1))
 
         data = self.data[tuple(slices)]
-        if len(data) == 1:
+        if data.shape[2] == 1:
             # Do not allow time dimension to get squeezed, a 2D result need to
             # come out of this method.
             data = data.squeeze()

--- a/framework_tvb/tvb/adapters/datatypes/h5/time_series_h5.py
+++ b/framework_tvb/tvb/adapters/datatypes/h5/time_series_h5.py
@@ -158,13 +158,12 @@ class TimeSeriesH5(H5File):
                 slices.append(slice(specific_slices[i], min(specific_slices[i] + 1, overall_shape[i]), 1))
 
         data = self.data[tuple(slices)]
-        if data.shape[2] == 1:
+        data = data.squeeze()
+
+        if len(data.shape) == 1:
             # Do not allow time dimension to get squeezed, a 2D result need to
             # come out of this method.
-            data = data.squeeze()
             data = data.reshape((1, len(data)))
-        else:
-            data = data.squeeze()
 
         return data
 

--- a/framework_tvb/tvb/adapters/visualizers/eeg_monitor.py
+++ b/framework_tvb/tvb/adapters/visualizers/eeg_monitor.py
@@ -349,9 +349,6 @@ class EegMonitor(ABCSpaceDisplayer):
 
             page_chunk_data = timeseries.read_data_page(self.current_page * self.page_size,
                                                         (self.current_page + 1) * self.page_size)
-            if len(page_chunk_data.shape) == 1:
-                page_chunk_data = page_chunk_data.reshape(page_chunk_data.shape[0], 1)
-
             channels_per_set.append(int(resulting_shape[1]))
 
             for idx in range(resulting_shape[1]):

--- a/framework_tvb/tvb/adapters/visualizers/eeg_monitor.py
+++ b/framework_tvb/tvb/adapters/visualizers/eeg_monitor.py
@@ -349,6 +349,9 @@ class EegMonitor(ABCSpaceDisplayer):
 
             page_chunk_data = timeseries.read_data_page(self.current_page * self.page_size,
                                                         (self.current_page + 1) * self.page_size)
+            if len(page_chunk_data.shape) == 1:
+                page_chunk_data = page_chunk_data.reshape(page_chunk_data.shape[0], 1)
+
             channels_per_set.append(int(resulting_shape[1]))
 
             for idx in range(resulting_shape[1]):


### PR DESCRIPTION
In case of page_chunk_data has only one shape (x), it should have the shape (x, 1) so the next for doesn't fail. 

I made some tests and the only visualizer that it has (Animated Time Series) works. Only trying to launch a PSE on this won't work...