### PR TITLE
TVB-2690 RegionSelector does not preserve hemisphere ordering

### DIFF
--- a/framework_tvb/tvb/interfaces/web/static/js/spatial/stimulus.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/spatial/stimulus.js
@@ -35,7 +35,7 @@ var StimView;
 function main(weights, selectionGID) {
     StimView = new TVBUI.RegionAssociatorView({
         selectionGID: selectionGID,
-        onPut: STIM_saveWeightForSelectedNodes,
+        onPut: _STIM_saveWeightForSelectedNodes,
         prepareSubmitData: function () {
             console.warn('This should not happen. Stimulus page does not use the submit logic of RegionAssociatorView. ');
             return false;
@@ -59,7 +59,7 @@ function _STIM_server_update_scaling() {
 /**
  * Saves the given weight for all the selected nodes.
  */
-function STIM_saveWeightForSelectedNodes() {
+function _STIM_saveWeightForSelectedNodes() {
     const weightElement = $("#current_weight");
     let newWeight = parseFloat(weightElement.val());
     if (!isNaN(newWeight)) {
@@ -70,7 +70,6 @@ function STIM_saveWeightForSelectedNodes() {
         weightElement.val("");
         _STIM_server_update_scaling();
     }
-    return newWeight;
 }
 
 

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/burst/model_param_region.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/burst/model_param_region.html
@@ -25,7 +25,6 @@
     <script type="text/javascript">
         $(document).ready(function () {
             modelParam.main({{ dynamics_json | safe }}, {{ initial_dynamic_ids }}, "{{ measurePointsSelectionGID }}");
-            GFUN_initSelectionComponent("{{ measurePointsSelectionGID }}", "{{ hemisphereOrderUrl }}");
         });
     </script>
 {%- endmacro %}

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/burst/noise.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/burst/noise.html
@@ -11,7 +11,6 @@
     <script type="text/javascript">
         $(document).ready(function () {
             noiseParam.main({{ stateVarsJson | safe }}, {{ initialNoiseValues | safe }}, "{{ measurePointsSelectionGID }}");
-            GFUN_initSelectionComponent("{{ measurePointsSelectionGID }}", "{{ hemisphereOrderUrl }}");
         });
     </script>
 {%- endmacro %}

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/spatial/stimulus_region_step2_left.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/spatial/stimulus_region_step2_left.html
@@ -17,8 +17,7 @@
                 BS_loadEntity();
             });
 			main({{ node_weights }}, "{{ measurePointsSelectionGID }}");
-			GFUN_initSelectionComponent("{{ measurePointsSelectionGID }}", "{{ hemisphereOrderUrl }}");
-            setEventsOnStaticFormFields({{ fieldsWithEvents | safe }});
+			setEventsOnStaticFormFields({{ fieldsWithEvents | safe }});
         });
     </script>
     

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/connectivity/left_template_connectivity_view.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/connectivity/left_template_connectivity_view.html
@@ -24,8 +24,6 @@
 
     <script type="text/javascript">
         $(document).ready(function() {
-            GFUN_initSelectionComponent("{{ measurePointsSelectionGID }}", "{{ hemisphereOrderUrl }}");
-
             {#Need this to pass JSON parsing later in JS#}
             {% if urlVertices is undefined %}
                 {% set urlVertices='""' %}


### PR DESCRIPTION
In recent TVB web versions, setting scaling on Stimulus Region is not preserving order after submit+save+reload.