### PR TITLE
Allow function type for attributes

### DIFF
--- a/scientific_library/tvb/basic/neotraits/_attr.py
+++ b/scientific_library/tvb/basic/neotraits/_attr.py
@@ -154,7 +154,7 @@ class Attr(_Attr):
         # (this attr instance is a class field, so the default is for the class)
         # This is consistent with how class fields work before they are assigned and become instance bound
         if self.field_name not in instance.__dict__:
-            if isinstance(self.default, types.FunctionType):
+            if self.field_type != types.FunctionType and isinstance(self.default, types.FunctionType):
                 default = self.default()
             else:
                 default = self.default

--- a/scientific_library/tvb/tests/library/basic/neotraits/neotraits_test.py
+++ b/scientific_library/tvb/tests/library/basic/neotraits/neotraits_test.py
@@ -29,6 +29,7 @@
 #
 
 import abc
+import types
 import uuid
 import numpy
 import numpy as np
@@ -883,3 +884,30 @@ def test_perf_trait(benchmark):
         arr = NArray(shape=(Dim.any, Dim.any), default=numpy.eye(3))
 
     benchmark(access_attr, A())
+
+
+def test_function_attribute():
+    def func1():
+        return 2.0
+
+    def func2():
+        return "Hello!"
+
+    class A(HasTraits):
+        a = Attr(field_type=types.FunctionType)
+        b = Attr(field_type=types.FunctionType, default=lambda: 1)
+        c = Attr(field_type=types.FunctionType, default=func1)
+
+    ainst = A()
+    ainst.a = func2
+    val_a = ainst.a()
+    val_b = ainst.b()
+    val_c = ainst.c()
+    assert val_a == "Hello!"
+    assert val_b == 1
+    assert val_c == 2.0
+
+    with pytest.raises(TypeError):
+        # out of bounds
+        ainst.c = "Not a function"
+


### PR DESCRIPTION
Hi,

This is a proposal to allow functions as values for attributes. Right now, if the value is a function it gets evaluated and the result is assigned to the attribute, thus preventing the use of functions as values. This is a very small change that allows to use function types without breaking the previous behavior.

Right now I'm using this type of value as factories