### PR TITLE
TVB-2733 Fixes related for Simulator web page

### DIFF
--- a/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
@@ -579,7 +579,7 @@ class SimulatorController(BurstBaseController):
         rendering_rules = SimulatorFragmentRenderingRules(None, None, SimulatorWizzardURLs.SET_INTEGRATOR_PARAMS_URL,
                                                           is_simulator_copy, is_simulator_load,
                                                           self.last_loaded_form_url, cherrypy.request.method,
-                                                          is_noise_fragment=True)
+                                                          is_noise_fragment=False)
 
         if not isinstance(session_stored_simulator.integrator, IntegratorStochastic):
             return self._prepare_monitor_form(session_stored_simulator, rendering_rules)

--- a/framework_tvb/tvb/interfaces/web/static/js/spatial/stimulus.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/spatial/stimulus.js
@@ -70,6 +70,7 @@ function _STIM_saveWeightForSelectedNodes() {
         weightElement.val("");
         _STIM_server_update_scaling();
     }
+    return newWeight;
 }
 
 


### PR DESCRIPTION
I managed to put back the Configure Noise button where it belongs and to fix the updating of weight values in Region Stimulus which recently was only possible after refresh.

I fixed another problem, namely the failing Projection monitors in my branch for Spatial Average monitor.

Also, something weird I discovered was that I launched some PSE simulations and some of them showed up with red (failing) in the Simulator Page when in Operations you can see that they were succesfully finished and you can even use both visualizers for them. Also, once I saw that a Simulation was marked in Simulator with green before it actually finished and at restarting, it was red... I don't know where it comes from, I tried to find any recent modifications which might cause that, but the only thing I know is that somewhere these BurstConfigs' status in the DB are updated to error, so it's not a JS problem cause if I manually edit them to finished, then there's no problem. 

In the end, I suggest to do some testings on Monday or Tuesday to investigate this problem and other problems that might have appeared.