### PR TITLE
Mistake in parameter labelling W-C Model

### DIFF
--- a/scientific_library/tvb/simulator/models/wilson_cowan.py
+++ b/scientific_library/tvb/simulator/models/wilson_cowan.py
@@ -153,13 +153,13 @@ class WilsonCowan(Model):
         domain=Range(lo=11.0, hi=16.0, step=0.01),
         doc="""Excitatory to excitatory  coupling coefficient""")
 
-    c_ie = NArray(
+    c_ei = NArray(
         label=":math:`c_{ei}`",
         default=numpy.array([4.0]),
         domain=Range(lo=2.0, hi=15.0, step=0.01),
         doc="""Inhibitory to excitatory coupling coefficient""")
 
-    c_ei = NArray(
+    c_ie = NArray(
         label=":math:`c_{ie}`",
         default=numpy.array([13.0]),
         domain=Range(lo=2.0, hi=22.0, step=0.01),


### PR DESCRIPTION
The variable name is not the same with the label (which I assume is what appears in the TVB GUI).
Change variable name to suit label and also align with the differential equations.
Checked with pg10 of Wilson Cowan 1972.