### PR TITLE
TVB-2736. Enhance Copy simulation use-case 

### DIFF
--- a/framework_tvb/tvb/adapters/simulator/integrator_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/integrator_forms.py
@@ -79,7 +79,8 @@ class IntegratorStochasticForm(IntegratorForm):
 
     def fill_trait(self, datatype):
         super(IntegratorStochasticForm, self).fill_trait(datatype)
-        datatype.noise = self.noise.data()
+        if type(datatype.noise) != self.noise.data:
+            datatype.noise = self.noise.data()
 
     def fill_from_trait(self, trait):
         # type: (Integrator) -> None

--- a/framework_tvb/tvb/adapters/simulator/integrator_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/integrator_forms.py
@@ -29,25 +29,29 @@
 #
 from tvb.adapters.simulator.noise_forms import get_form_for_noise
 from tvb.adapters.simulator.subforms_mapping import SubformsEnum, get_ui_name_to_noise_dict
-from tvb.simulator.integrators import *
+from tvb.basic.neotraits.api import Attr
+from tvb.core.entities.file.simulator.view_model import HeunDeterministicViewModel, HeunStochasticViewModel, \
+    EulerDeterministicViewModel, EulerStochasticViewModel, RungeKutta4thOrderDeterministicViewModel, IdentityViewModel, \
+    VODEViewModel, VODEStochasticViewModel, Dopri5ViewModel, Dopri5StochasticViewModel, Dop853ViewModel, \
+    Dop853StochasticViewModel, IntegratorViewModel, NoiseViewModel
+from tvb.core.entities.file.simulator.view_model import IntegratorStochasticViewModel
 from tvb.core.neotraits.forms import Form, ScalarField, SelectField
-from tvb.simulator.noise import Noise
 
 
 def get_integrator_to_form_dict():
     integrator_class_to_form = {
-        HeunDeterministic: HeunDeterministicIntegratorForm,
-        HeunStochastic: HeunStochasticIntegratorForm,
-        EulerDeterministic: EulerDeterministicIntegratorForm,
-        EulerStochastic: EulerStochasticIntegratorForm,
-        RungeKutta4thOrderDeterministic: RungeKutta4thOrderDeterministicIntegratorForm,
-        Identity: IdentityIntegratorForm,
-        VODE: VODEIntegratorForm,
-        VODEStochastic: VODEStochasticIntegratorForm,
-        Dopri5: Dopri5IntegratorForm,
-        Dopri5Stochastic: Dopri5StochasticIntegratorForm,
-        Dop853: Dop853IntegratorForm,
-        Dop853Stochastic: Dop853StochasticIntegratorForm
+        HeunDeterministicViewModel: HeunDeterministicIntegratorForm,
+        HeunStochasticViewModel: HeunStochasticIntegratorForm,
+        EulerDeterministicViewModel: EulerDeterministicIntegratorForm,
+        EulerStochasticViewModel: EulerStochasticIntegratorForm,
+        RungeKutta4thOrderDeterministicViewModel: RungeKutta4thOrderDeterministicIntegratorForm,
+        IdentityViewModel: IdentityIntegratorForm,
+        VODEViewModel: VODEIntegratorForm,
+        VODEStochasticViewModel: VODEStochasticIntegratorForm,
+        Dopri5ViewModel: Dopri5IntegratorForm,
+        Dopri5StochasticViewModel: Dopri5StochasticIntegratorForm,
+        Dop853ViewModel: Dop853IntegratorForm,
+        Dop853StochasticViewModel: Dop853StochasticIntegratorForm
     }
     return integrator_class_to_form
 
@@ -63,7 +67,7 @@ class IntegratorForm(Form):
 
     def __init__(self, prefix=''):
         super(IntegratorForm, self).__init__(prefix)
-        self.dt = ScalarField(Integrator.dt, self)
+        self.dt = ScalarField(IntegratorViewModel.dt, self)
 
 
 class IntegratorStochasticForm(IntegratorForm):
@@ -74,7 +78,7 @@ class IntegratorStochasticForm(IntegratorForm):
         self.noise_choices = get_ui_name_to_noise_dict()
         default_noise = list(self.noise_choices.values())[0]
 
-        self.noise = SelectField(Attr(Noise, label='Noise', default=default_noise), self, name='noise',
+        self.noise = SelectField(Attr(NoiseViewModel, label='Noise', default=default_noise), self, name='noise',
                                  choices=self.noise_choices, subform=get_form_for_noise(default_noise))
 
     def fill_trait(self, datatype):
@@ -83,7 +87,7 @@ class IntegratorStochasticForm(IntegratorForm):
             datatype.noise = self.noise.data()
 
     def fill_from_trait(self, trait):
-        # type: (Integrator) -> None
+        # type: (IntegratorStochasticViewModel) -> None
         self.noise.data = trait.noise.__class__
 
 

--- a/framework_tvb/tvb/adapters/simulator/monitor_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/monitor_forms.py
@@ -213,7 +213,8 @@ class BoldMonitorForm(MonitorForm):
     def fill_trait(self, datatype):
         super(BoldMonitorForm, self).fill_trait(datatype)
         datatype.period = self.period.data
-        datatype.hrf_kernel = self.hrf_kernel.data()
+        if type(datatype.hrf_kernel) != self.hrf_kernel.data:
+            datatype.hrf_kernel = self.hrf_kernel.data()
 
     def fill_from_trait(self, trait):
         super(BoldMonitorForm, self).fill_from_trait(trait)

--- a/framework_tvb/tvb/adapters/simulator/noise_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/noise_forms.py
@@ -87,7 +87,8 @@ class MultiplicativeNoiseForm(NoiseForm):
     def fill_trait(self, datatype):
         super(MultiplicativeNoiseForm, self).fill_trait(datatype)
         datatype.nsig = self.nsig.data
-        datatype.b = self.equation.data()
+        if type(datatype.b) != self.equation.data:
+            datatype.b = self.equation.data()
 
     def fill_from_trait(self, trait):
         # type: (Noise) -> None

--- a/framework_tvb/tvb/adapters/simulator/noise_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/noise_forms.py
@@ -31,16 +31,17 @@ from tvb.adapters.simulator.equation_forms import get_form_for_equation
 from tvb.adapters.simulator.form_with_ranges import FormWithRanges
 from tvb.adapters.simulator.subforms_mapping import SubformsEnum, get_ui_name_to_equation_dict
 from tvb.basic.neotraits.api import Attr, Range
+from tvb.core.entities.file.simulator.view_model import NoiseViewModel, AdditiveNoiseViewModel, \
+    MultiplicativeNoiseViewModel
 from tvb.core.entities.transient.range_parameter import RangeParameter
 from tvb.core.neotraits.forms import ScalarField, ArrayField, SelectField
 from tvb.datatypes.equations import Equation
-from tvb.simulator.noise import Noise, Additive, Multiplicative
 
 
 def get_form_for_noise(noise_class):
     noise_class_to_form = {
-        Additive: AdditiveNoiseForm,
-        Multiplicative: MultiplicativeNoiseForm,
+        AdditiveNoiseViewModel: AdditiveNoiseForm,
+        MultiplicativeNoiseViewModel: MultiplicativeNoiseForm,
     }
 
     return noise_class_to_form.get(noise_class)
@@ -53,8 +54,8 @@ class NoiseForm(FormWithRanges):
 
     def __init__(self, prefix=''):
         super(NoiseForm, self).__init__(prefix)
-        self.ntau = ScalarField(Noise.ntau, self)
-        self.noise_seed = ScalarField(Noise.noise_seed, self)
+        self.ntau = ScalarField(NoiseViewModel.ntau, self)
+        self.noise_seed = ScalarField(NoiseViewModel.noise_seed, self)
         # TODO: should we display something for random_stream?
         # self.random_stream = ScalarField(Noise.random_stream)
 
@@ -63,10 +64,10 @@ class AdditiveNoiseForm(NoiseForm):
 
     def __init__(self, prefix=''):
         super(AdditiveNoiseForm, self).__init__(prefix)
-        self.nsig = ArrayField(Additive.nsig, self)
+        self.nsig = ArrayField(AdditiveNoiseViewModel.nsig, self)
 
     def get_range_parameters(self):
-        ntau_range_param = RangeParameter(Noise.ntau.field_name, float, Range(lo=0.0, hi=20.0, step=1.0))
+        ntau_range_param = RangeParameter(NoiseViewModel.ntau.field_name, float, Range(lo=0.0, hi=20.0, step=1.0))
         params_with_range_defined = super(NoiseForm, self).get_range_parameters()
         params_with_range_defined.append(ntau_range_param)
 
@@ -80,7 +81,7 @@ class MultiplicativeNoiseForm(NoiseForm):
         self.equation_choices = get_ui_name_to_equation_dict()
         default_equation = list(self.equation_choices.values())[0]
 
-        self.nsig = ArrayField(Multiplicative.nsig, self)
+        self.nsig = ArrayField(MultiplicativeNoiseViewModel.nsig, self)
         self.equation = SelectField(Attr(Equation, label='Equation', default=default_equation), self, name='equation',
                                     choices=self.equation_choices, subform=get_form_for_equation(default_equation))
 
@@ -91,6 +92,6 @@ class MultiplicativeNoiseForm(NoiseForm):
             datatype.b = self.equation.data()
 
     def fill_from_trait(self, trait):
-        # type: (Noise) -> None
+        # type: (NoiseViewModel) -> None
         super(MultiplicativeNoiseForm, self).fill_from_trait(trait)
         self.equation.data = trait.b.__class__

--- a/framework_tvb/tvb/adapters/simulator/simulator_adapter.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_adapter.py
@@ -60,6 +60,7 @@ from tvb.core.adapters.exceptions import LaunchException
 from tvb.core.neotraits.forms import FloatField, SelectField
 from tvb.core.neocom import h5
 from tvb.simulator.coupling import Coupling
+from tvb.simulator.integrators import IntegratorStochastic
 from tvb.simulator.simulator import Simulator
 
 

--- a/framework_tvb/tvb/adapters/simulator/simulator_adapter.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_adapter.py
@@ -90,7 +90,8 @@ class SimulatorAdapterForm(ABCAdapterForm):
         datatype.connectivity = self.connectivity.value
         datatype.conduction_speed = self.conduction_speed.value
         coupling = self.coupling.value
-        datatype.coupling = coupling()
+        if type(datatype.coupling) != coupling:
+            datatype.coupling = coupling()
 
     @staticmethod
     def get_view_model():

--- a/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
@@ -64,8 +64,9 @@ class SimulatorSurfaceFragment(ABCAdapterForm):
     def fill_trait(self, datatype):
         surface_gid = self.surface.value
         if surface_gid:
-            datatype.surface = CortexViewModel()
-            datatype.surface.surface_gid = surface_gid
+            if not datatype.surface or (datatype.surface and datatype.surface.surface_gid != surface_gid):
+                datatype.surface = CortexViewModel()
+                datatype.surface.surface_gid = surface_gid
         else:
             datatype.surface = None
 
@@ -117,7 +118,8 @@ class SimulatorModelFragment(ABCAdapterForm):
         self.model.data = trait.model.__class__
 
     def fill_trait(self, datatype):
-        datatype.model = self.model.value()
+        if type(datatype.model) != self.model.value:
+            datatype.model = self.model.value()
 
 
 class SimulatorIntegratorFragment(ABCAdapterForm):
@@ -137,7 +139,8 @@ class SimulatorIntegratorFragment(ABCAdapterForm):
         self.integrator.data = trait.integrator.__class__
 
     def fill_trait(self, datatype):
-        datatype.integrator = self.integrator.value()
+        if type(datatype.integrator) != self.integrator.value:
+            datatype.integrator = self.integrator.value()
 
 
 class SimulatorMonitorFragment(ABCAdapterForm):

--- a/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
@@ -39,7 +39,7 @@ from tvb.adapters.simulator.monitor_forms import get_ui_name_to_monitor_dict, ge
 from tvb.adapters.simulator.subforms_mapping import get_ui_name_to_integrator_dict
 from tvb.basic.neotraits.api import Attr, Range, List
 from tvb.core.adapters.abcadapter import ABCAdapterForm
-from tvb.core.entities.file.simulator.view_model import CortexViewModel, SimulatorAdapterModel
+from tvb.core.entities.file.simulator.view_model import CortexViewModel, SimulatorAdapterModel, IntegratorViewModel
 from tvb.core.entities.filters.chain import FilterChain
 from tvb.core.entities.transient.range_parameter import RangeParameter
 from tvb.core.neocom import h5
@@ -47,10 +47,7 @@ from tvb.core.neotraits.forms import ScalarField, ArrayField, SimpleFloatField, 
     MultiSelectField, TraitDataTypeSelectField
 from tvb.core.neotraits.view_model import Str
 from tvb.datatypes.surfaces import CORTICAL
-from tvb.simulator.integrators import Integrator
 from tvb.simulator.models.base import Model
-from tvb.simulator.simulator import Simulator
-
 
 
 class SimulatorSurfaceFragment(ABCAdapterForm):
@@ -110,11 +107,12 @@ class SimulatorModelFragment(ABCAdapterForm):
         default_model = list(self.model_choices.values())[0]
 
         self.model = SelectField(
-            Attr(Model, default=default_model, label=Simulator.model.label, doc=Simulator.model.doc), self,
+            Attr(Model, default=default_model, label=SimulatorAdapterModel.model.label,
+                 doc=SimulatorAdapterModel.model.doc), self,
             choices=self.model_choices, name='model')
 
     def fill_from_trait(self, trait):
-        # type: (Simulator) -> None
+        # type: (SimulatorAdapterModel) -> None
         self.model.data = trait.model.__class__
 
     def fill_trait(self, datatype):
@@ -129,13 +127,14 @@ class SimulatorIntegratorFragment(ABCAdapterForm):
         self.integrator_choices = get_ui_name_to_integrator_dict()
         default_integrator = list(self.integrator_choices.values())[0]
 
-        self.integrator = SelectField(Attr(Integrator, default=default_integrator, label=Simulator.integrator.label,
-                                           doc=Simulator.integrator.doc), self, name='integrator',
-                                      choices=self.integrator_choices,
-                                      subform=get_form_for_integrator(default_integrator))
+        self.integrator = SelectField(
+            Attr(IntegratorViewModel, default=default_integrator, label=SimulatorAdapterModel.integrator.label,
+                 doc=SimulatorAdapterModel.integrator.doc), self, name='integrator',
+            choices=self.integrator_choices,
+            subform=get_form_for_integrator(default_integrator))
 
     def fill_from_trait(self, trait):
-        # type: (Simulator) -> None
+        # type: (SimulatorAdapterModel) -> None
         self.integrator.data = trait.integrator.__class__
 
     def fill_trait(self, datatype):
@@ -155,7 +154,7 @@ class SimulatorMonitorFragment(ABCAdapterForm):
                                          self, name='monitors')
 
     def fill_from_trait(self, trait):
-        # type: (Simulator) -> None
+        # type: (SimulatorAdapterModel) -> None
         self.monitors.data = [
             get_monitor_to_ui_name_dict(self.is_surface_simulation)[type(monitor)]
             for monitor in trait]
@@ -165,10 +164,10 @@ class SimulatorFinalFragment(ABCAdapterForm):
 
     def __init__(self, prefix='', project_id=None, default_simulation_name="simulation_1"):
         super(SimulatorFinalFragment, self).__init__(prefix, project_id)
-        self.simulation_length = ScalarField(Simulator.simulation_length, self)
+        self.simulation_length = ScalarField(SimulatorAdapterModel.simulation_length, self)
         self.simulation_name = ScalarField(Attr(str, doc='Name for the current simulation configuration',
-                                                default=default_simulation_name,
-                                                label='Simulation name'), self, name='input_simulation_name_id')
+                                                default=default_simulation_name, label='Simulation name'), self,
+                                           name='input_simulation_name_id')
 
     def fill_from_post(self, form_data):
         super(SimulatorFinalFragment, self).fill_from_post(form_data)

--- a/framework_tvb/tvb/adapters/simulator/subforms_mapping.py
+++ b/framework_tvb/tvb/adapters/simulator/subforms_mapping.py
@@ -29,9 +29,12 @@
 #
 from enum import Enum
 from functools import partial
-from tvb.simulator.integrators import *
+
+from tvb.core.entities.file.simulator.view_model import HeunDeterministicViewModel, HeunStochasticViewModel, \
+    EulerDeterministicViewModel, EulerStochasticViewModel, RungeKutta4thOrderDeterministicViewModel, IdentityViewModel, \
+    VODEViewModel, VODEStochasticViewModel, Dopri5ViewModel, Dopri5StochasticViewModel, Dop853ViewModel, \
+    Dop853StochasticViewModel, AdditiveNoiseViewModel, MultiplicativeNoiseViewModel
 from tvb.datatypes.equations import *
-from tvb.simulator.noise import Additive, Multiplicative
 
 LINEAR_EQUATION = 'Linear'
 GAUSSIAN_EQUATION = 'Gaussian'
@@ -61,26 +64,26 @@ def get_ui_name_to_equation_dict():
 
 def get_ui_name_to_noise_dict():
     ui_name_to_noise = {
-        'Additive': Additive,
-        'Multiplicative': Multiplicative
+        'Additive': AdditiveNoiseViewModel,
+        'Multiplicative': MultiplicativeNoiseViewModel
     }
     return ui_name_to_noise
 
 
 def get_ui_name_to_integrator_dict():
     ui_name_to_integrator = {
-        'Heun': HeunDeterministic,
-        'Stochastic Heun': HeunStochastic,
-        'Euler': EulerDeterministic,
-        'Euler-Maruyama': EulerStochastic,
-        'Runge-Kutta 4th order': RungeKutta4thOrderDeterministic,
-        '"Difference equation': Identity,
-        'Variable-order Adams / BDF': VODE,
-        'Stochastic variable-order Adams / BDF': VODEStochastic,
-        'Dormand-Prince, order (4, 5)': Dopri5,
-        'Stochastic Dormand-Prince, order (4, 5)': Dopri5Stochastic,
-        'Dormand-Prince, order 8 (5, 3)': Dop853,
-        'Stochastic Dormand-Prince, order 8 (5, 3)': Dop853Stochastic,
+        'Heun': HeunDeterministicViewModel,
+        'Stochastic Heun': HeunStochasticViewModel,
+        'Euler': EulerDeterministicViewModel,
+        'Euler-Maruyama': EulerStochasticViewModel,
+        'Runge-Kutta 4th order': RungeKutta4thOrderDeterministicViewModel,
+        '"Difference equation': IdentityViewModel,
+        'Variable-order Adams / BDF': VODEViewModel,
+        'Stochastic variable-order Adams / BDF': VODEStochasticViewModel,
+        'Dormand-Prince, order (4, 5)': Dopri5ViewModel,
+        'Stochastic Dormand-Prince, order (4, 5)': Dopri5StochasticViewModel,
+        'Dormand-Prince, order 8 (5, 3)': Dop853ViewModel,
+        'Stochastic Dormand-Prince, order 8 (5, 3)': Dop853StochasticViewModel,
 
     }
     return ui_name_to_integrator

--- a/framework_tvb/tvb/core/entities/file/simulator/view_model.py
+++ b/framework_tvb/tvb/core/entities/file/simulator/view_model.py
@@ -30,17 +30,139 @@
 from tvb.basic.neotraits.api import Attr, List
 from tvb.core.entities.file.simulator.simulation_history_h5 import SimulationHistory
 from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
+from tvb.datatypes.connectivity import Connectivity
 from tvb.datatypes.cortex import Cortex
+from tvb.datatypes.local_connectivity import LocalConnectivity
+from tvb.datatypes.patterns import SpatioTemporalPattern
 from tvb.datatypes.projections import ProjectionSurfaceEEG, ProjectionSurfaceMEG, ProjectionSurfaceSEEG
+from tvb.datatypes.region_mapping import RegionMapping
 from tvb.datatypes.sensors import SensorsEEG, SensorsMEG, SensorsInternal
 from tvb.datatypes.surfaces import CorticalSurface
-from tvb.datatypes.local_connectivity import LocalConnectivity
-from tvb.datatypes.region_mapping import RegionMapping
+from tvb.simulator.integrators import HeunDeterministic, Integrator, IntegratorStochastic, HeunStochastic, \
+    EulerDeterministic, EulerStochastic, RungeKutta4thOrderDeterministic, Identity, VODE, VODEStochastic, Dopri5, \
+    Dopri5Stochastic, Dop853, Dop853Stochastic
 from tvb.simulator.monitors import Monitor, EEG, MEG, iEEG, Raw, SubSample, SpatialAverage, GlobalAverage, \
     TemporalAverage, Projection, Bold, BoldRegionROI
+from tvb.simulator.noise import Noise, Additive, Multiplicative
 from tvb.simulator.simulator import Simulator
-from tvb.datatypes.connectivity import Connectivity
-from tvb.datatypes.patterns import SpatioTemporalPattern
+
+
+class NoiseViewModel(ViewModel, Noise):
+    @property
+    def linked_has_traits(self):
+        return Noise
+
+
+class AdditiveNoiseViewModel(NoiseViewModel, Additive):
+    @property
+    def linked_has_traits(self):
+        return Additive
+
+
+class MultiplicativeNoiseViewModel(NoiseViewModel, Multiplicative):
+    @property
+    def linked_has_traits(self):
+        return Multiplicative
+
+    def __init__(self):
+        super(MultiplicativeNoiseViewModel, self).__init__()
+        self.b = type(self.b)()
+
+
+class IntegratorViewModel(ViewModel, Integrator):
+    @property
+    def linked_has_traits(self):
+        return Integrator
+
+
+class IntegratorStochasticViewModel(IntegratorViewModel, IntegratorStochastic):
+    noise = Attr(
+        field_type=NoiseViewModel,
+        label=IntegratorStochastic.noise.label,
+        default=AdditiveNoiseViewModel(),
+        required=IntegratorStochastic.noise.required,
+        doc=IntegratorStochastic.noise.doc
+    )
+
+    @property
+    def linked_has_traits(self):
+        return IntegratorStochastic
+
+    def __init__(self):
+        super(IntegratorStochasticViewModel, self).__init__()
+        self.noise = type(self.noise)()
+
+
+class HeunDeterministicViewModel(IntegratorViewModel, HeunDeterministic):
+    @property
+    def linked_has_traits(self):
+        return HeunDeterministic
+
+
+class HeunStochasticViewModel(IntegratorStochasticViewModel, HeunStochastic):
+    @property
+    def linked_has_traits(self):
+        return HeunStochastic
+
+
+class EulerDeterministicViewModel(IntegratorViewModel, EulerDeterministic):
+    @property
+    def linked_has_traits(self):
+        return EulerDeterministic
+
+
+class EulerStochasticViewModel(IntegratorStochasticViewModel, EulerStochastic):
+    @property
+    def linked_has_traits(self):
+        return EulerStochastic
+
+
+class RungeKutta4thOrderDeterministicViewModel(IntegratorViewModel, RungeKutta4thOrderDeterministic):
+    @property
+    def linked_has_traits(self):
+        return RungeKutta4thOrderDeterministic
+
+
+class IdentityViewModel(IntegratorViewModel, Identity):
+    @property
+    def linked_has_traits(self):
+        return Identity
+
+
+class VODEViewModel(IntegratorViewModel, VODE):
+    @property
+    def linked_has_traits(self):
+        return VODE
+
+
+class VODEStochasticViewModel(IntegratorStochasticViewModel, VODEStochastic):
+    @property
+    def linked_has_traits(self):
+        return VODEStochastic
+
+
+class Dopri5ViewModel(IntegratorViewModel, Dopri5):
+    @property
+    def linked_has_traits(self):
+        return Dopri5
+
+
+class Dopri5StochasticViewModel(IntegratorStochasticViewModel, Dopri5Stochastic):
+    @property
+    def linked_has_traits(self):
+        return Dopri5Stochastic
+
+
+class Dop853ViewModel(IntegratorViewModel, Dop853):
+    @property
+    def linked_has_traits(self):
+        return Dop853
+
+
+class Dop853StochasticViewModel(IntegratorStochasticViewModel, Dop853Stochastic):
+    @property
+    def linked_has_traits(self):
+        return Dop853Stochastic
 
 
 class MonitorViewModel(ViewModel, Monitor):
@@ -151,6 +273,10 @@ class BoldViewModel(MonitorViewModel, Bold):
     def linked_has_traits(self):
         return Bold
 
+    def __init__(self):
+        super(BoldViewModel, self).__init__()
+        self.hrf_kernel = type(self.hrf_kernel)()
+
 
 class BoldRegionROIViewModel(BoldViewModel, BoldRegionROI):
     @property
@@ -220,9 +346,24 @@ class SimulatorAdapterModel(ViewModel, Simulator):
         required=False
     )
 
+    integrator = Attr(
+        field_type=IntegratorViewModel,
+        label=Simulator.integrator.label,
+        default=HeunDeterministicViewModel(),
+        required=Simulator.integrator.required,
+        doc=Simulator.integrator.doc
+    )
+
     monitors = List(
         of=MonitorViewModel,
         label=Simulator.monitors.label,
         default=(TemporalAverageViewModel(),),
         doc=Simulator.monitors.doc
     )
+
+    def __init__(self):
+        super(SimulatorAdapterModel, self).__init__()
+        self.coupling = type(self.coupling)()
+        self.model = type(self.model)()
+        self.integrator = type(self.integrator)()
+        self.monitors = (type(self.monitors[0])(),)

--- a/framework_tvb/tvb/core/services/simulator_service.py
+++ b/framework_tvb/tvb/core/services/simulator_service.py
@@ -100,7 +100,8 @@ class SimulatorService(object):
         In case the user copies a surface-simulation and changes the Surface, we want to reset the Model
         parameters because they might not fit to the new Surface's nr of vertices.
         """
-        if is_simulator_copy and session_stored_simulator.surface and form.surface.value != session_stored_simulator.surface.surface_gid:
+        if is_simulator_copy and (session_stored_simulator.surface is None and form.surface.value
+                                  or session_stored_simulator.surface and form.surface.value != session_stored_simulator.surface.surface_gid):
             self._reset_model(session_stored_simulator)
 
     @transactional

--- a/framework_tvb/tvb/interfaces/web/controllers/burst/dynamic_model_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/burst/dynamic_model_controller.py
@@ -46,6 +46,7 @@ from tvb.adapters.visualizers.phase_plane_interactive import phase_space_d3
 from tvb.basic.logger.builder import get_logger
 from tvb.core import utils
 from tvb.core.adapters.abcadapter import ABCAdapterForm
+from tvb.core.entities.file.simulator.view_model import HeunDeterministicViewModel, IntegratorStochasticViewModel
 from tvb.core.entities.storage import dao
 import tvb.core.entities.model.model_burst as model_burst
 from tvb.core.neotraits.forms import SimpleStrField
@@ -55,7 +56,7 @@ from tvb.interfaces.web.controllers.autologging import traced
 from tvb.interfaces.web.controllers.burst.base_controller import BurstBaseController
 from tvb.interfaces.web.controllers.decorators import expose_page, expose_json, expose_fragment, using_template, \
     handle_error, check_user
-from tvb.simulator import models, integrators
+from tvb.simulator import models
 
 
 class Dynamic(object):
@@ -66,7 +67,7 @@ class Dynamic(object):
         if model is None:
             model = models.Generic2dOscillator()
         if integrator is None:
-            integrator = integrators.HeunDeterministic()
+            integrator = HeunDeterministicViewModel()
 
         model.configure()
         self.model = model
@@ -270,7 +271,7 @@ class DynamicModelController(BurstBaseController):
         Should I call noise.configure() as well?
         similar to simulator.configure_integrator_noise
         """
-        if isinstance(integrator, integrators.IntegratorStochastic):
+        if isinstance(integrator, IntegratorStochasticViewModel):
             shape = (model.nvar, 1, model.number_of_modes)
             if integrator.noise.ntau > 0.0:
                 integrator.noise.configure_coloured(integrator.dt, shape)

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
@@ -53,7 +53,6 @@ from tvb.core.services.exceptions import BurstServiceException, ServicesBaseExce
 from tvb.core.services.simulator_service import SimulatorService
 from tvb.interfaces.web.controllers.autologging import traced
 from tvb.interfaces.web.controllers.burst.base_controller import BurstBaseController
-from tvb.interfaces.web.controllers.common import KEY_ADAPTER
 from tvb.interfaces.web.controllers.decorators import *
 from tvb.interfaces.web.controllers.flow_controller import FlowController
 from tvb.simulator.coupling import Linear

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
@@ -325,10 +325,7 @@ class SimulatorController(BurstBaseController):
         form.fill_from_trait(session_stored_simulator)
         return form
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def set_connectivity(self, **data):
         session_stored_simulator = common.get_from_session(common.KEY_SIMULATOR_CONFIG)
         is_simulator_copy = common.get_from_session(common.KEY_IS_SIMULATOR_COPY) or False
@@ -351,10 +348,7 @@ class SimulatorController(BurstBaseController):
                                                           cherrypy.request.method)
         return rendering_rules.to_dict()
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def set_coupling_params(self, **data):
         session_stored_simulator = common.get_from_session(common.KEY_SIMULATOR_CONFIG)
         is_simulator_copy = common.get_from_session(common.KEY_IS_SIMULATOR_COPY) or False
@@ -394,10 +388,7 @@ class SimulatorController(BurstBaseController):
         rendering_rules.form_action_url = SimulatorWizzardURLs.SET_STIMULUS_URL
         return rendering_rules.to_dict()
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def set_surface(self, **data):
         session_stored_simulator = common.get_from_session(common.KEY_SIMULATOR_CONFIG)
         is_simulator_copy = common.get_from_session(common.KEY_IS_SIMULATOR_COPY) or False
@@ -424,10 +415,7 @@ class SimulatorController(BurstBaseController):
             return self._prepare_cortex_fragment(session_stored_simulator, rendering_rules)
         return self._prepare_stimulus_fragment(session_stored_simulator, rendering_rules, False)
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def set_cortex(self, **data):
         session_stored_simulator = common.get_from_session(common.KEY_SIMULATOR_CONFIG)
         is_simulator_copy = common.get_from_session(common.KEY_IS_SIMULATOR_COPY) or False
@@ -444,10 +432,7 @@ class SimulatorController(BurstBaseController):
                                                           self.last_loaded_form_url, cherrypy.request.method)
         return self._prepare_stimulus_fragment(session_stored_simulator, rendering_rules, True)
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def set_stimulus(self, **data):
         session_stored_simulator = common.get_from_session(common.KEY_SIMULATOR_CONFIG)
         is_simulator_copy = common.get_from_session(common.KEY_IS_SIMULATOR_COPY) or False
@@ -470,10 +455,7 @@ class SimulatorController(BurstBaseController):
                                                           is_surface_simulation=session_stored_simulator.is_surface_simulation)
         return rendering_rules.to_dict()
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def set_model(self, **data):
         session_stored_simulator = common.get_from_session(common.KEY_SIMULATOR_CONFIG)
         is_simulator_copy = common.get_from_session(common.KEY_IS_SIMULATOR_COPY) or False
@@ -495,10 +477,7 @@ class SimulatorController(BurstBaseController):
                                                           cherrypy.request.method)
         return rendering_rules.to_dict()
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def set_model_params(self, **data):
         session_stored_simulator = common.get_from_session(common.KEY_SIMULATOR_CONFIG)
         is_simulator_copy = common.get_from_session(common.KEY_IS_SIMULATOR_COPY) or False
@@ -520,10 +499,7 @@ class SimulatorController(BurstBaseController):
                                                           cherrypy.request.method)
         return rendering_rules.to_dict()
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def set_integrator(self, **data):
         session_stored_simulator = common.get_from_session(common.KEY_SIMULATOR_CONFIG)
         is_simulator_copy = common.get_from_session(common.KEY_IS_SIMULATOR_COPY) or False
@@ -556,10 +532,7 @@ class SimulatorController(BurstBaseController):
         rendering_rules.form_action_url = SimulatorWizzardURLs.SET_MONITORS_URL
         return rendering_rules.to_dict()
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def set_integrator_params(self, **data):
         session_stored_simulator = common.get_from_session(common.KEY_SIMULATOR_CONFIG)
         is_simulator_copy = common.get_from_session(common.KEY_IS_SIMULATOR_COPY) or False
@@ -593,10 +566,7 @@ class SimulatorController(BurstBaseController):
         rendering_rules.is_noise_fragment = True
         return rendering_rules.to_dict()
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def set_noise_params(self, **data):
         session_stored_simulator = common.get_from_session(common.KEY_SIMULATOR_CONFIG)
         is_simulator_copy = common.get_from_session(common.KEY_IS_SIMULATOR_COPY) or False
@@ -626,10 +596,7 @@ class SimulatorController(BurstBaseController):
         rendering_rules.form_action_url = SimulatorWizzardURLs.SET_NOISE_EQUATION_PARAMS_URL
         return rendering_rules.to_dict()
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def set_noise_equation_params(self, **data):
         session_stored_simulator = common.get_from_session(common.KEY_SIMULATOR_CONFIG)
         is_simulator_copy = common.get_from_session(common.KEY_IS_SIMULATOR_COPY) or False
@@ -711,10 +678,7 @@ class SimulatorController(BurstBaseController):
         rendering_rules.is_pse_launch = session_stored_burst.is_pse_burst()
         return rendering_rules.to_dict()
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def set_monitors(self, **data):
         session_stored_simulator = common.get_from_session(common.KEY_SIMULATOR_CONFIG)
         is_simulator_copy = common.get_from_session(common.KEY_IS_SIMULATOR_COPY) or False
@@ -783,10 +747,7 @@ class SimulatorController(BurstBaseController):
         # Currently at the last monitor
         return None, len(monitors) - 1
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def set_monitor_params(self, current_monitor, **data):
         session_stored_simulator = common.get_from_session(common.KEY_SIMULATOR_CONFIG)
         next_monitor, current_monitor_index = self._get_current_index_and_next_monitor(
@@ -830,10 +791,7 @@ class SimulatorController(BurstBaseController):
                                                                           type(monitor).__name__)
         return self._handle_next_fragment_for_monitors(session_stored_simulator, next_monitor, rendering_rules)
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def set_monitor_equation(self, current_monitor, **data):
         session_stored_simulator = common.get_from_session(common.KEY_SIMULATOR_CONFIG)
         next_monitor, current_monitor_index = self._get_current_index_and_next_monitor(
@@ -862,10 +820,7 @@ class SimulatorController(BurstBaseController):
 
         return self._handle_next_fragment_for_monitors(session_stored_simulator, next_monitor, rendering_rules)
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def setup_pse(self, **data):
         is_simulator_copy = common.get_from_session(common.KEY_IS_SIMULATOR_COPY) or False
         is_simulator_load = common.get_from_session(common.KEY_IS_SIMULATOR_LOAD) or False
@@ -904,10 +859,7 @@ class SimulatorController(BurstBaseController):
 
         return param1, param2
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def set_pse_params(self, **data):
         is_simulator_copy = common.get_from_session(common.KEY_IS_SIMULATOR_COPY) or False
         is_simulator_load = common.get_from_session(common.KEY_IS_SIMULATOR_LOAD) or False
@@ -937,9 +889,6 @@ class SimulatorController(BurstBaseController):
         return rendering_rules.to_dict()
 
     @expose_json
-    @cherrypy.expose
-    @handle_error(redirect=False)
-    @check_user
     def launch_pse(self, **data):
         all_range_parameters = self.range_parameters.get_all_range_parameters()
         range_param1, range_param2 = SimulatorPSERangeFragment.fill_from_post(all_range_parameters, **data)
@@ -971,9 +920,6 @@ class SimulatorController(BurstBaseController):
             return {'error': e.message}
 
     @expose_json
-    @cherrypy.expose
-    @handle_error(redirect=False)
-    @check_user
     def launch_simulation(self, launch_mode, **data):
         current_form = SimulatorFinalFragment()
         session_burst_config = common.get_from_session(common.KEY_BURST_CONFIG)
@@ -1051,10 +997,7 @@ class SimulatorController(BurstBaseController):
         common.add2session(common.KEY_BURST_CONFIG, burst_config)
         return self._prepare_last_fragment_by_burst_type(burst_config)
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def load_burst_read_only(self, burst_config_id):
         try:
             burst_config = self.burst_service.load_burst_configuration(burst_config_id)
@@ -1079,10 +1022,7 @@ class SimulatorController(BurstBaseController):
             common.remove_from_session(common.KEY_BURST_CONFIG)
             raise
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def copy_simulator_configuration(self, burst_config_id):
         burst_config = self.burst_service.load_burst_configuration(burst_config_id)
         burst_config_copy = burst_config.clone()
@@ -1104,10 +1044,7 @@ class SimulatorController(BurstBaseController):
                                                           is_first_fragment=True)
         return rendering_rules.to_dict()
 
-    @cherrypy.expose
-    @using_template("simulator_fragment")
-    @handle_error(redirect=False)
-    @check_user
+    @expose_fragment('simulator_fragment')
     def reset_simulator_configuration(self):
         common.add2session(common.KEY_SIMULATOR_CONFIG, None)
         common.add2session(common.KEY_IS_SIMULATOR_COPY, False)

--- a/framework_tvb/tvb/tests/framework/adapters/simulator/simulator_adapter_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/simulator/simulator_adapter_test.py
@@ -42,7 +42,6 @@ from tvb.core.adapters.abcadapter import ABCAdapter
 from tvb.core.entities.storage import dao
 from tvb.core.services.project_service import initialize_storage
 from tvb.datatypes.surfaces import CORTICAL
-from tvb.simulator.integrators import HeunDeterministic
 from tvb.tests.framework.core.factory import TestFactory
 from tvb.tests.framework.core.base_testcase import TransactionalTestCase
 
@@ -135,7 +134,6 @@ class TestSimulatorAdapter(TransactionalTestCase):
 
         # Modify integration step and simulation length:
         initial_simulation_length = model.simulation_length
-        model.integrator = HeunDeterministic()
         initial_integration_step = model.integrator.dt
 
         for factor in (2, 4, 10):

--- a/framework_tvb/tvb/tests/framework/conftest.py
+++ b/framework_tvb/tvb/tests/framework/conftest.py
@@ -625,7 +625,8 @@ def local_connectivity_index_factory(surface_factory, operation_factory):
 @pytest.fixture()
 def simulator_factory(connectivity_index_factory, operation_factory, region_mapping_index_factory):
     def build(user=None, project=None, op=None, nr_regions=76, monitor=TemporalAverageViewModel(), with_surface=False):
-        model = SimulatorAdapterModel(monitors=[monitor])
+        model = SimulatorAdapterModel()
+        model.monitors = [monitor]
         if not op:
             op = operation_factory(test_user=user, test_project=project)
         if not with_surface:

--- a/framework_tvb/tvb/tests/framework/core/neocom_test.py
+++ b/framework_tvb/tvb/tests/framework/core/neocom_test.py
@@ -31,12 +31,11 @@ import os
 
 import numpy
 from tvb.core.entities.file.files_helper import FilesHelper
-from tvb.core.entities.file.simulator.view_model import SimulatorAdapterModel, EEGViewModel
+from tvb.core.entities.file.simulator.view_model import SimulatorAdapterModel, EEGViewModel, HeunStochasticViewModel
 from tvb.core.entities.storage import dao
 from tvb.core.neocom import h5
 from tvb.core.neocom.h5 import load, store, load_from_dir, store_to_dir
 from tvb.datatypes.projections import ProjectionSurfaceEEG
-from tvb.simulator.integrators import HeunStochastic
 
 
 def test_store_load(tmpdir, connectivity_factory):
@@ -76,9 +75,8 @@ def test_store_simulator_view_model_noise(connectivity_index_factory, operation_
     conn = connectivity_index_factory()
     sim_view_model = SimulatorAdapterModel()
     sim_view_model.connectivity = conn.gid
-    integrator = HeunStochastic()
-    integrator.noise.noise_seed = 45
-    sim_view_model.integrator = integrator
+    sim_view_model.integrator = HeunStochasticViewModel()
+    sim_view_model.integrator.noise.noise_seed = 45
 
     op = operation_factory()
     storage_path = FilesHelper().get_project_folder(op.project, str(op.id))

--- a/framework_tvb/tvb/tests/framework/interfaces/web/controllers/noise_configuration_controller_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/web/controllers/noise_configuration_controller_test.py
@@ -34,11 +34,11 @@
 
 import json
 import cherrypy
+from tvb.core.entities.file.simulator.view_model import HeunStochasticViewModel
 from tvb.interfaces.web.controllers.simulator_controller import SimulatorController
 from tvb.tests.framework.interfaces.web.controllers.base_controller_test import BaseTransactionalControllerTest
 from tvb.interfaces.web.controllers import common
 from tvb.interfaces.web.controllers.burst.noise_configuration_controller import NoiseConfigurationController
-from tvb.simulator.integrators import EulerStochastic, HeunStochastic
 
 
 class TestNoiseConfigurationController(BaseTransactionalControllerTest):
@@ -53,7 +53,7 @@ class TestNoiseConfigurationController(BaseTransactionalControllerTest):
         simulator = cherrypy.session[common.KEY_SIMULATOR_CONFIG]
         connectivity = connectivity_factory()
         simulator.connectivity = connectivity.gid
-        simulator.integrator = HeunStochastic()
+        simulator.integrator = HeunStochasticViewModel()
 
         # a noise configuration in the format expected by submit. Assumes Generic2dOscillator model.
         nodes_range = list(range(connectivity.number_of_regions))

--- a/framework_tvb/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
@@ -58,10 +58,7 @@ from tvb.datatypes.surfaces import CORTICAL
 from tvb.interfaces.web.controllers.common import *
 from tvb.interfaces.web.controllers.simulator_controller import SimulatorController, common
 from tvb.simulator.coupling import Sigmoidal
-from tvb.simulator.integrators import HeunDeterministic, IntegratorStochastic, Dopri5Stochastic, EulerStochastic
 from tvb.simulator.models import ModelsEnum
-from tvb.simulator.monitors import TemporalAverage, MEG, Bold, SubSample, EEG, iEEG
-from tvb.simulator.noise import Multiplicative
 from tvb.tests.framework.core.factory import TestFactory
 from tvb.tests.framework.interfaces.web.controllers.base_controller_test import BaseTransactionalControllerTest
 
@@ -293,7 +290,7 @@ class TestSimulationController(BaseTransactionalControllerTest):
             self.simulator_controller.set_integrator(**self.sess_mock._data)
 
         assert isinstance(self.session_stored_simulator.integrator,
-                          HeunDeterministic), "Integrator was not set correctly."
+                          HeunDeterministicViewModel), "Integrator was not set correctly."
 
     def test_set_integrator_params(self):
         self.sess_mock['dt'] = '0.01220703125'
@@ -308,16 +305,16 @@ class TestSimulationController(BaseTransactionalControllerTest):
         self.sess_mock['dt'] = '0.01220703125'
         self.sess_mock['noise'] = 'Multiplicative'
 
-        self.session_stored_simulator.integrator = Dopri5Stochastic()
+        self.session_stored_simulator.integrator = Dopri5StochasticViewModel()
 
         with patch('cherrypy.session', self.sess_mock, create=True):
             common.add2session(common.KEY_SIMULATOR_CONFIG, self.session_stored_simulator)
             rendering_rules = self.simulator_controller.set_integrator_params(**self.sess_mock._data)
 
-        assert isinstance(self.session_stored_simulator.integrator, IntegratorStochastic), \
+        assert isinstance(self.session_stored_simulator.integrator, IntegratorStochasticViewModel), \
             "Coupling should be Stochastic Dormand-Prince."
         assert self.session_stored_simulator.integrator.dt == 0.01220703125, 'dt value was not set correctly.'
-        assert isinstance(self.session_stored_simulator.integrator.noise, Multiplicative), 'Noise class is incorrect.'
+        assert isinstance(self.session_stored_simulator.integrator.noise, MultiplicativeNoiseViewModel), 'Noise class is incorrect.'
         assert rendering_rules['renderer'].is_noise_fragment, 'Noise fragment should be next!'
 
     def test_set_noise_params(self):
@@ -325,7 +322,7 @@ class TestSimulationController(BaseTransactionalControllerTest):
         self.sess_mock['noise_seed'] = '42'
         self.sess_mock['nsig'] = '[1.0]'
 
-        self.session_stored_simulator.integrator = EulerStochastic()
+        self.session_stored_simulator.integrator = EulerStochasticViewModel()
 
         with patch('cherrypy.session', self.sess_mock, create=True):
             common.add2session(common.KEY_SIMULATOR_CONFIG, self.session_stored_simulator)
@@ -342,8 +339,8 @@ class TestSimulationController(BaseTransactionalControllerTest):
         self.sess_mock['nsig'] = '[1.0]'
         self.sess_mock['equation'] = 'Linear'
 
-        self.session_stored_simulator.integrator = EulerStochastic()
-        self.session_stored_simulator.integrator.noise = Multiplicative()
+        self.session_stored_simulator.integrator = EulerStochasticViewModel()
+        self.session_stored_simulator.integrator.noise = MultiplicativeNoiseViewModel()
 
         with patch('cherrypy.session', self.sess_mock, create=True):
             common.add2session(common.KEY_SIMULATOR_CONFIG, self.session_stored_simulator)
@@ -362,8 +359,8 @@ class TestSimulationController(BaseTransactionalControllerTest):
         self.sess_mock['midpoint'] = '1.0'
         self.sess_mock['sigma'] = '0.3'
 
-        self.session_stored_simulator.integrator = Dopri5Stochastic()
-        self.session_stored_simulator.integrator.noise = Multiplicative()
+        self.session_stored_simulator.integrator = Dopri5StochasticViewModel()
+        self.session_stored_simulator.integrator.noise = MultiplicativeNoiseViewModel()
         self.session_stored_simulator.integrator.noise.b = GeneralizedSigmoid()
 
         with patch('cherrypy.session', self.sess_mock, create=True):
@@ -415,10 +412,10 @@ class TestSimulationController(BaseTransactionalControllerTest):
             common.add2session(common.KEY_BURST_CONFIG, BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitors(**self.sess_mock._data)
 
-        assert isinstance(self.session_stored_simulator.monitors[0], TemporalAverage), \
+        assert isinstance(self.session_stored_simulator.monitors[0], TemporalAverageViewModel), \
             'First monitor class is incorrect.'
-        assert isinstance(self.session_stored_simulator.monitors[1], EEG), 'Second monitor class is incorrect.'
-        assert isinstance(self.session_stored_simulator.monitors[2], MEG), 'Third monitor class is incorrect.'
+        assert isinstance(self.session_stored_simulator.monitors[1], EEGViewModel), 'Second monitor class is incorrect.'
+        assert isinstance(self.session_stored_simulator.monitors[2], MEGViewModel), 'Third monitor class is incorrect.'
 
     def test_set_monitor_params(self):
         self.session_stored_simulator.model.variables_of_interest = ('V', 'W', 'V - W')


### PR DESCRIPTION
At Copy time:
- fill fields from session for a better user experience
- reset dependent entities (model, noise) if the user changes the Connectivity/Surface

In the current form, it also keeps selected values at NEW simulation config, in case the user uses Previous.

Would help if someone else would also click a bit on the GUI to assess if there are inconsistencies left.