### PR TITLE
HBP-87 Move sensors type to library. Create an enum

### DIFF
--- a/framework_tvb/tvb/adapters/simulator/monitor_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/monitor_forms.py
@@ -157,7 +157,7 @@ class EEGMonitorForm(ProjectionMonitorForm):
                                     values=[SensorTypes.TYPE_EEG.value])
 
         projection_filter = FilterChain(fields=[FilterChain.datatype + '.projection_type'], operations=["=="],
-                                        values=[ProjectionsType.EEG_POLYMORPHIC_IDENTITY.value])
+                                        values=[ProjectionsType.EEG.value])
 
         self.projection = TraitDataTypeSelectField(EEGViewModel.projection, self, name='projection',
                                                    conditions=projection_filter)
@@ -172,10 +172,10 @@ class MEGMonitorForm(ProjectionMonitorForm):
         super(MEGMonitorForm, self).__init__(variables_of_interest_indexes, prefix, project_id)
 
         sensor_filter = FilterChain(fields=[FilterChain.datatype + '.sensors_type'], operations=["=="],
-                                    values=[SensorTypes.TYPE_MEG.value)
+                                    values=[SensorTypes.TYPE_MEG.value])
 
         projection_filter = FilterChain(fields=[FilterChain.datatype + '.projection_type'], operations=["=="],
-                                        values=[ProjectionsType.MEG_POLYMORPHIC_IDENTITY.value])
+                                        values=[ProjectionsType.MEG.value])
 
         self.projection = TraitDataTypeSelectField(MEGViewModel.projection, self, name='projection',
                                                    conditions=projection_filter)
@@ -188,10 +188,10 @@ class iEEGMonitorForm(ProjectionMonitorForm):
         super(iEEGMonitorForm, self).__init__(variables_of_interest_indexes, prefix, project_id)
 
         sensor_filter = FilterChain(fields=[FilterChain.datatype + '.sensors_type'], operations=["=="],
-                                    values=[SensorTypes.TYPE_SEEG.value])
+                                    values=[SensorTypes.TYPE_INTERNAL.value])
 
         projection_filter = FilterChain(fields=[FilterChain.datatype + '.projection_type'], operations=["=="],
-                                        values=[ProjectionsType.SEEG_POLYMORPHIC_IDENTITY.value])
+                                        values=[ProjectionsType.SEEG.value])
 
         self.projection = TraitDataTypeSelectField(iEEGViewModel.projection, self, name='projection',
                                                    conditions=projection_filter)

--- a/framework_tvb/tvb/adapters/simulator/monitor_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/monitor_forms.py
@@ -28,17 +28,13 @@
 #
 from tvb.core.entities.file.simulator.view_model import *
 from tvb.core.entities.filters.chain import FilterChain
-from tvb.datatypes.sensors import EEG_POLYMORPHIC_IDENTITY as EEG_S
-from tvb.datatypes.sensors import MEG_POLYMORPHIC_IDENTITY as MEG_S
-from tvb.datatypes.sensors import INTERNAL_POLYMORPHIC_IDENTITY as SEEG_S
-from tvb.datatypes.projections import EEG_POLYMORPHIC_IDENTITY as EEG_P
-from tvb.datatypes.projections import MEG_POLYMORPHIC_IDENTITY as MEG_P
-from tvb.datatypes.projections import SEEG_POLYMORPHIC_IDENTITY as SEEG_P
+from tvb.datatypes.projections import ProjectionsType
 from tvb.adapters.simulator.equation_forms import get_ui_name_to_monitor_equation_dict, HRFKernelEquation
 from tvb.core.neotraits.forms import Form, ScalarField, ArrayField, MultiSelectField, SelectField, \
     TraitDataTypeSelectField
 from tvb.basic.neotraits.api import List
 import numpy
+from tvb.datatypes.sensors import SensorTypes
 
 
 def get_monitor_to_form_dict():
@@ -158,10 +154,10 @@ class EEGMonitorForm(ProjectionMonitorForm):
         super(EEGMonitorForm, self).__init__(variables_of_interest_indexes, prefix, project_id)
 
         sensor_filter = FilterChain(fields=[FilterChain.datatype + '.sensors_type'], operations=["=="],
-                                    values=[EEG_S])
+                                    values=[SensorTypes.TYPE_EEG.value])
 
         projection_filter = FilterChain(fields=[FilterChain.datatype + '.projection_type'], operations=["=="],
-                                        values=[EEG_P])
+                                        values=[ProjectionsType.EEG_POLYMORPHIC_IDENTITY.value])
 
         self.projection = TraitDataTypeSelectField(EEGViewModel.projection, self, name='projection',
                                                    conditions=projection_filter)
@@ -176,10 +172,10 @@ class MEGMonitorForm(ProjectionMonitorForm):
         super(MEGMonitorForm, self).__init__(variables_of_interest_indexes, prefix, project_id)
 
         sensor_filter = FilterChain(fields=[FilterChain.datatype + '.sensors_type'], operations=["=="],
-                                    values=[MEG_S])
+                                    values=[SensorTypes.TYPE_MEG.value)
 
         projection_filter = FilterChain(fields=[FilterChain.datatype + '.projection_type'], operations=["=="],
-                                        values=[MEG_P])
+                                        values=[ProjectionsType.MEG_POLYMORPHIC_IDENTITY.value])
 
         self.projection = TraitDataTypeSelectField(MEGViewModel.projection, self, name='projection',
                                                    conditions=projection_filter)
@@ -192,10 +188,10 @@ class iEEGMonitorForm(ProjectionMonitorForm):
         super(iEEGMonitorForm, self).__init__(variables_of_interest_indexes, prefix, project_id)
 
         sensor_filter = FilterChain(fields=[FilterChain.datatype + '.sensors_type'], operations=["=="],
-                                    values=[SEEG_S])
+                                    values=[SensorTypes.TYPE_SEEG.value])
 
         projection_filter = FilterChain(fields=[FilterChain.datatype + '.projection_type'], operations=["=="],
-                                        values=[SEEG_P])
+                                        values=[ProjectionsType.SEEG_POLYMORPHIC_IDENTITY.value])
 
         self.projection = TraitDataTypeSelectField(iEEGViewModel.projection, self, name='projection',
                                                    conditions=projection_filter)

--- a/framework_tvb/tvb/adapters/uploaders/mat_timeseries_eeg_importer.py
+++ b/framework_tvb/tvb/adapters/uploaders/mat_timeseries_eeg_importer.py
@@ -31,7 +31,7 @@
 from tvb.core.entities.filters.chain import FilterChain
 from tvb.core.neotraits.uploader_view_model import UploaderViewModel
 from tvb.core.neotraits.view_model import DataTypeGidAttr
-from tvb.datatypes.sensors import EEG_POLYMORPHIC_IDENTITY, Sensors
+from tvb.datatypes.sensors import Sensors, SensorTypes
 from tvb.adapters.uploaders.mat_timeseries_importer import RegionMatTimeSeriesImporterForm, TS_EEG, \
     RegionTimeSeriesImporter
 from tvb.core.neotraits.forms import TraitDataTypeSelectField
@@ -49,7 +49,7 @@ class EEGRegionMatTimeSeriesImporterForm(RegionMatTimeSeriesImporterForm):
     def __init__(self, prefix='', project_id=None):
         super(EEGRegionMatTimeSeriesImporterForm, self).__init__(prefix, project_id)
         eeg_conditions = FilterChain(fields=[FilterChain.datatype + '.sensors_type'], operations=['=='],
-                                     values=[EEG_POLYMORPHIC_IDENTITY])
+                                     values=[SensorTypes.TYPE_EEG.value])
         self.datatype = TraitDataTypeSelectField(EEGMatTimeSeriesImporterModel.datatype, self, name='tstype_parameters',
                                                  conditions=eeg_conditions)
 

--- a/framework_tvb/tvb/core/entities/file/file_update_scripts/004_update_files.py
+++ b/framework_tvb/tvb/core/entities/file/file_update_scripts/004_update_files.py
@@ -72,11 +72,11 @@ def update(input_file):
     if "ProjectionSurface" in class_name and FIELD_PROJECTION_TYPE not in root_metadata:
         LOGGER.info("Updating ProjectionSurface %s from %s" % (file_name, folder))
 
-        projection_type = ProjectionsType.EEG_POLYMORPHIC_IDENTITY.value
+        projection_type = ProjectionsType.EEG.value
         if "SEEG" in class_name:
-            projection_type = ProjectionsType.SEEG_POLYMORPHIC_IDENTITY.value
+            projection_type = ProjectionsType.SEEG.value
         elif "MEG" in class_name:
-            projection_type = ProjectionsType.MEG_POLYMORPHIC_IDENTITY.value
+            projection_type = ProjectionsType.MEG.value
 
         root_metadata[FIELD_PROJECTION_TYPE] = json.dumps(projection_type)
         LOGGER.debug("Setting %s = %s" % (FIELD_PROJECTION_TYPE, projection_type))

--- a/framework_tvb/tvb/core/entities/file/file_update_scripts/004_update_files.py
+++ b/framework_tvb/tvb/core/entities/file/file_update_scripts/004_update_files.py
@@ -43,7 +43,7 @@ from tvb.core.entities.file.exceptions import IncompatibleFileManagerException
 from tvb.core.entities.file.hdf5_storage_manager import HDF5StorageManager
 from tvb.core.entities.transient.structure_entities import DataTypeMetaData
 from tvb.core.services.import_service import ImportService
-from tvb.datatypes import projections
+from tvb.datatypes.projections import ProjectionsType
 
 LOGGER = get_logger(__name__)
 FIELD_PROJECTION_TYPE = "Projection_type"
@@ -72,11 +72,11 @@ def update(input_file):
     if "ProjectionSurface" in class_name and FIELD_PROJECTION_TYPE not in root_metadata:
         LOGGER.info("Updating ProjectionSurface %s from %s" % (file_name, folder))
 
-        projection_type = projections.EEG_POLYMORPHIC_IDENTITY
+        projection_type = ProjectionsType.EEG_POLYMORPHIC_IDENTITY.value
         if "SEEG" in class_name:
-            projection_type = projections.SEEG_POLYMORPHIC_IDENTITY
+            projection_type = ProjectionsType.SEEG_POLYMORPHIC_IDENTITY.value
         elif "MEG" in class_name:
-            projection_type = projections.MEG_POLYMORPHIC_IDENTITY
+            projection_type = ProjectionsType.MEG_POLYMORPHIC_IDENTITY.value
 
         root_metadata[FIELD_PROJECTION_TYPE] = json.dumps(projection_type)
         LOGGER.debug("Setting %s = %s" % (FIELD_PROJECTION_TYPE, projection_type))

--- a/framework_tvb/tvb/tests/framework/adapters/visualizers/sensorsviewer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/visualizers/sensorsviewer_test.py
@@ -41,7 +41,7 @@ from tvb.adapters.uploaders.sensors_importer import SensorsImporterModel
 from tvb.adapters.visualizers.sensors import SensorsViewer
 from tvb.core.entities.filters.chain import FilterChain
 from tvb.core.entities.file.files_helper import FilesHelper
-from tvb.datatypes.sensors import EEG_POLYMORPHIC_IDENTITY, MEG_POLYMORPHIC_IDENTITY
+from tvb.datatypes.sensors import SensorTypes
 from tvb.datatypes.surfaces import EEG_CAP
 from tvb.tests.framework.core.base_testcase import TransactionalTestCase
 from tvb.tests.framework.core.factory import TestFactory
@@ -86,7 +86,7 @@ class TestSensorViewers(TransactionalTestCase):
         TestFactory.import_sensors(self.test_user, self.test_project, zip_path,
                                    SensorsImporterModel.OPTIONS['EEG Sensors'])
         field = FilterChain.datatype + '.sensors_type'
-        filters = FilterChain('', [field], [EEG_POLYMORPHIC_IDENTITY], ['=='])
+        filters = FilterChain('', [field], [SensorTypes.TYPE_EEG.value], ['=='])
         sensors_index = TestFactory.get_entity(self.test_project, SensorsIndex, filters)
 
         # Import EEGCap
@@ -122,7 +122,7 @@ class TestSensorViewers(TransactionalTestCase):
                                    SensorsImporterModel.OPTIONS['MEG Sensors'])
 
         field = FilterChain.datatype + '.sensors_type'
-        filters = FilterChain('', [field], [MEG_POLYMORPHIC_IDENTITY], ['=='])
+        filters = FilterChain('', [field], [SensorTypes.TYPE_MEG.value], ['=='])
         sensors_index = TestFactory.get_entity(self.test_project, SensorsIndex, filters)
 
         viewer = SensorsViewer()

--- a/framework_tvb/tvb/tests/framework/core/services/links_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/links_test.py
@@ -46,7 +46,7 @@ from tvb.core.entities.transient.structure_entities import DataTypeMetaData
 from tvb.core.services.algorithm_service import AlgorithmService
 from tvb.core.services.project_service import ProjectService
 from tvb.core.services.import_service import ImportService
-from tvb.datatypes.sensors import EEG_POLYMORPHIC_IDENTITY
+from tvb.datatypes.sensors import SensorTypes
 from tvb.tests.framework.core.factory import TestFactory
 from tvb.tests.framework.core.base_testcase import TransactionalTestCase
 
@@ -73,7 +73,7 @@ class _BaseLinksTest(TransactionalTestCase):
         zip_path = os.path.join(os.path.dirname(tvb_data.__file__), 'connectivity', 'paupau.zip')
         self.red_datatype = TestFactory.import_zip_connectivity(src_user, self.src_project, zip_path, "John")
         zip_path = os.path.join(os.path.dirname(tvb_data.__file__), 'sensors', 'eeg_unitvector_62.txt.bz2')
-        self.blue_datatype = TestFactory.import_sensors(src_user, self.src_project, zip_path, EEG_POLYMORPHIC_IDENTITY)
+        self.blue_datatype = TestFactory.import_sensors(src_user, self.src_project, zip_path, SensorTypes.TYPE_EEG.value)
         assert 1 == self.red_datatypes_in(self.src_project.id)
         assert 1 == self.blue_datatypes_in(self.src_project.id)
 

--- a/scientific_library/tvb/datatypes/projections.py
+++ b/scientific_library/tvb/datatypes/projections.py
@@ -32,14 +32,17 @@ The ProjectionMatrices DataTypes.
 
 .. moduleauthor:: Lia Domide <lia.domide@codemart.ro>
 """
+from enum import Enum
 
 from tvb.basic.readers import try_get_absolute_path, FileReader
 from tvb.datatypes import surfaces, sensors
 from tvb.basic.neotraits.api import HasTraits, Attr, NArray
 
-EEG_POLYMORPHIC_IDENTITY = "projEEG"
-MEG_POLYMORPHIC_IDENTITY = "projMEG"
-SEEG_POLYMORPHIC_IDENTITY = "projSEEG"
+
+class ProjectionsType(Enum):
+    EEG_POLYMORPHIC_IDENTITY = "projEEG"
+    MEG_POLYMORPHIC_IDENTITY = "projMEG"
+    SEEG_POLYMORPHIC_IDENTITY = "projSEEG"
 
 
 class ProjectionMatrix(HasTraits):
@@ -104,7 +107,7 @@ class ProjectionSurfaceEEG(ProjectionMatrix):
     Specific projection, from a CorticalSurface to EEG sensors.
     """
 
-    projection_type = Attr(field_type=str, default=EEG_POLYMORPHIC_IDENTITY)
+    projection_type = Attr(field_type=str, default=ProjectionsType.EEG_POLYMORPHIC_IDENTITY.value)
 
     sensors = Attr(field_type=sensors.SensorsEEG)
 
@@ -119,7 +122,7 @@ class ProjectionSurfaceMEG(ProjectionMatrix):
     Specific projection, from a CorticalSurface to MEG sensors.
     """
 
-    projection_type = Attr(field_type=str, default=MEG_POLYMORPHIC_IDENTITY)
+    projection_type = Attr(field_type=str, default=ProjectionsType.MEG_POLYMORPHIC_IDENTITY.value)
 
     sensors = Attr(field_type=sensors.SensorsMEG)
 
@@ -133,7 +136,7 @@ class ProjectionSurfaceSEEG(ProjectionMatrix):
     Specific projection, from a CorticalSurface to SEEG sensors.
     """
 
-    projection_type = Attr(field_type=str, default=SEEG_POLYMORPHIC_IDENTITY)
+    projection_type = Attr(field_type=str, default=ProjectionsType.SEEG_POLYMORPHIC_IDENTITY.value)
 
     sensors = Attr(field_type=sensors.SensorsInternal)
 
@@ -148,10 +151,10 @@ def make_proj_matrix(proj_type):
     :param proj_type: one of the supported subtypes
     :return: Instance of the corresponding projectiion matrix class, or None
     """
-    if proj_type == EEG_POLYMORPHIC_IDENTITY:
+    if proj_type == ProjectionsType.EEG_POLYMORPHIC_IDENTITY.value:
         return ProjectionSurfaceEEG()
-    elif proj_type == MEG_POLYMORPHIC_IDENTITY:
+    elif proj_type == ProjectionsType.MEG_POLYMORPHIC_IDENTITY.value:
         return ProjectionSurfaceMEG()
-    elif proj_type == SEEG_POLYMORPHIC_IDENTITY:
+    elif proj_type == ProjectionsType.SEEG_POLYMORPHIC_IDENTITY.value:
         return ProjectionSurfaceSEEG()
     return None

--- a/scientific_library/tvb/datatypes/projections.py
+++ b/scientific_library/tvb/datatypes/projections.py
@@ -40,9 +40,9 @@ from tvb.basic.neotraits.api import HasTraits, Attr, NArray
 
 
 class ProjectionsType(Enum):
-    EEG_POLYMORPHIC_IDENTITY = "projEEG"
-    MEG_POLYMORPHIC_IDENTITY = "projMEG"
-    SEEG_POLYMORPHIC_IDENTITY = "projSEEG"
+    EEG = "projEEG"
+    MEG = "projMEG"
+    SEEG = "projSEEG"
 
 
 class ProjectionMatrix(HasTraits):
@@ -107,7 +107,7 @@ class ProjectionSurfaceEEG(ProjectionMatrix):
     Specific projection, from a CorticalSurface to EEG sensors.
     """
 
-    projection_type = Attr(field_type=str, default=ProjectionsType.EEG_POLYMORPHIC_IDENTITY.value)
+    projection_type = Attr(field_type=str, default=ProjectionsType.EEG.value)
 
     sensors = Attr(field_type=sensors.SensorsEEG)
 
@@ -122,7 +122,7 @@ class ProjectionSurfaceMEG(ProjectionMatrix):
     Specific projection, from a CorticalSurface to MEG sensors.
     """
 
-    projection_type = Attr(field_type=str, default=ProjectionsType.MEG_POLYMORPHIC_IDENTITY.value)
+    projection_type = Attr(field_type=str, default=ProjectionsType.MEG.value)
 
     sensors = Attr(field_type=sensors.SensorsMEG)
 
@@ -136,7 +136,7 @@ class ProjectionSurfaceSEEG(ProjectionMatrix):
     Specific projection, from a CorticalSurface to SEEG sensors.
     """
 
-    projection_type = Attr(field_type=str, default=ProjectionsType.SEEG_POLYMORPHIC_IDENTITY.value)
+    projection_type = Attr(field_type=str, default=ProjectionsType.SEEG.value)
 
     sensors = Attr(field_type=sensors.SensorsInternal)
 
@@ -151,10 +151,10 @@ def make_proj_matrix(proj_type):
     :param proj_type: one of the supported subtypes
     :return: Instance of the corresponding projectiion matrix class, or None
     """
-    if proj_type == ProjectionsType.EEG_POLYMORPHIC_IDENTITY.value:
+    if proj_type == ProjectionsType.EEG.value:
         return ProjectionSurfaceEEG()
-    elif proj_type == ProjectionsType.MEG_POLYMORPHIC_IDENTITY.value:
+    elif proj_type == ProjectionsType.MEG.value:
         return ProjectionSurfaceMEG()
-    elif proj_type == ProjectionsType.SEEG_POLYMORPHIC_IDENTITY.value:
+    elif proj_type == ProjectionsType.SEEG.value:
         return ProjectionSurfaceSEEG()
     return None

--- a/scientific_library/tvb/datatypes/sensors.py
+++ b/scientific_library/tvb/datatypes/sensors.py
@@ -49,7 +49,6 @@ class SensorTypes(Enum):
     TYPE_EEG = "EEG"
     TYPE_MEG = "MEG"
     TYPE_INTERNAL = "Internal"
-    TYPE_SEEG = "SEEG"
 
 
 class Sensors(HasTraits):

--- a/scientific_library/tvb/datatypes/sensors.py
+++ b/scientific_library/tvb/datatypes/sensors.py
@@ -38,13 +38,18 @@ The Sensors dataType.
 """
 
 import re
+from enum import Enum
+
 import numpy
 from tvb.basic.readers import FileReader, try_get_absolute_path
 from tvb.basic.neotraits.api import HasTraits, Attr, NArray, Int
 
-EEG_POLYMORPHIC_IDENTITY = "EEG"
-MEG_POLYMORPHIC_IDENTITY = "MEG"
-INTERNAL_POLYMORPHIC_IDENTITY = "Internal"
+
+class SensorTypes(Enum):
+    TYPE_EEG = "EEG"
+    TYPE_MEG = "MEG"
+    TYPE_INTERNAL = "Internal"
+    TYPE_SEEG = "SEEG"
 
 
 class Sensors(HasTraits):
@@ -190,7 +195,7 @@ class SensorsEEG(Sensors):
         file columns: labels, x, y, z
 
     """
-    sensors_type = Attr(str, default=EEG_POLYMORPHIC_IDENTITY)
+    sensors_type = Attr(str, default=SensorTypes.TYPE_EEG.value)
 
     has_orientation = Attr(bool, default=False)
 
@@ -208,7 +213,7 @@ class SensorsMEG(Sensors):
         file columns: labels, x, y, z,   dx, dy, dz
 
     """
-    sensors_type = Attr(str, default=MEG_POLYMORPHIC_IDENTITY)
+    sensors_type = Attr(str, default=SensorTypes.TYPE_MEG.value)
 
     orientations = NArray(label="Sensor orientations",
                           doc="An array representing the orientation of the MEG SQUIDs")
@@ -230,7 +235,7 @@ class SensorsInternal(Sensors):
     """
     Sensors inside the brain...
     """
-    sensors_type = Attr(str, default=INTERNAL_POLYMORPHIC_IDENTITY)
+    sensors_type = Attr(str, default=SensorTypes.TYPE_INTERNAL.value)
 
     @classmethod
     def from_file(cls, source_file="seeg_39.txt.bz2"):
@@ -268,10 +273,10 @@ def make_sensors(sensors_type):
     :param sensors_type: one of the supported subtypes
     :return: Instance of the corresponding sensors class, or None
     """
-    if sensors_type == EEG_POLYMORPHIC_IDENTITY:
+    if sensors_type == SensorTypes.TYPE_EEG.value:
         return SensorsEEG()
-    elif sensors_type == MEG_POLYMORPHIC_IDENTITY:
+    elif sensors_type == SensorTypes.TYPE_MEG.value:
         return SensorsMEG()
-    elif sensors_type == INTERNAL_POLYMORPHIC_IDENTITY:
+    elif sensors_type == SensorTypes.TYPE_INTERNAL.value:
         return SensorsInternal()
     return None

--- a/scientific_library/tvb/tests/library/datatypes/sensors_test.py
+++ b/scientific_library/tvb/tests/library/datatypes/sensors_test.py
@@ -33,10 +33,10 @@
 
 import pytest
 import numpy
+from tvb.datatypes.sensors import SensorTypes
 from tvb.tests.library.base_testcase import BaseTestCase
 from tvb.datatypes import sensors
 from tvb.datatypes.surfaces import SkinAir
-from tvb.datatypes.sensors import INTERNAL_POLYMORPHIC_IDENTITY, MEG_POLYMORPHIC_IDENTITY, EEG_POLYMORPHIC_IDENTITY
 
 
 class TestSensors(BaseTestCase):
@@ -85,7 +85,7 @@ class TestSensors(BaseTestCase):
         assert dt.locations.shape == (65, 3)
         assert dt.number_of_sensors == 65
         assert dt.orientations is None
-        assert dt.sensors_type == EEG_POLYMORPHIC_IDENTITY
+        assert dt.sensors_type == SensorTypes.TYPE_EEG.value
 
     def test_sensorsmeg(self):
         dt = sensors.SensorsMEG.from_file()
@@ -96,7 +96,7 @@ class TestSensors(BaseTestCase):
         assert dt.locations.shape == (151, 3)
         assert dt.number_of_sensors == 151
         assert dt.orientations.shape == (151, 3)
-        assert dt.sensors_type == MEG_POLYMORPHIC_IDENTITY
+        assert dt.sensors_type == SensorTypes.TYPE_MEG.value
 
     def test_sensorsinternal(self):
         dt = sensors.SensorsInternal.from_file()
@@ -107,4 +107,4 @@ class TestSensors(BaseTestCase):
         assert dt.locations.shape == (103, 3)
         assert dt.number_of_sensors == 103
         assert dt.orientations is None
-        assert dt.sensors_type == INTERNAL_POLYMORPHIC_IDENTITY
+        assert dt.sensors_type == SensorTypes.TYPE_INTERNAL.value

--- a/tvb_contrib/tvb/contrib/scripts/datatypes/head.py
+++ b/tvb_contrib/tvb/contrib/scripts/datatypes/head.py
@@ -45,8 +45,7 @@ from tvb.contrib.scripts.utils.file_utils import insensitive_glob
 from tvb.datatypes.connectivity import Connectivity as TVBConnectivity
 from tvb.datatypes.cortex import Cortex
 from tvb.datatypes.local_connectivity import LocalConnectivity as TVBLocalConnectivity
-from tvb.datatypes.projections import EEG_POLYMORPHIC_IDENTITY, SEEG_POLYMORPHIC_IDENTITY, MEG_POLYMORPHIC_IDENTITY
-from tvb.datatypes.projections import ProjectionMatrix as TVBProjectionMatrix
+from tvb.datatypes.projections import ProjectionMatrix as TVBProjectionMatrix, ProjectionsType
 from tvb.datatypes.projections import ProjectionSurfaceEEG as TVBProjectionSurfaceEEG
 from tvb.datatypes.projections import ProjectionSurfaceMEG as TVBProjectionSurfaceMEG
 from tvb.datatypes.projections import ProjectionSurfaceSEEG as TVBProjectionSurfaceSEEG
@@ -125,7 +124,7 @@ class Head(HasTraits):
                 self.region_volume_mapping.configure()
         for s_type, p_type, s_datatype, p_datatype \
                 in zip(["eeg", "seeg", "meg"],
-                       [EEG_POLYMORPHIC_IDENTITY, SEEG_POLYMORPHIC_IDENTITY, MEG_POLYMORPHIC_IDENTITY],
+                       [ProjectionsType.EEG_POLYMORPHIC_IDENTITY.value, ProjectionsType.SEEG_POLYMORPHIC_IDENTITY.value, ProjectionsType.MEG_POLYMORPHIC_IDENTITY.value],
                        [TVBSensorsEEG, TVBSensorsInternal, TVBSensorsMEG],
                        [TVBProjectionSurfaceEEG, TVBProjectionSurfaceSEEG, TVBProjectionSurfaceMEG]):
             sensor_name = "%s_sensors" % s_type

--- a/tvb_contrib/tvb/contrib/scripts/datatypes/head.py
+++ b/tvb_contrib/tvb/contrib/scripts/datatypes/head.py
@@ -124,7 +124,7 @@ class Head(HasTraits):
                 self.region_volume_mapping.configure()
         for s_type, p_type, s_datatype, p_datatype \
                 in zip(["eeg", "seeg", "meg"],
-                       [ProjectionsType.EEG_POLYMORPHIC_IDENTITY.value, ProjectionsType.SEEG_POLYMORPHIC_IDENTITY.value, ProjectionsType.MEG_POLYMORPHIC_IDENTITY.value],
+                       [ProjectionsType.EEG.value, ProjectionsType.SEEG.value, ProjectionsType.MEG.value],
                        [TVBSensorsEEG, TVBSensorsInternal, TVBSensorsMEG],
                        [TVBProjectionSurfaceEEG, TVBProjectionSurfaceSEEG, TVBProjectionSurfaceMEG]):
             sensor_name = "%s_sensors" % s_type

--- a/tvb_contrib/tvb/contrib/scripts/datatypes/projections.py
+++ b/tvb_contrib/tvb/contrib/scripts/datatypes/projections.py
@@ -36,18 +36,19 @@ from tvb.datatypes.projections import ProjectionMatrix as TVBProjectionMatrix
 from tvb.datatypes.projections import ProjectionSurfaceEEG as TVBProjectionSurfaceEEG
 from tvb.datatypes.projections import ProjectionSurfaceSEEG as TVBProjectionSurfaceSEEG
 from tvb.datatypes.projections import ProjectionSurfaceMEG as TVBProjectionSurfaceMEG
+from tvb.datatypes.sensors import SensorTypes
 
 
 class TvbProjectionType(Enum):
     eeg = TVBProjectionSurfaceEEG
-    seeg = TVBProjectionSurfaceSEEG
+    internal = TVBProjectionSurfaceSEEG
     meg = TVBProjectionSurfaceMEG
 
 
 def get_TVB_proj_type(s_type):
     try:
-        return TvbProjectionType[s_type.lower()].value
-    except KeyError:
+        return TvbProjectionType[s_type.value.lower()].value
+    except (KeyError, AttributeError):
         return TVBProjectionMatrix
 
 
@@ -87,7 +88,7 @@ class ProjectionSurfaceEEG(ProjectionMatrix, TVBProjectionSurfaceEEG):
     @classmethod
     def from_tvb_file(cls, source_file, matlab_data_name=None, is_brainstorm=False,
                       return_tvb_instance=False, **kwargs):
-        return cls._from_tvb_projection_file("eeg", source_file, matlab_data_name, is_brainstorm,
+        return cls._from_tvb_projection_file(SensorTypes.TYPE_EEG, source_file, matlab_data_name, is_brainstorm,
                                              return_tvb_instance, **kwargs)
 
 
@@ -99,7 +100,7 @@ class ProjectionSurfaceSEEG(ProjectionMatrix, TVBProjectionSurfaceSEEG):
     @classmethod
     def from_tvb_file(cls, source_file, matlab_data_name=None, is_brainstorm=False,
                       return_tvb_instance=False, **kwargs):
-        return cls._from_tvb_projection_file("seeg", source_file, matlab_data_name, is_brainstorm,
+        return cls._from_tvb_projection_file(SensorTypes.TYPE_INTERNAL, source_file, matlab_data_name, is_brainstorm,
                                              return_tvb_instance, **kwargs)
 
 
@@ -111,5 +112,5 @@ class ProjectionSurfaceMEG(ProjectionMatrix, TVBProjectionSurfaceMEG):
     @classmethod
     def from_tvb_file(cls, source_file, matlab_data_name=None, is_brainstorm=False,
                       return_tvb_instance=False, **kwargs):
-        return cls._from_tvb_projection_file("meg", source_file, matlab_data_name, is_brainstorm,
+        return cls._from_tvb_projection_file(SensorTypes.TYPE_MEG, source_file, matlab_data_name, is_brainstorm,
                                              return_tvb_instance, **kwargs)

--- a/tvb_contrib/tvb/contrib/scripts/datatypes/projections.py
+++ b/tvb_contrib/tvb/contrib/scripts/datatypes/projections.py
@@ -29,6 +29,7 @@
 """
 .. moduleauthor:: Dionysios Perdikis <Denis@tvb.invalid>
 """
+from enum import Enum
 
 from tvb.contrib.scripts.datatypes.base import BaseModel
 from tvb.datatypes.projections import ProjectionMatrix as TVBProjectionMatrix
@@ -37,14 +38,16 @@ from tvb.datatypes.projections import ProjectionSurfaceSEEG as TVBProjectionSurf
 from tvb.datatypes.projections import ProjectionSurfaceMEG as TVBProjectionSurfaceMEG
 
 
+class TvbProjectionType(Enum):
+    eeg = TVBProjectionSurfaceEEG
+    seeg = TVBProjectionSurfaceSEEG
+    meg = TVBProjectionSurfaceMEG
+
+
 def get_TVB_proj_type(s_type):
-    if s_type.lower() == "eeg":
-        return TVBProjectionSurfaceEEG
-    elif s_type.lower() == "seeg":
-        return TVBProjectionSurfaceSEEG
-    elif s_type.lower() == "meg":
-        return TVBProjectionSurfaceMEG
-    else:
+    try:
+        return TvbProjectionType[s_type.lower()].value
+    except KeyError:
         return TVBProjectionMatrix
 
 

--- a/tvb_contrib/tvb/contrib/scripts/datatypes/sensors.py
+++ b/tvb_contrib/tvb/contrib/scripts/datatypes/sensors.py
@@ -151,7 +151,7 @@ class SensorsInternal(Sensors, TVBSensorsInternal):
             return np.unique(sensors_inds)
 
     def group_sensors_to_electrodes(self, labels=None):
-        if self.sensors_type == SensorTypes.TYPE_SEEG.value:
+        if self.sensors_type == SensorTypes.TYPE_INTERNAL.value:
             if labels is None:
                 labels = self.labels
             sensor_names = np.array(split_string_text_numbers(labels))
@@ -186,7 +186,7 @@ class SensorsInternal(Sensors, TVBSensorsInternal):
 
 
 class SensorsSEEG(SensorsInternal):
-    sensors_type = Attr(str, default=SensorTypes.TYPE_SEEG.value, required=False)
+    sensors_type = Attr(str, default=SensorTypes.TYPE_INTERNAL.value, required=False)
 
     def to_tvb_instance(self, **kwargs):
         return super(SensorsSEEG, self).to_tvb_instance(TVBSensorsInternal, **kwargs)

--- a/tvb_contrib/tvb/contrib/scripts/datatypes/sensors.py
+++ b/tvb_contrib/tvb/contrib/scripts/datatypes/sensors.py
@@ -30,28 +30,17 @@
 .. moduleauthor:: Dionysios Perdikis <Denis@tvb.invalid>
 """
 
-from enum import Enum
 import numpy as np
 from tvb.contrib.scripts.datatypes.base import BaseModel
 from tvb.contrib.scripts.utils.data_structures_utils import labels_to_inds, monopolar_to_bipolar, \
     split_string_text_numbers
 from tvb.basic.logger.builder import get_logger
 from tvb.basic.neotraits.api import Attr, NArray
-from tvb.datatypes.sensors import EEG_POLYMORPHIC_IDENTITY, MEG_POLYMORPHIC_IDENTITY, \
-    INTERNAL_POLYMORPHIC_IDENTITY
-from tvb.datatypes.sensors import Sensors as TVBSensors
+from tvb.datatypes.sensors import Sensors as TVBSensors, SensorTypes
 from tvb.datatypes.sensors import SensorsEEG as TVBSensorsEEG
 from tvb.datatypes.sensors import SensorsInternal as TVBSensorsInternal
 from tvb.datatypes.sensors import SensorsMEG as TVBSensorsMEG
 from tvb.simulator.plot.utils import ensure_list
-
-
-# TODO: Move this ENUM in library an replace hardcoded sensor types strings from there
-class SensorTypes(Enum):
-    TYPE_EEG = EEG_POLYMORPHIC_IDENTITY
-    TYPE_MEG = MEG_POLYMORPHIC_IDENTITY
-    TYPE_INTERNAL = INTERNAL_POLYMORPHIC_IDENTITY
-    TYPE_SEEG = "SEEG"
 
 
 class Sensors(TVBSensors, BaseModel):


### PR DESCRIPTION
- From tvb-contrib move the Sensors enum higher into tvb-library, as it will be useful for other cases also.
- for sensors keep only "Internal" type, and remove the duplicate SEEG. We might need to migrate previous data files (if any exist). We should be consistent