### PR TITLE
TVB-2769 Correct Metadata editing in a DT overlay and ensure DB&H5 persistence

### DIFF
--- a/framework_tvb/tvb/adapters/simulator/simulator_adapter.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_adapter.py
@@ -324,7 +324,10 @@ class SimulatorAdapter(ABCAdapter):
         if not self._is_group_launch():
             simulation_history = SimulationHistory()
             simulation_history.populate_from(self.algorithm)
-            history_index = h5.store_complete(simulation_history, self._get_output_path())
+            self.generic_attributes.visible = False
+            history_index = h5.store_complete(simulation_history, self._get_output_path(), self.generic_attributes)
+            self.generic_attributes.visible = True
+            history_index.fixed_generic_attributes = True
             results.append(history_index)
 
         self.log.debug("Simulation state persisted, returning results ")

--- a/framework_tvb/tvb/core/adapters/abcadapter.py
+++ b/framework_tvb/tvb/core/adapters/abcadapter.py
@@ -56,6 +56,7 @@ from tvb.core.adapters.exceptions import NoMemoryAvailableException
 from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.entities.generic_attributes import GenericAttributes
 from tvb.core.entities.load import load_entity_by_gid
+from tvb.core.entities.model.model_operation import Algorithm
 from tvb.core.entities.storage import dao
 from tvb.core.entities.transient.structure_entities import DataTypeMetaData
 from tvb.core.neocom import h5
@@ -515,6 +516,7 @@ class ABCAdapter(object):
 
     @staticmethod
     def determine_adapter_class(stored_adapter):
+        # type: (Algorithm) -> ABCAdapter
         """
         Determine the class of an adapter based on module and classname strings from stored_adapter
         :param stored_adapter: Algorithm or AlgorithmDTO type
@@ -526,6 +528,7 @@ class ABCAdapter(object):
 
     @staticmethod
     def build_adapter(stored_adapter):
+        # type: (Algorithm) -> ABCAdapter
         """
         Having a module and a class name, create an instance of ABCAdapter.
         """

--- a/framework_tvb/tvb/core/adapters/abcadapter.py
+++ b/framework_tvb/tvb/core/adapters/abcadapter.py
@@ -389,15 +389,8 @@ class ABCAdapter(object):
         for res in result:
             if res is None:
                 continue
-            res.subject = self.generic_attributes.subject
-            res.state = self.generic_attributes.state
-            res.fk_parent_burst = self.generic_attributes.parent_burst
+            res.fill_from_generic_attributes(self.generic_attributes)
             res.fk_from_operation = self.operation_id
-            res.user_tag_1 = self.generic_attributes.user_tag_1
-            res.user_tag_2 = self.generic_attributes.user_tag_2
-            res.user_tag_3 = self.generic_attributes.user_tag_3
-            res.user_tag_4 = self.generic_attributes.user_tag_4
-            res.user_tag_5 = self.generic_attributes.user_tag_5
             res.fk_datatype_group = data_type_group_id
 
             associated_file = h5.path_for_stored_index(res)

--- a/framework_tvb/tvb/core/adapters/abcadapter.py
+++ b/framework_tvb/tvb/core/adapters/abcadapter.py
@@ -390,14 +390,16 @@ class ABCAdapter(object):
         for res in result:
             if res is None:
                 continue
-            res.fill_from_generic_attributes(self.generic_attributes)
+            if not res.fixed_generic_attributes:
+                res.fill_from_generic_attributes(self.generic_attributes)
             res.fk_from_operation = self.operation_id
             res.fk_datatype_group = data_type_group_id
 
             associated_file = h5.path_for_stored_index(res)
             if os.path.exists(associated_file):
-                with H5File.from_file(associated_file) as f:
-                    f.store_generic_attributes(self.generic_attributes)
+                if not res.fixed_generic_attributes:
+                    with H5File.from_file(associated_file) as f:
+                        f.store_generic_attributes(self.generic_attributes)
                 # Compute size-on disk, in case file-storage is used
                 res.disk_size = self.file_handler.compute_size_on_disk(associated_file)
 

--- a/framework_tvb/tvb/core/entities/file/files_helper.py
+++ b/framework_tvb/tvb/core/entities/file/files_helper.py
@@ -42,7 +42,7 @@ from tvb.basic.profile import TvbProfile
 from tvb.core.decorators import synchronized
 from tvb.core.entities.file.exceptions import FileStructureException
 from tvb.core.entities.file.xml_metadata_handlers import XMLReader, XMLWriter
-from tvb.core.entities.transient.structure_entities import DataTypeMetaData, GenericMetaData
+from tvb.core.entities.transient.structure_entities import GenericMetaData
 from werkzeug.utils import secure_filename
 
 LOCK_CREATE_FOLDER = Lock()
@@ -183,7 +183,6 @@ class FilesHelper(object):
         except Exception:
             self.logger.exception("Could not remove files")
             raise FileStructureException("Could not remove files for OP" + str(operation_id))
-
 
     ####################### DATA-TYPES METHODS Start Here #####################
     def remove_datatype_file(self, h5_file):

--- a/framework_tvb/tvb/core/entities/generic_attributes.py
+++ b/framework_tvb/tvb/core/entities/generic_attributes.py
@@ -48,6 +48,7 @@ class GenericAttributes(object):
     user_tag_3 = ''
     user_tag_4 = ''
     user_tag_5 = ''
+    operation_tag = ''
     parent_burst = None
     visible = True
     create_date = None
@@ -63,5 +64,6 @@ class GenericAttributes(object):
         self.user_tag_3 = extra_attributes.user_tag_3 or self.user_tag_3
         self.user_tag_4 = extra_attributes.user_tag_4 or self.user_tag_4
         self.user_tag_5 = extra_attributes.user_tag_5 or self.user_tag_5
+        self.operation_tag = extra_attributes.operation_tag or self.operation_tag
         self.parent_burst = extra_attributes.parent_burst or self.parent_burst
         self.visible = extra_attributes.visible

--- a/framework_tvb/tvb/core/entities/model/model_datatype.py
+++ b/framework_tvb/tvb/core/entities/model/model_datatype.py
@@ -69,10 +69,12 @@ FILTER_CATEGORIES = {'DataType.subject': {'display': 'Subject', 'type': 'string'
                                              'operations': ['!=', '==', 'like']},
                      'DataType.user_tag_5': {'display': 'Tag 5', 'type': 'string',
                                              'operations': ['!=', '==', 'like']},
-                     'Operation.start_date': {'display': 'Start date', 'type': 'date',
-                                              'operations': ['!=', '<', '>']},
                      'BurstConfiguration.name': {'display': 'Simulation name', 'type': 'string',
                                                  'operations': ['==', '!=', 'like']},
+                     'Operation.user_group': {'display': 'Operation Tag', 'type': 'string',
+                                              'operations': ['==', '!=', 'like']},
+                     'Operation.start_date': {'display': 'Start date', 'type': 'date',
+                                              'operations': ['!=', '<', '>']},
                      'Operation.completion_date': {'display': 'Completion date', 'type': 'date',
                                                    'operations': ['!=', '<', '>']}}
 

--- a/framework_tvb/tvb/core/entities/model/model_datatype.py
+++ b/framework_tvb/tvb/core/entities/model/model_datatype.py
@@ -117,11 +117,11 @@ class DataType(HasTraitsIndex):
     fk_from_operation = Column(Integer, ForeignKey('OPERATIONS.id', ondelete="CASCADE"))
     parent_operation = relationship(Operation, backref=backref("DATA_TYPES", order_by=id, cascade="all,delete"))
 
+    # Transient info
+    fixed_generic_attributes = False
+
     def __init__(self, gid=None, **kwargs):
 
-        # if gid is None:
-        #     self.gid = generate_guid()
-        # else:
         self.gid = gid
         self.type = self.__class__.__name__
         self.module = self.__class__.__module__

--- a/framework_tvb/tvb/core/entities/transient/context_overlay.py
+++ b/framework_tvb/tvb/core/entities/transient/context_overlay.py
@@ -168,7 +168,7 @@ class OperationOverlayDetails(CommonDetails):
                 self.job_id = op_pid.job_id
                 self.metadata['job_id'] = {"name": "Cluster job Id", "disabled": "True"}
 
-        ### Now set/update generic fields
+        # Now set/update generic fields
         self.gid = operation.gid
         self.author = user_display_name
         self.count = no_of_op_in_group
@@ -280,7 +280,7 @@ class DataTypeOverlayDetails(CommonDetails):
         else:
             self.burst_name = ''
 
-        ### Populate Group attributes
+        # Populate Group attributes
         if isinstance(datatype_result, DataTypeGroup):
             self.count = datatype_result.count_results
             self.operation_group_name = datatype_result.parent_operation.operation_group.name
@@ -289,5 +289,5 @@ class DataTypeOverlayDetails(CommonDetails):
         else:
             self.operation_label = datatype_result.parent_operation.user_group
 
-        ### Populate Scientific attributes
+        # Populate Scientific attributes
         self.add_scientific_fields(datatype_result.summary_info)

--- a/framework_tvb/tvb/core/entities/transient/structure_entities.py
+++ b/framework_tvb/tvb/core/entities/transient/structure_entities.py
@@ -37,7 +37,6 @@ import json
 from tvb.basic.config.utils import EnhancedDictionary
 
 
-
 class StructureNode:
     """
     This entity represents a node in the Tree of a Project related Structure.
@@ -45,13 +44,12 @@ class StructureNode:
     TYPE_FOLDER = "Folder"
     TYPE_FILE = "File"
     TYPE_INVALID = "Invalid"
-    
+
     PREFIX_ID_NODE = "node_"
     PREFIX_ID_LEAF = "leaf_"
     PREFIX_ID_PROJECT = "projectID"
-    
-    SEP = "__"
 
+    SEP = "__"
 
     def __init__(self, nid, node_name, ntype=TYPE_FOLDER, meta=None, children=None):
         """
@@ -70,7 +68,6 @@ class StructureNode:
         self.metadata = meta
         self.children = children
 
-        
     @property
     def has_children(self):
         """
@@ -78,16 +75,15 @@ class StructureNode:
         Return FALSE when current node is a leaf in Tree.
         """
         return self.children and len(self.children) > 0
-    
+
     @property
     def is_link(self):
         """
         Check if meta_data has the transient is_link attribute set.
         """
-        return (self.metadata is not None 
+        return (self.metadata is not None
                 and DataTypeMetaData.KEY_LINK in self.metadata and
                 self.metadata[DataTypeMetaData.KEY_LINK] > 0)
-
 
     @property
     def is_irelevant(self):
@@ -97,24 +93,22 @@ class StructureNode:
             return True
         return False
 
-
     @property
     def is_group(self):
         """
         Check if meta_data has the transient is_link attribute set.
         """
-        return (self.metadata is not None 
+        return (self.metadata is not None
                 and DataTypeMetaData.KEY_OP_GROUP_ID in self.metadata and
                 self.metadata[DataTypeMetaData.KEY_OP_GROUP_ID] is not None)
-    
+
     @property
     def type(self):
         """
         Type of a node it can be FOLDER, FILE or INVALID.
         """
         return self._type
-    
-    
+
     @staticmethod
     def metadata2tree(metadatas, first_level, second_level, project_id, project_name):
         """ 
@@ -150,7 +144,7 @@ class StructureNode:
 
                     if meta[meta.KEY_OPERATION_TAG]:
                         parent_name = parent_name + " - " + meta[meta.KEY_OPERATION_TAG]
-                    
+
                     parent = StructureNode(meta.gid, parent_name, meta=meta)
                     if meta.invalid:
                         parent._type = StructureNode.TYPE_INVALID
@@ -162,12 +156,12 @@ class StructureNode:
                 sublevel_node = StructureNode(sublevel_id, sublevel_name, children=datas)
                 sublevel_node._type = StructureNode._capitalize_first_letter(second_level)
                 level_children.append(sublevel_node)
-                
+
             dir_name = StructureNode._prepare_node_name(level, first_level)
             level_node = StructureNode(level, dir_name, children=level_children)
             level_node._type = StructureNode._capitalize_first_letter(first_level)
             forest.append(level_node)
-            
+
         json_children = StructureNode.__convert2json(forest, project_id)
         if len(json_children) > 0:
             result = '{data: [{ data: {title: "' + project_name + '"'
@@ -178,9 +172,8 @@ class StructureNode:
             result = '{data: [{ data: {title: "' + project_name + '"'
             result += ',icon: "/static/style/nodes/nodeRoot.png"}'
             result += ',attr:{id:"' + StructureNode.PREFIX_ID_PROJECT + '"}}]}'
-            
-        return result
 
+        return result
 
     @staticmethod
     def _prepare_node_name(name, level_filter):
@@ -191,15 +184,13 @@ class StructureNode:
             return DataTypeMetaData.STATES[name]
         return name
 
-
     @staticmethod
     def _capitalize_first_letter(word):
         """
         :returns: same string, but with first letter capitalized.
         """
         return word[0].upper() + word[1:]
-    
-    
+
     @staticmethod
     def __convert2json(nodes_list, project_id):
         """
@@ -231,7 +222,7 @@ class StructureNode:
             if node.is_link:
                 json_node += 'font-style: italic;'
             json_node += '" }'
-            
+
             if node.has_children:
                 json_node += ', children:[' + StructureNode.__convert2json(node.children, project_id) + ']'
 
@@ -242,10 +233,7 @@ class StructureNode:
             place_comma = True
 
             result += json_node
-        return result  
-
-
-
+        return result
 
 
 class GenericMetaData(EnhancedDictionary):
@@ -255,8 +243,7 @@ class GenericMetaData(EnhancedDictionary):
     """
     KEY_GID = "Gid"
     KEY_FILENAME = "file_name"
-    
-    
+
     def __init__(self, data=None):
         """
         :param data: The actual dictionary to be wrapped by current entity.
@@ -264,7 +251,7 @@ class GenericMetaData(EnhancedDictionary):
         super(GenericMetaData, self).__init__()
         if data is not None:
             self.update(data)
-        
+
     @property
     def gid(self):
         """
@@ -273,7 +260,7 @@ class GenericMetaData(EnhancedDictionary):
         if self.KEY_GID in list(self):
             return self[self.KEY_GID]
         return None
-    
+
     @property
     def file_name(self):
         """
@@ -284,7 +271,6 @@ class GenericMetaData(EnhancedDictionary):
         return None
 
 
-    
 class DataTypeMetaData(GenericMetaData):
     """
     This object will be populated from meta-data stored on a particular DataType/Operation.
@@ -312,7 +298,7 @@ class DataTypeMetaData(GenericMetaData):
     KEY_RELEVANCY = "Relevant"
     KEY_TITLE = "title"
 
-    #Transient attributes
+    # Transient attributes
     KEY_NODE_TYPE = "DataType"
     KEY_DATATYPE_ID = "Datatypeid"
     KEY_INVALID = "datatype_invalid"
@@ -320,17 +306,16 @@ class DataTypeMetaData(GenericMetaData):
     KEY_LINK = "link"
     KEY_CREATE_DATA_MONTH = "createDataMonth"
     KEY_CREATE_DATA_DAY = "createDataDay"
-    
-    #operation details
+
+    # operation details
     KEY_OPERATION_GROUP_NAME = "op_group_name"
     KEY_OPERATION_ALGORITHM = "Operation_Algorithm"
     KEY_FK_OPERATION_GROUP = 'fk_operation_group'
 
-    
     def __init__(self, data=None, invalid=False):
         GenericMetaData.__init__(self, data)
         self.invalid = invalid
-        
+
     @property
     def subject(self):
         """
@@ -339,7 +324,7 @@ class DataTypeMetaData(GenericMetaData):
         if self.KEY_SUBJECT not in list(self):
             return self.DEFAULT_SUBJECT
         return self[self.KEY_SUBJECT]
-    
+
     @property
     def create_date(self):
         """
@@ -348,7 +333,7 @@ class DataTypeMetaData(GenericMetaData):
         if self.KEY_DATE in list(self):
             return self[self.KEY_DATE]
         return None
-    
+
     @property
     def group(self):
         """
@@ -357,14 +342,14 @@ class DataTypeMetaData(GenericMetaData):
         if self.KEY_OPERATION_TAG in list(self):
             return self[self.KEY_OPERATION_TAG]
         return None
-    
+
     def mark_invalid(self):
         """ 
         Mark current meta-data as invalid.
         e.g. Because of a missing associated file.
         """
         self.invalid = True
-        
+
     def merge_data(self, new_data):
         """
         Update current state, from an external dictionary.
@@ -372,13 +357,9 @@ class DataTypeMetaData(GenericMetaData):
         if new_data is None:
             return
         for val in new_data:
-            #Ignore transient entities
+            # Ignore transient entities
             if val != self.KEY_COUNT and val != self.KEY_OP_GROUP_ID:
-                self[val] = new_data[val] 
-               
-               
-    #####   CLASS METHODS start Here ########################################
-
+                self[val] = new_data[val]
 
     @classmethod
     def get_filterable_meta(cls):
@@ -405,6 +386,3 @@ class DataTypeMetaData(GenericMetaData):
             {cls.KEY_TAG_4: "DataType Tag 4"},
             {cls.KEY_TAG_5: "DataType Tag 5"}
         ]
-
-
-

--- a/framework_tvb/tvb/core/neocom/h5.py
+++ b/framework_tvb/tvb/core/neocom/h5.py
@@ -116,6 +116,7 @@ def store_complete(datatype, base_dir, generic_attributes=GenericAttributes()):
     index_class = REGISTRY.get_index_for_datatype(datatype.__class__)
     index_inst = index_class()
     index_inst.fill_from_has_traits(datatype)
+    index_inst.fill_from_generic_attributes(generic_attributes)
 
     h5_class = REGISTRY.get_h5file_for_datatype(datatype.__class__)
     storage_path = path_for(base_dir, h5_class, datatype.gid)

--- a/framework_tvb/tvb/core/neocom/h5.py
+++ b/framework_tvb/tvb/core/neocom/h5.py
@@ -108,8 +108,8 @@ def load_with_links(source_path):
     return loader.load_with_links(source_path)
 
 
-def store_complete(datatype, base_dir):
-    # type: (HasTraits, str) -> DataType
+def store_complete(datatype, base_dir, generic_attributes=GenericAttributes()):
+    # type: (HasTraits, str, GenericAttributes) -> DataType
     """
     Stores the given HasTraits instance in a h5 file, and fill the Index entity for later storage in DB
     """
@@ -122,7 +122,7 @@ def store_complete(datatype, base_dir):
     with h5_class(storage_path) as f:
         f.store(datatype)
         # Store empty Generic Attributes, in case the file is saved no through ABCAdapter it can still be used
-        f.store_generic_attributes(GenericAttributes())
+        f.store_generic_attributes(generic_attributes)
 
     return index_inst
 

--- a/framework_tvb/tvb/core/neotraits/_h5core.py
+++ b/framework_tvb/tvb/core/neotraits/_h5core.py
@@ -84,6 +84,7 @@ class H5File(object):
         self.user_tag_3 = Scalar(Attr(str), self, name='user_tag_3')
         self.user_tag_4 = Scalar(Attr(str), self, name='user_tag_4')
         self.user_tag_5 = Scalar(Attr(str), self, name='user_tag_5')
+        self.operation_tag = Scalar(Attr(str), self, name='operation_tag')
         self.parent_burst = Uuid(Attr(uuid.UUID, required=False), self, name='parent_burst')
         self.visible = Scalar(Attr(bool), self, name='visible')
         self.metadata_cache = None
@@ -184,6 +185,7 @@ class H5File(object):
         self.user_tag_3.store(self.generic_attributes.user_tag_3)
         self.user_tag_4.store(self.generic_attributes.user_tag_4)
         self.user_tag_5.store(self.generic_attributes.user_tag_5)
+        self.operation_tag.store(self.generic_attributes.operation_tag)
         self.visible.store(self.generic_attributes.visible)
         if self.generic_attributes.parent_burst is not None:
             self.parent_burst.store(uuid.UUID(self.generic_attributes.parent_burst))
@@ -199,6 +201,7 @@ class H5File(object):
         self.generic_attributes.user_tag_3 = self.user_tag_3.load()
         self.generic_attributes.user_tag_4 = self.user_tag_4.load()
         self.generic_attributes.user_tag_5 = self.user_tag_5.load()
+        self.generic_attributes.operation_tag = self.operation_tag.load()
         self.generic_attributes.visible = self.visible.load()
         self.generic_attributes.create_date = string2date(str(self.create_date.load())) or None
         try:
@@ -273,6 +276,7 @@ class H5File(object):
 
 class ViewModelH5(H5File):
 
+    # TODO  it will be good to be able to just call with H5File.from_file(h5_path) as f for ViewModelH5 also
     def __init__(self, path, view_model):
         super(ViewModelH5, self).__init__(path)
         self.view_model = type(view_model)

--- a/framework_tvb/tvb/core/neotraits/_h5core.py
+++ b/framework_tvb/tvb/core/neotraits/_h5core.py
@@ -84,7 +84,7 @@ class H5File(object):
         self.user_tag_3 = Scalar(Attr(str), self, name='user_tag_3')
         self.user_tag_4 = Scalar(Attr(str), self, name='user_tag_4')
         self.user_tag_5 = Scalar(Attr(str), self, name='user_tag_5')
-        self.operation_tag = Scalar(Attr(str), self, name='operation_tag')
+        self.operation_tag = Scalar(Attr(str, required=False), self, name='operation_tag')
         self.parent_burst = Uuid(Attr(uuid.UUID, required=False), self, name='parent_burst')
         self.visible = Scalar(Attr(bool), self, name='visible')
         self.metadata_cache = None
@@ -201,9 +201,12 @@ class H5File(object):
         self.generic_attributes.user_tag_3 = self.user_tag_3.load()
         self.generic_attributes.user_tag_4 = self.user_tag_4.load()
         self.generic_attributes.user_tag_5 = self.user_tag_5.load()
-        self.generic_attributes.operation_tag = self.operation_tag.load()
         self.generic_attributes.visible = self.visible.load()
         self.generic_attributes.create_date = string2date(str(self.create_date.load())) or None
+        try:
+            self.generic_attributes.operation_tag = self.operation_tag.load()
+        except MissingDataSetException:
+            self.generic_attributes.operation_tag = None
         try:
             burst = self.parent_burst.load()
             self.generic_attributes.parent_burst = burst.hex if burst is not None else None

--- a/framework_tvb/tvb/core/services/import_service.py
+++ b/framework_tvb/tvb/core/services/import_service.py
@@ -285,6 +285,7 @@ class ImportService(object):
                     operation = Operation(project.fk_admin, project.id, alg.id,
                                           parameters=self._get_param_from_view_model_gid(main_view_model),
                                           status=STATUS_FINISHED,
+                                          user_group=main_view_model.generic_attributes.operation_tag,
                                           start_date=datetime.now(), completion_date=datetime.now())
                     operation.create_date = main_view_model.create_date
                     self.logger.debug("Found main ViewModel to create operation for it: " + str(operation))

--- a/framework_tvb/tvb/core/services/project_service.py
+++ b/framework_tvb/tvb/core/services/project_service.py
@@ -683,10 +683,9 @@ class ProjectService:
                                                               new_data[CommonDetails.CODE_OPERATION_GROUP_ID])
                 if len(all_data_in_group) < 1:
                     raise StructureException("Inconsistent group, can not be updated!")
-                datatype_group = dao.get_generic_entity(DataTypeGroup, all_data_in_group[0].fk_datatype_group)[0]
-                all_data_in_group.append(datatype_group)
+                # datatype_group = dao.get_generic_entity(DataTypeGroup, all_data_in_group[0].fk_datatype_group)[0]
+                # all_data_in_group.append(datatype_group)
                 for datatype in all_data_in_group:
-                    new_data[CommonDetails.CODE_GID] = datatype.gid
                     self._edit_data(datatype, new_data, True)
             else:
                 # Get the required DataType and operation from DB to store changes that will be done in XML.

--- a/framework_tvb/tvb/core/services/simulator_service.py
+++ b/framework_tvb/tvb/core/services/simulator_service.py
@@ -98,8 +98,8 @@ class SimulatorService(object):
         try:
             operation = self.operation_service.prepare_operation(user.id, project.id, simulator_algo,
                                                                  session_stored_simulator.gid)
-            ga, _ = self.operation_service._prepare_metadata(simulator_algo.algorithm_category, {},
-                                                             None, burst_config.gid)
+            ga = self.operation_service._prepare_metadata(simulator_algo.algorithm_category, {},
+                                                          None, burst_config.gid)
             session_stored_simulator.generic_attributes = ga
             storage_path = self.files_helper.get_project_folder(project, str(operation.id))
             h5.store_view_model(session_stored_simulator, storage_path)

--- a/framework_tvb/tvb/interfaces/web/controllers/flow_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/flow_controller.py
@@ -42,6 +42,7 @@ import formencode
 import numpy
 import six
 import sys
+from tvb.basic.neotraits.ex import TraitValueError
 from tvb.core.adapters import constants
 from tvb.core.adapters.abcadapter import ABCAdapter
 from tvb.core.adapters.abcdisplayer import ABCDisplayer
@@ -331,12 +332,9 @@ class FlowController(BaseController):
             errors = excep.unpack_errors()
             common.set_error_message("Invalid form inputs")
             self.logger.warning("Invalid form inputs %s" % errors)
-        except OperationException as excep1:
+        except (OperationException, LaunchException, TraitValueError) as excep1:
             self.logger.exception("Error while executing a Launch procedure:" + excep1.message)
             common.set_error_message(excep1.message)
-        except LaunchException as excep3:
-            self.logger.exception("Error while executing a Launch procedure:" + excep3.message)
-            common.set_error_message(excep3.message)
         except InvalidFormValues as excep2:
             message, errors = excep2.display_full_errors()
             common.set_error_message(message)

--- a/framework_tvb/tvb/tests/framework/adapters/testadapter3.py
+++ b/framework_tvb/tvb/tests/framework/adapters/testadapter3.py
@@ -35,8 +35,10 @@
 from tvb.basic.neotraits.api import Int
 from tvb.core.adapters import abcadapter
 from tvb.core.adapters.abcadapter import AdapterLaunchModeEnum
+from tvb.core.neocom import h5
 from tvb.core.neotraits.forms import IntField
 from tvb.core.neotraits.view_model import ViewModel
+from tvb.tests.framework.datatypes.dummy_datatype import DummyDataType
 from tvb.tests.framework.datatypes.dummy_datatype_index import DummyDataTypeIndex
 
 
@@ -110,14 +112,12 @@ class TestAdapter3(abcadapter.ABCAdapter):
         return 0
 
     def launch(self, view_model):
-        result = DummyDataTypeIndex()
+        result = DummyDataType()
         if view_model.param_5 is not None:
-            result.row1 = view_model.param_5
+            result.row1 = str(view_model.param_5)
         if view_model.param_6 is not None:
-            result.row2 = view_model.param_6
-        result.storage_path = self.storage_path
-        result.string_data = ["data"]
-        return result
+            result.row2 = str(view_model.param_6)
+        return h5.store_complete(result, self.storage_path)
 
 
 class TestAdapterHugeMemoryRequiredForm(abcadapter.ABCAdapterForm):

--- a/framework_tvb/tvb/tests/framework/core/factory.py
+++ b/framework_tvb/tvb/tests/framework/core/factory.py
@@ -57,6 +57,9 @@ from tvb.adapters.uploaders.region_mapping_importer import RegionMappingImporter
 from tvb.adapters.uploaders.sensors_importer import SensorsImporterModel, SensorsImporter
 from tvb.adapters.uploaders.zip_connectivity_importer import ZIPConnectivityImporterModel, ZIPConnectivityImporter
 from tvb.adapters.uploaders.zip_surface_importer import ZIPSurfaceImporter, ZIPSurfaceImporterModel
+from tvb.adapters.datatypes.db.sensors import SensorsIndex
+from tvb.adapters.datatypes.db.surface import SurfaceIndex
+from tvb.core.adapters import constants
 from tvb.core.adapters.abcadapter import ABCAdapter
 from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.entities.load import try_get_last_datatype
@@ -174,13 +177,18 @@ class TestFactory(object):
 
         adapter_inst = TestFactory.create_adapter('tvb.tests.framework.adapters.testadapter3', 'TestAdapter3')
         adapter_inst.generic_attributes.subject = subject
-        args = {RANGE_PARAMETER_1: 'param_5', 'param_5': [1, 2]}
+
+        view_model = adapter_inst.get_view_model()()
+        args = {RANGE_PARAMETER_1: 'param_5', 'param_5': json.dumps({constants.ATT_MINVALUE: 1,
+                                                                     constants.ATT_MAXVALUE: 2.1,
+                                                                     constants.ATT_STEP: 1})}
         algo = adapter_inst.stored_adapter
         algo_category = dao.get_category_by_id(algo.fk_category)
 
         # Prepare Operations group. Execute them synchronously
         service = OperationService()
-        operations = service.prepare_operations(test_user.id, test_project, algo, algo_category, **args)[0]
+        operations = service.prepare_operations(test_user.id, test_project, algo, algo_category,
+                                                view_model=view_model, **args)[0]
         service.launch_operation(operations[0].id, False, adapter_inst)
         service.launch_operation(operations[1].id, False, adapter_inst)
 

--- a/framework_tvb/tvb/tests/framework/core/services/operation_service_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/operation_service_test.py
@@ -38,7 +38,6 @@ from tvb.core.adapters.abcadapter import ABCAdapter
 from tvb.core.adapters.exceptions import NoMemoryAvailableException
 from tvb.core.entities.model import model_burst, model_operation
 from tvb.core.entities.storage import dao
-from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.entities.transient.structure_entities import DataTypeMetaData
 from tvb.core.services.operation_service import OperationService
 from tvb.core.services.project_service import initialize_storage, ProjectService
@@ -123,29 +122,22 @@ class TestOperationService(BaseTestCase):
         """
         Test the actual operation flow by executing a test adapter.
         """
-        module = "tvb.tests.framework.adapters.testadapter1"
-        class_name = "TestAdapter1"
         test_adapter_factory()
-        adapter = TestFactory.create_adapter(module, class_name)
-        output = adapter.get_output()
-        output_type = output[0].__name__
-        tmp_folder = FilesHelper().get_project_folder(self.test_project, "TEMP")
-
-        view_model = adapter.get_view_model()()
+        adapter = TestFactory.create_adapter("tvb.tests.framework.adapters.testadapter1", "TestAdapter1")
+        view_model = TestModel()
         view_model.test1_val1 = 5
         view_model.test1_val2 = 5
-        self.operation_service.initiate_operation(self.test_user, self.test_project, adapter,
-                                                  tmp_folder, model_view=view_model)
+        adapter.generic_attributes.subject = "Test4242"
 
-        group = dao.get_algorithm_by_module(module, class_name)
-        assert group.module == 'tvb.tests.framework.adapters.testadapter1', "Wrong data stored."
-        assert group.classname == 'TestAdapter1', "Wrong data stored."
+        self.operation_service.initiate_operation(self.test_user, self.test_project, adapter,
+                                                  model_view=view_model)
+
         dts, count = dao.get_values_of_datatype(self.test_project.id, DummyDataTypeIndex)
         assert count == 1
         assert len(dts) == 1
         datatype = dao.get_datatype_by_id(dts[0][0])
-        assert datatype.subject == DataTypeMetaData.DEFAULT_SUBJECT, "Wrong data stored."
-        assert datatype.type == output_type, "Wrong data stored."
+        assert datatype.subject == "Test4242", "Wrong data stored."
+        assert datatype.type == adapter.get_output()[0].__name__, "Wrong data stored."
 
     def test_delete_dt_free_hdd_space(self, test_adapter_factory, operation_factory):
         """
@@ -155,17 +147,16 @@ class TestOperationService(BaseTestCase):
         adapter = TestFactory.create_adapter("tvb.tests.framework.adapters.testadapter3", "TestAdapterHDDRequired")
         view_model = adapter.get_view_model()()
         TvbProfile.current.MAX_DISK_SPACE = float(adapter.get_required_disk_size(view_model))
-        tmp_folder = FilesHelper().get_project_folder(self.test_project, "TEMP")
 
         self._assert_no_ddti()
-        self.operation_service.initiate_operation(self.test_user, self.test_project, adapter, tmp_folder,
+        self.operation_service.initiate_operation(self.test_user, self.test_project, adapter,
                                                   model_view=view_model)
         datatype = self._assert_stored_ddti()
 
         # Now free some space and relaunch
         ProjectService().remove_datatype(self.test_project.id, datatype.gid)
         self._assert_no_ddti()
-        self.operation_service.initiate_operation(self.test_user, self.test_project, adapter, tmp_folder,
+        self.operation_service.initiate_operation(self.test_user, self.test_project, adapter,
                                                   model_view=view_model)
         self._assert_stored_ddti()
 
@@ -177,9 +168,8 @@ class TestOperationService(BaseTestCase):
         adapter = TestFactory.create_adapter("tvb.tests.framework.adapters.testadapter3", "TestAdapterHDDRequired")
         view_model = adapter.get_view_model()()
         TvbProfile.current.MAX_DISK_SPACE = 2 * float(adapter.get_required_disk_size(view_model))
-        tmp_folder = FilesHelper().get_project_folder(self.test_project, "TEMP")
 
-        self.operation_service.initiate_operation(self.test_user, self.test_project, adapter, tmp_folder,
+        self.operation_service.initiate_operation(self.test_user, self.test_project, adapter,
                                                   model_view=view_model)
         datatype = self._assert_stored_ddti()
 
@@ -188,7 +178,7 @@ class TestOperationService(BaseTestCase):
         TvbProfile.current.MAX_DISK_SPACE = float(datatype.disk_size) + float(
             adapter.get_required_disk_size(view_model))
 
-        self.operation_service.initiate_operation(self.test_user, self.test_project, adapter, tmp_folder,
+        self.operation_service.initiate_operation(self.test_user, self.test_project, adapter,
                                                   model_view=view_model)
         self._assert_stored_ddti(2)
 
@@ -201,18 +191,17 @@ class TestOperationService(BaseTestCase):
         view_model = adapter.get_view_model()()
 
         TvbProfile.current.MAX_DISK_SPACE = (1 + float(adapter.get_required_disk_size(view_model)))
-        tmp_folder = FilesHelper().get_project_folder(self.test_project, "TEMP")
-        self.operation_service.initiate_operation(self.test_user, self.test_project, adapter, tmp_folder,
+        self.operation_service.initiate_operation(self.test_user, self.test_project, adapter,
                                                   model_view=view_model)
 
         datatype = self._assert_stored_ddti()
-        # Now update the maximum disk size to be less than size of the previously resulted datatypes (transform kB to MB)
+        # Now update the maximum disk size to be less than size of the previously resulted dts (transform kB to MB)
         # plus what is estimated to be required from the next one (transform from B to MB)
         TvbProfile.current.MAX_DISK_SPACE = float(datatype.disk_size - 1) + \
                                             float(adapter.get_required_disk_size(view_model) - 1)
 
         with pytest.raises(NoMemoryAvailableException):
-            self.operation_service.initiate_operation(self.test_user, self.test_project, adapter, tmp_folder,
+            self.operation_service.initiate_operation(self.test_user, self.test_project, adapter,
                                                       model_view=view_model)
         self._assert_stored_ddti()
 
@@ -224,8 +213,7 @@ class TestOperationService(BaseTestCase):
         view_model = adapter.get_view_model()()
 
         TvbProfile.current.MAX_DISK_SPACE = float(adapter.get_required_disk_size(view_model))
-        tmp_folder = FilesHelper().get_project_folder(self.test_project, "TEMP")
-        self.operation_service.initiate_operation(self.test_user, self.test_project, adapter, tmp_folder,
+        self.operation_service.initiate_operation(self.test_user, self.test_project, adapter,
                                                   model_view=view_model)
         self._assert_stored_ddti()
 
@@ -234,7 +222,6 @@ class TestOperationService(BaseTestCase):
         Test the actual operation flow by executing a test adapter.
         """
         test_adapter_factory(adapter_class=TestAdapterHDDRequired)
-
         space_taken_by_started = 100
         adapter = TestFactory.create_adapter("tvb.tests.framework.adapters.testadapter3", "TestAdapterHDDRequired")
         form = TestAdapterHDDRequiredForm()
@@ -244,11 +231,10 @@ class TestOperationService(BaseTestCase):
                                                       status=model_operation.STATUS_STARTED,
                                                       estimated_disk_size=space_taken_by_started)
         view_model = adapter.get_view_model()()
-
         dao.store_entity(started_operation)
         TvbProfile.current.MAX_DISK_SPACE = float(adapter.get_required_disk_size(view_model) + space_taken_by_started)
-        tmp_folder = FilesHelper().get_project_folder(self.test_project, "TEMP")
-        self.operation_service.initiate_operation(self.test_user, self.test_project, adapter, tmp_folder,
+
+        self.operation_service.initiate_operation(self.test_user, self.test_project, adapter,
                                                   model_view=view_model)
         self._assert_stored_ddti()
 
@@ -257,16 +243,14 @@ class TestOperationService(BaseTestCase):
         Test the actual operation flow by executing a test adapter.
         """
         test_adapter_factory(adapter_class=TestAdapterHDDRequired)
-
         adapter = TestFactory.create_adapter("tvb.tests.framework.adapters.testadapter3", "TestAdapterHDDRequired")
         form = TestAdapterHDDRequiredForm()
         adapter.submit_form(form)
         view_model = adapter.get_view_model()()
-
         TvbProfile.current.MAX_DISK_SPACE = float(adapter.get_required_disk_size(view_model) - 1)
-        tmp_folder = FilesHelper().get_project_folder(self.test_project, "TEMP")
+
         with pytest.raises(NoMemoryAvailableException):
-            self.operation_service.initiate_operation(self.test_user, self.test_project, adapter, tmp_folder,
+            self.operation_service.initiate_operation(self.test_user, self.test_project, adapter,
                                                       model_view=view_model)
         self._assert_no_ddti()
 
@@ -275,7 +259,6 @@ class TestOperationService(BaseTestCase):
         Test the actual operation flow by executing a test adapter.
         """
         test_adapter_factory(adapter_class=TestAdapterHDDRequired)
-
         space_taken_by_started = 100
         adapter = TestFactory.create_adapter("tvb.tests.framework.adapters.testadapter3", "TestAdapterHDDRequired")
         form = TestAdapterHDDRequiredForm()
@@ -285,13 +268,12 @@ class TestOperationService(BaseTestCase):
                                                       status=model_operation.STATUS_STARTED,
                                                       estimated_disk_size=space_taken_by_started)
         view_model = adapter.get_view_model()()
-
         dao.store_entity(started_operation)
-        TvbProfile.current.MAX_DISK_SPACE = float(
-            adapter.get_required_disk_size(view_model) + space_taken_by_started - 1)
-        tmp_folder = FilesHelper().get_project_folder(self.test_project, "TEMP")
+        TvbProfile.current.MAX_DISK_SPACE = float(adapter.get_required_disk_size(view_model) +
+                                                  space_taken_by_started - 1)
+
         with pytest.raises(NoMemoryAvailableException):
-            self.operation_service.initiate_operation(self.test_user, self.test_project, adapter, tmp_folder,
+            self.operation_service.initiate_operation(self.test_user, self.test_project, adapter,
                                                       model_view=view_model)
         self._assert_no_ddti()
 
@@ -307,8 +289,10 @@ class TestOperationService(BaseTestCase):
         algo_category = dao.get_category_by_id(algo.fk_category)
         operations, _ = self.operation_service.prepare_operations(self.test_user.id, self.test_project, algo,
                                                                   algo_category, view_model=view_model)
+
         self.operation_service._send_to_cluster(operations, adapter)
         self.operation_service.stop_operation(operations[0].id)
+
         operation = dao.get_operation_by_id(operations[0].id)
         assert operation.status, model_operation.STATUS_CANCELED == "Operation should have been canceled!"
 

--- a/framework_tvb/tvb/tests/framework/core/services/project_service_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/project_service_test.py
@@ -312,16 +312,12 @@ class TestProjectService(TransactionalTestCase):
         user1 = TestFactory.create_user("another_user")
         for i in range(4):
             test_proj.append(TestFactory.create_project(self.test_user if i < 3 else user1, 'test_proj' + str(i)))
-
-        project_storage = self.structure_helper.get_project_folder(test_proj[0])
-
         operation = TestFactory.create_operation(test_user=self.test_user, test_project=test_proj[0])
-
-        project_storage = os.path.join(project_storage, str(operation.id))
-        os.makedirs(project_storage)
         datatype = dao.store_entity(model_datatype.DataType(module="test_data", subject="subj1",
                                                             state="test_state", operation_id=operation.id))
+
         linkable = self.project_service.get_linkable_projects_for_user(self.test_user.id, str(datatype.id))[0]
+
         assert len(linkable) == 2, "Wrong count of link-able projects!"
         proj_names = [project.name for project in linkable]
         assert test_proj[1].name in proj_names
@@ -390,7 +386,7 @@ class TestProjectService(TransactionalTestCase):
 
         assert not os.path.exists(vw_h5_path)
         exact_data = dao.get_datatype_by_gid(gid)
-        assert exact_data  is not None, "Data should still be in DB, because of links"
+        assert exact_data is not None, "Data should still be in DB, because of links"
         vw_h5_path_new = h5.path_for_stored_index(exact_data)
         assert os.path.exists(vw_h5_path_new)
         assert vw_h5_path_new != vw_h5_path

--- a/scientific_library/tvb/basic/neotraits/ex.py
+++ b/scientific_library/tvb/basic/neotraits/ex.py
@@ -33,6 +33,7 @@ class TraitError(Exception):
     def __init__(self, msg='', trait=None, attr=None):
         self.trait = trait
         self.attr = attr
+        self.message = msg
         super(TraitError, self).__init__(msg)
 
     def __str__(self):


### PR DESCRIPTION
In TVB Web GUI, on a DataType, we can open an overlay to show details.
Some of these details can be edited (e.g. "user tags").
This PR ensures that changing those fields can be done without throwing errors and that the changes are persisted both in DB and in H5 files