### PR TITLE
TVB-2771: Clear SessionStoredSim on project delete (and not only)

### DIFF
--- a/framework_tvb/tvb/interfaces/web/controllers/base_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/base_controller.py
@@ -125,22 +125,23 @@ class BaseController(object):
         Set the project passed as parameter as the selected project.
         """
         previous_project = common.get_current_project()
-        ### Update project stored in selection, with latest Project entity from DB.
+        # Update project stored in selection, with latest Project entity from DB.
         members = self.user_service.get_users_for_project("", project.id)[1]
         project.members = members
-        common.remove_from_session(common.KEY_CACHED_SIMULATOR_TREE)
-        common.add2session(common.KEY_PROJECT, project)
 
         if previous_project is None or previous_project.id != project.id:
-            ### Clean Burst selection from session in case of a different project.
-            common.remove_from_session(common.KEY_BURST_CONFIG)
-            ### Store in DB new project selection
+            # Clean Burst selection from session in case of a different project.
+            common.clean_project_data_from_session()
+            # Store in DB new project selection
             user = common.get_from_session(common.KEY_USER)
             if user is not None:
                 self.user_service.save_project_to_user(user.id, project.id)
-            ### Display info message about project change
+            # Display info message about project change
             self.logger.debug("Selected project is now " + project.name)
             common.set_info_message("Your current working project is: " + str(project.name))
+
+        # Add the project entity to session every time, as it might be changed (e.g. after edit)
+        common.add2session(common.KEY_PROJECT, project)
 
     @staticmethod
     def get_url_adapter(step_key, adapter_id, back_page=None):

--- a/framework_tvb/tvb/interfaces/web/controllers/common.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/common.py
@@ -85,7 +85,6 @@ KEY_SIMULATOR_CONFIG = 'simulator_configuration'
 KEY_IS_SIMULATOR_COPY = 'is_simulator_copy'
 KEY_IS_SIMULATOR_LOAD = 'is_simulator_load'
 KEY_LAST_LOADED_FORM_URL = 'last_loaded_form_url'
-KEY_CACHED_SIMULATOR_TREE = 'simulator_input_tree'
 KEY_BACK_PAGE = "back_page_link"
 KEY_SECTION_TITLES = "section_titles"
 KEY_SUBSECTION_TITLES = "sub_section_titles"
@@ -209,6 +208,14 @@ def get_current_project():
     return get_from_session(KEY_PROJECT)
 
 
+def clean_project_data_from_session():
+    remove_from_session(KEY_PROJECT)
+    remove_from_session(KEY_SIMULATOR_CONFIG)
+    remove_from_session(KEY_LAST_LOADED_FORM_URL)
+    remove_from_session(KEY_BURST_CONFIG)
+    add2session(KEY_IS_SIMULATOR_LOAD, False)
+
+
 class NotAllowed(TVBException):
     """
     Raised when accessing a resource is not allowed
@@ -229,10 +236,12 @@ class NotAuthenticated(NotAllowed):
         NotAllowed.__init__(self, message, redirect_url)
         self.status = 401
 
+
 class MissingDataException(TVBException):
 
     def __init__(self, message):
         TVBException.__init__(self, message)
+
 
 class InvalidFormValues(TVBException):
     """

--- a/framework_tvb/tvb/interfaces/web/controllers/project/project_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/project/project_controller.py
@@ -896,6 +896,15 @@ class ProjectController(BaseController):
         BaseController.fill_default_attributes(self, template_dictionary)
         return template_dictionary
 
+    @cherrypy.expose
+    @handle_error(redirect=False)
+    @check_user
+    def clean_simulator_for_project(self):
+        common.remove_from_session(common.KEY_SIMULATOR_CONFIG)
+        common.remove_from_session(common.KEY_LAST_LOADED_FORM_URL)
+        common.remove_from_session(common.KEY_BURST_CONFIG)
+        common.add2session(common.KEY_IS_SIMULATOR_LOAD, False)
+
 
 class EditForm(formencode.Schema):
     """

--- a/framework_tvb/tvb/interfaces/web/controllers/project/project_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/project/project_controller.py
@@ -146,19 +146,7 @@ class ProjectController(BaseController):
             common.set_error_message(exc.message)
         prj = common.get_current_project()
         if prj is not None and prj.id == int(project_id):
-            common.remove_from_session(common.KEY_PROJECT)
-
-
-    def _persist_project(self, data, project_id, is_create, current_user):
-        """Private method to persist"""
-        data = EditForm().to_python(data)
-        saved_project = self.project_service.store_project(current_user, is_create, project_id, **data)
-        selected_project = common.get_current_project()
-        if len(self.project_service.retrieve_projects_for_user(current_user.id, 1)) == 1:
-            selected_project = saved_project
-        if selected_project is None or (saved_project.id == selected_project.id):
-            self._mark_selected(saved_project)
-
+            common.clean_project_data_from_session()
 
     @expose_page
     @settings
@@ -195,9 +183,9 @@ class ProjectController(BaseController):
                                       editUsersEnabled=(current_user.username == admin_username))
         try:
             if cherrypy.request.method == 'POST' and save:
-                common.remove_from_session(common.KEY_PROJECT)
-                common.remove_from_session(common.KEY_CACHED_SIMULATOR_TREE)
-                self._persist_project(data, project_id, is_create, current_user)
+                data = EditForm().to_python(data)
+                saved_project = self.project_service.store_project(current_user, is_create, project_id, **data)
+                self._mark_selected(saved_project)
                 raise cherrypy.HTTPRedirect('/project/viewall')
         except formencode.Invalid as excep:
             self.logger.debug(str(excep))
@@ -895,15 +883,6 @@ class ProjectController(BaseController):
         template_dictionary[common.KEY_INCLUDE_RESOURCES] = 'project/included_resources'
         BaseController.fill_default_attributes(self, template_dictionary)
         return template_dictionary
-
-    @cherrypy.expose
-    @handle_error(redirect=False)
-    @check_user
-    def clean_simulator_for_project(self):
-        common.remove_from_session(common.KEY_SIMULATOR_CONFIG)
-        common.remove_from_session(common.KEY_LAST_LOADED_FORM_URL)
-        common.remove_from_session(common.KEY_BURST_CONFIG)
-        common.add2session(common.KEY_IS_SIMULATOR_LOAD, False)
 
 
 class EditForm(formencode.Schema):

--- a/framework_tvb/tvb/interfaces/web/controllers/users_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/users_controller.py
@@ -182,9 +182,7 @@ class UserController(BaseController):
         user = common.remove_from_session(common.KEY_USER)
         if user is not None:
             self.logger.debug("User " + user.username + " is just logging out!")
-        common.remove_from_session(common.KEY_PROJECT)
-        common.remove_from_session(common.KEY_BURST_CONFIG)
-        common.remove_from_session(common.KEY_CACHED_SIMULATOR_TREE)
+        common.clean_project_data_from_session()
         common.set_info_message("Thank you for using The Virtual Brain!")
 
         common.expire_session()

--- a/framework_tvb/tvb/interfaces/web/static/js/genericTVB.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/genericTVB.js
@@ -380,11 +380,6 @@ function selectProject(projectId, formId) {
     // Change hidden project_id and submit
     document.getElementById("hidden_project_id").value = projectId;
     document.getElementById(formId).submit();
-
-    doAjaxCall({
-        url: '/project/clean_simulator_for_project',
-        type: 'POST'
-    });
 }
 
 function exportProject(projectId) {

--- a/framework_tvb/tvb/interfaces/web/static/js/genericTVB.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/genericTVB.js
@@ -380,6 +380,11 @@ function selectProject(projectId, formId) {
     // Change hidden project_id and submit
     document.getElementById("hidden_project_id").value = projectId;
     document.getElementById(formId).submit();
+
+    doAjaxCall({
+        url: '/project/clean_simulator_for_project',
+        type: 'POST'
+    });
 }
 
 function exportProject(projectId) {


### PR DESCRIPTION
I made some tests and deleting only the session stored simulator won't work, the burst config and the last_loaded_url should be removed as well + is_simulationloaded must be False in case you loaded a simulation and then you switched the project.

Is this okay in ProjectController or would it be better in SimulationController?