### PR TITLE
HBP-106 and TVB-2765. Run uploaders in a separate process and fix tests 

### DIFF
--- a/framework_tvb/tvb/adapters/analyzers/bct_adapters.py
+++ b/framework_tvb/tvb/adapters/analyzers/bct_adapters.py
@@ -30,13 +30,14 @@
 
 import os
 from abc import abstractmethod
+
 from tvb.adapters.analyzers.matlab_worker import MatlabWorker
 from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
 from tvb.adapters.datatypes.db.graph import ConnectivityMeasureIndex
 from tvb.adapters.datatypes.db.mapped_value import ValueWrapperIndex
 from tvb.adapters.datatypes.h5.mapped_value_h5 import ValueWrapper
 from tvb.basic.profile import TvbProfile
-from tvb.core.adapters.abcadapter import ABCAsynchronous, ABCAdapterForm
+from tvb.core.adapters.abcadapter import ABCAdapterForm, ABCAdapter
 from tvb.core.entities.filters.chain import FilterChain
 from tvb.core.entities.load import load_entity_by_gid
 from tvb.core.entities.model.model_operation import AlgorithmTransientGroup
@@ -102,14 +103,14 @@ class BaseUnidirectedBCTForm(BaseBCTForm):
         return FilterChain(fields=[FilterChain.datatype + '.undirected'], operations=["=="], values=['1'])
 
 
-class BaseBCT(ABCAsynchronous):
+class BaseBCT(ABCAdapter):
     """
     Interface between Brain Connectivity Toolbox of Olaf Sporns and TVB Framework.
     This adapter requires BCT deployed locally, and Matlab or Octave installed separately of TVB.
     """
 
     def __init__(self):
-        ABCAsynchronous.__init__(self)
+        ABCAdapter.__init__(self)
         self.matlab_worker = MatlabWorker()
 
     @staticmethod

--- a/framework_tvb/tvb/adapters/analyzers/cross_correlation_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/cross_correlation_adapter.py
@@ -39,24 +39,25 @@ Adapter that uses the traits module to generate interfaces for ... Analyzer.
 
 import json
 import uuid
+
 import numpy
 from scipy.signal.signaltools import correlate
-from tvb.adapters.datatypes.h5.temporal_correlations_h5 import CrossCorrelationH5
 from tvb.adapters.datatypes.db.graph import CorrelationCoefficientsIndex
 from tvb.adapters.datatypes.db.temporal_correlations import CrossCorrelationIndex
 from tvb.adapters.datatypes.db.time_series import TimeSeriesIndex, TimeSeriesEEGIndex, TimeSeriesMEGIndex, \
     TimeSeriesSEEGIndex
+from tvb.adapters.datatypes.h5.temporal_correlations_h5 import CrossCorrelationH5
 from tvb.basic.neotraits.api import HasTraits, Attr, Float
 from tvb.basic.neotraits.info import narray_describe
-from tvb.core.adapters.abcadapter import ABCAsynchronous, ABCAdapterForm
+from tvb.core.adapters.abcadapter import ABCAdapterForm, ABCAdapter
 from tvb.core.adapters.exceptions import LaunchException
 from tvb.core.entities.filters.chain import FilterChain
-from tvb.core.neotraits.forms import ScalarField, TraitDataTypeSelectField
 from tvb.core.neocom import h5
+from tvb.core.neotraits.forms import ScalarField, TraitDataTypeSelectField
 from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
-from tvb.datatypes.time_series import TimeSeries
-from tvb.datatypes.temporal_correlations import CrossCorrelation
 from tvb.datatypes.graph import CorrelationCoefficients
+from tvb.datatypes.temporal_correlations import CrossCorrelation
+from tvb.datatypes.time_series import TimeSeries
 
 
 class CrossCorrelate(HasTraits):
@@ -104,7 +105,7 @@ class CrossCorrelateAdapterForm(ABCAdapterForm):
         return FilterChain(fields=[FilterChain.datatype + '.data_ndim'], operations=["=="], values=[4])
 
 
-class CrossCorrelateAdapter(ABCAsynchronous):
+class CrossCorrelateAdapter(ABCAdapter):
     """ TVB adapter for calling the CrossCorrelate algorithm. """
     _ui_name = "Cross-correlation of nodes"
     _ui_description = "Cross-correlate two one-dimensional arrays."
@@ -313,7 +314,7 @@ class PearsonCorrelationCoefficientAdapterForm(ABCAdapterForm):
         return CorrelationCoefficient()
 
 
-class PearsonCorrelationCoefficientAdapter(ABCAsynchronous):
+class PearsonCorrelationCoefficientAdapter(ABCAdapter):
     """ TVB adapter for calling the Pearson correlation coefficients algorithm. """
 
     _ui_name = "Pearson correlation coefficients"

--- a/framework_tvb/tvb/adapters/analyzers/fcd_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/fcd_adapter.py
@@ -38,23 +38,24 @@ Adapter that uses the traits model to generate interfaces for FCD Analyzer.
 
 import json
 import uuid
+
 import numpy as np
 from scipy import linalg
 from scipy.spatial.distance import pdist
 from sklearn.cluster import DBSCAN
 from sklearn.manifold import SpectralEmbedding
-from tvb.basic.neotraits.api import HasTraits, Attr, Float
-from tvb.basic.neotraits.info import narray_describe
-from tvb.core.adapters.abcadapter import ABCAsynchronous, ABCAdapterForm
-from tvb.core.adapters.exceptions import LaunchException
-from tvb.adapters.datatypes.h5.fcd_h5 import FcdH5
-from tvb.adapters.datatypes.h5.graph_h5 import ConnectivityMeasureH5
-from tvb.core.entities.filters.chain import FilterChain
 from tvb.adapters.datatypes.db.fcd import FcdIndex
 from tvb.adapters.datatypes.db.graph import ConnectivityMeasureIndex
 from tvb.adapters.datatypes.db.time_series import TimeSeriesRegionIndex
-from tvb.core.neotraits.forms import ScalarField, TraitDataTypeSelectField
+from tvb.adapters.datatypes.h5.fcd_h5 import FcdH5
+from tvb.adapters.datatypes.h5.graph_h5 import ConnectivityMeasureH5
+from tvb.basic.neotraits.api import HasTraits, Attr, Float
+from tvb.basic.neotraits.info import narray_describe
+from tvb.core.adapters.abcadapter import ABCAdapterForm, ABCAdapter
+from tvb.core.adapters.exceptions import LaunchException
+from tvb.core.entities.filters.chain import FilterChain
 from tvb.core.neocom import h5
+from tvb.core.neotraits.forms import ScalarField, TraitDataTypeSelectField
 from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
 from tvb.datatypes.fcd import Fcd
 from tvb.datatypes.graph import ConnectivityMeasure
@@ -127,7 +128,7 @@ class FCDAdapterForm(ABCAdapterForm):
         return FcdCalculator()
 
 
-class FunctionalConnectivityDynamicsAdapter(ABCAsynchronous):
+class FunctionalConnectivityDynamicsAdapter(ABCAdapter):
     """ TVB adapter for calling the Pearson CrossCorrelation algorithm.
 
         The present class will do the following actions:

--- a/framework_tvb/tvb/adapters/analyzers/fmri_balloon_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/fmri_balloon_adapter.py
@@ -36,18 +36,19 @@ Adapter that uses the traits module to generate interfaces for BalloonModel Anal
 """
 
 import uuid
+
 import numpy
+from tvb.adapters.datatypes.db.time_series import TimeSeriesRegionIndex
+from tvb.adapters.datatypes.h5.time_series_h5 import TimeSeriesRegionH5
 from tvb.analyzers.fmri_balloon import BalloonModel
 from tvb.basic.neotraits.api import Float, Attr
+from tvb.core.adapters.abcadapter import ABCAdapterForm, ABCAdapter
+from tvb.core.entities.filters.chain import FilterChain
+from tvb.core.neocom import h5
+from tvb.core.neotraits.db import prepare_array_shape_meta
+from tvb.core.neotraits.forms import ScalarField, TraitDataTypeSelectField
 from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
 from tvb.datatypes.time_series import TimeSeries, TimeSeriesRegion
-from tvb.core.adapters.abcadapter import ABCAsynchronous, ABCAdapterForm
-from tvb.core.entities.filters.chain import FilterChain
-from tvb.adapters.datatypes.h5.time_series_h5 import TimeSeriesRegionH5
-from tvb.adapters.datatypes.db.time_series import TimeSeriesRegionIndex
-from tvb.core.neotraits.forms import ScalarField, TraitDataTypeSelectField
-from tvb.core.neotraits.db import prepare_array_shape_meta
-from tvb.core.neocom import h5
 
 
 class BalloonModelAdapterModel(ViewModel):
@@ -128,7 +129,7 @@ class BalloonModelAdapterForm(ABCAdapterForm):
         return BalloonModel()
 
 
-class BalloonModelAdapter(ABCAsynchronous):
+class BalloonModelAdapter(ABCAdapter):
     """
     TVB adapter for calling the BalloonModel algorithm.
     """

--- a/framework_tvb/tvb/adapters/analyzers/fourier_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/fourier_adapter.py
@@ -35,20 +35,21 @@ Adapter that uses the traits module to generate interfaces for FFT Analyzer.
 .. moduleauthor:: Stuart A. Knock <Stuart@tvb.invalid>
 
 """
-import uuid
-import psutil
-import numpy
 import math
+import uuid
+
+import numpy
+import psutil
 import tvb.analyzers.fft as fft
-import tvb.core.adapters.abcadapter as abcadapter
-from tvb.core.entities.filters.chain import FilterChain
-from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
-from tvb.datatypes.time_series import TimeSeries
-from tvb.adapters.datatypes.h5.spectral_h5 import FourierSpectrumH5
 from tvb.adapters.datatypes.db.spectral import FourierSpectrumIndex
 from tvb.adapters.datatypes.db.time_series import TimeSeriesIndex
-from tvb.core.neotraits.forms import ScalarField, TraitDataTypeSelectField, SelectField
+from tvb.adapters.datatypes.h5.spectral_h5 import FourierSpectrumH5
+from tvb.core.adapters.abcadapter import ABCAdapterForm, ABCAdapter
+from tvb.core.entities.filters.chain import FilterChain
 from tvb.core.neocom import h5
+from tvb.core.neotraits.forms import ScalarField, TraitDataTypeSelectField, SelectField
+from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
+from tvb.datatypes.time_series import TimeSeries
 
 
 class FFTAdapterModel(ViewModel, fft.FFT):
@@ -66,7 +67,7 @@ class FFTAdapterModel(ViewModel, fft.FFT):
     )
 
 
-class FFTAdapterForm(abcadapter.ABCAdapterForm):
+class FFTAdapterForm(ABCAdapterForm):
 
     def __init__(self, prefix='', project_id=None):
         super(FFTAdapterForm, self).__init__(prefix, project_id)
@@ -96,7 +97,7 @@ class FFTAdapterForm(abcadapter.ABCAdapterForm):
         return fft.FFT()
 
 
-class FourierAdapter(abcadapter.ABCAsynchronous):
+class FourierAdapter(ABCAdapter):
     """ TVB adapter for calling the FFT algorithm. """
 
     _ui_name = "Fourier Spectral Analysis"

--- a/framework_tvb/tvb/adapters/analyzers/ica_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/ica_adapter.py
@@ -35,18 +35,19 @@ Adapter that uses the traits module to generate interfaces for ICA Analyzer.
 
 """
 
-import uuid
-import numpy
 import json
-from tvb.adapters.datatypes.h5.mode_decompositions_h5 import IndependentComponentsH5
+import uuid
+
+import numpy
 from tvb.adapters.datatypes.db.mode_decompositions import IndependentComponentsIndex
 from tvb.adapters.datatypes.db.time_series import TimeSeriesIndex
+from tvb.adapters.datatypes.h5.mode_decompositions_h5 import IndependentComponentsH5
 from tvb.analyzers.ica import FastICA
-from tvb.core.adapters.abcadapter import ABCAsynchronous, ABCAdapterForm
+from tvb.core.adapters.abcadapter import ABCAdapterForm, ABCAdapter
 from tvb.core.entities.filters.chain import FilterChain
-from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
-from tvb.core.neotraits.forms import ScalarField, TraitDataTypeSelectField
 from tvb.core.neocom import h5
+from tvb.core.neotraits.forms import ScalarField, TraitDataTypeSelectField
+from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
 from tvb.datatypes.time_series import TimeSeries
 
 
@@ -88,7 +89,7 @@ class ICAAdapterForm(ABCAdapterForm):
         return FastICA()
 
 
-class ICAAdapter(ABCAsynchronous):
+class ICAAdapter(ABCAdapter):
     """ TVB adapter for calling the ICA algorithm. """
 
     _ui_name = "Independent Component Analysis"

--- a/framework_tvb/tvb/adapters/analyzers/metrics_group_timeseries.py
+++ b/framework_tvb/tvb/adapters/analyzers/metrics_group_timeseries.py
@@ -47,7 +47,7 @@ from tvb.adapters.datatypes.db.time_series import TimeSeriesIndex
 from tvb.analyzers.metrics_base import BaseTimeseriesMetricAlgorithm
 from tvb.basic.neotraits.api import List
 from tvb.config import choices, ALGORITHMS
-from tvb.core.adapters.abcadapter import ABCAsynchronous, ABCAdapterForm
+from tvb.core.adapters.abcadapter import ABCAdapterForm, ABCAdapter
 from tvb.core.entities.file.simulator.datatype_measure_h5 import DatatypeMeasureH5
 from tvb.core.entities.filters.chain import FilterChain
 from tvb.core.neocom import h5
@@ -103,7 +103,7 @@ class TimeseriesMetricsAdapterForm(ABCAdapterForm):
         return FilterChain(fields=[FilterChain.datatype + '.data_ndim'], operations=["=="], values=[4])
 
 
-class TimeseriesMetricsAdapter(ABCAsynchronous):
+class TimeseriesMetricsAdapter(ABCAdapter):
     """
     TVB adapter for exposing as a group the measure algorithm.
     """

--- a/framework_tvb/tvb/adapters/analyzers/node_coherence_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/node_coherence_adapter.py
@@ -38,18 +38,19 @@ Adapter that uses the traits module to generate interfaces for FFT Analyzer.
 
 import json
 import uuid
+
 import numpy
-from tvb.adapters.datatypes.h5.spectral_h5 import CoherenceSpectrumH5
 from tvb.adapters.datatypes.db.spectral import CoherenceSpectrumIndex
 from tvb.adapters.datatypes.db.time_series import TimeSeriesIndex
+from tvb.adapters.datatypes.h5.spectral_h5 import CoherenceSpectrumH5
 from tvb.analyzers.node_coherence import NodeCoherence
-from tvb.core.adapters.abcadapter import ABCAsynchronous, ABCAdapterForm
+from tvb.core.adapters.abcadapter import ABCAdapterForm, ABCAdapter
 from tvb.core.entities.filters.chain import FilterChain
-from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
-from tvb.core.neotraits.forms import ScalarField, TraitDataTypeSelectField
 from tvb.core.neocom import h5
-from tvb.datatypes.time_series import TimeSeries
+from tvb.core.neotraits.forms import ScalarField, TraitDataTypeSelectField
+from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
 from tvb.datatypes.spectral import CoherenceSpectrum
+from tvb.datatypes.time_series import TimeSeries
 
 
 class NodeCoherenceModel(ViewModel, NodeCoherence):
@@ -89,7 +90,7 @@ class NodeCoherenceForm(ABCAdapterForm):
         return NodeCoherence()
 
 
-class NodeCoherenceAdapter(ABCAsynchronous):
+class NodeCoherenceAdapter(ABCAdapter):
     """ TVB adapter for calling the NodeCoherence algorithm. """
 
     _ui_name = "Cross coherence of nodes"

--- a/framework_tvb/tvb/adapters/analyzers/node_complex_coherence_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/node_complex_coherence_adapter.py
@@ -40,11 +40,11 @@ import numpy
 from tvb.adapters.datatypes.db.spectral import ComplexCoherenceSpectrumIndex
 from tvb.adapters.datatypes.db.time_series import TimeSeriesIndex
 from tvb.analyzers.node_complex_coherence import NodeComplexCoherence
-from tvb.core.adapters.abcadapter import ABCAsynchronous, ABCAdapterForm
-from tvb.core.neotraits.forms import TraitDataTypeSelectField
-from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
+from tvb.core.adapters.abcadapter import ABCAdapterForm, ABCAdapter
 from tvb.core.entities.filters.chain import FilterChain
 from tvb.core.neocom import h5
+from tvb.core.neotraits.forms import TraitDataTypeSelectField
+from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
 from tvb.datatypes.time_series import TimeSeries
 
 
@@ -85,7 +85,7 @@ class NodeComplexCoherenceForm(ABCAdapterForm):
         return NodeComplexCoherence()
 
 
-class NodeComplexCoherenceAdapter(ABCAsynchronous):
+class NodeComplexCoherenceAdapter(ABCAdapter):
     """ TVB adapter for calling the NodeComplexCoherence algorithm. """
 
     _ui_name = "Complex Coherence of Nodes"

--- a/framework_tvb/tvb/adapters/analyzers/node_covariance_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/node_covariance_adapter.py
@@ -37,19 +37,20 @@ Adapter that uses the traits module to generate interfaces for FFT Analyzer.
 """
 import json
 import uuid
+
 import numpy
-from tvb.basic.neotraits.api import HasTraits, Attr
-from tvb.basic.neotraits.info import narray_describe
-from tvb.core.adapters.abcadapter import ABCAsynchronous, ABCAdapterForm
-from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
-from tvb.datatypes.time_series import TimeSeries
-from tvb.datatypes.graph import Covariance
-from tvb.core.entities.filters.chain import FilterChain
-from tvb.adapters.datatypes.h5.graph_h5 import CovarianceH5
 from tvb.adapters.datatypes.db.graph import CovarianceIndex
 from tvb.adapters.datatypes.db.time_series import TimeSeriesIndex
-from tvb.core.neotraits.forms import TraitDataTypeSelectField
+from tvb.adapters.datatypes.h5.graph_h5 import CovarianceH5
+from tvb.basic.neotraits.api import HasTraits, Attr
+from tvb.basic.neotraits.info import narray_describe
+from tvb.core.adapters.abcadapter import ABCAdapterForm, ABCAdapter
+from tvb.core.entities.filters.chain import FilterChain
 from tvb.core.neocom import h5
+from tvb.core.neotraits.forms import TraitDataTypeSelectField
+from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
+from tvb.datatypes.graph import Covariance
+from tvb.datatypes.time_series import TimeSeries
 
 
 class NodeCovariance(HasTraits):
@@ -96,7 +97,7 @@ class NodeCovarianceAdapterForm(ABCAdapterForm):
         return FilterChain(fields=[FilterChain.datatype + '.data_ndim'], operations=["=="], values=[4])
 
 
-class NodeCovarianceAdapter(ABCAsynchronous):
+class NodeCovarianceAdapter(ABCAdapter):
     """ TVB adapter for calling the NodeCovariance algorithm. """
     _ui_name = "Temporal covariance of nodes"
     _ui_description = "Compute Temporal Node Covariance for a TimeSeries input DataType."

--- a/framework_tvb/tvb/adapters/analyzers/pca_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/pca_adapter.py
@@ -36,17 +36,18 @@ Adapter that uses the traits module to generate interfaces for FFT Analyzer.
 
 """
 import uuid
+
 import numpy
-from tvb.analyzers.pca import PCA
-from tvb.core.adapters.abcadapter import ABCAsynchronous, ABCAdapterForm
-from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
-from tvb.datatypes.time_series import TimeSeries
-from tvb.core.entities.filters.chain import FilterChain
-from tvb.adapters.datatypes.h5.mode_decompositions_h5 import PrincipalComponentsH5
 from tvb.adapters.datatypes.db.mode_decompositions import PrincipalComponentsIndex
 from tvb.adapters.datatypes.db.time_series import TimeSeriesIndex
-from tvb.core.neotraits.forms import TraitDataTypeSelectField
+from tvb.adapters.datatypes.h5.mode_decompositions_h5 import PrincipalComponentsH5
+from tvb.analyzers.pca import PCA
+from tvb.core.adapters.abcadapter import ABCAdapterForm, ABCAdapter
+from tvb.core.entities.filters.chain import FilterChain
 from tvb.core.neocom import h5
+from tvb.core.neotraits.forms import TraitDataTypeSelectField
+from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
+from tvb.datatypes.time_series import TimeSeries
 
 
 class PCAAdapterModel(ViewModel, PCA):
@@ -88,7 +89,7 @@ class PCAAdapterForm(ABCAdapterForm):
         return PCA()
 
 
-class PCAAdapter(ABCAsynchronous):
+class PCAAdapter(ABCAdapter):
     """ TVB adapter for calling the PCA algorithm. """
 
     _ui_name = "Principal Component Analysis"

--- a/framework_tvb/tvb/adapters/analyzers/wavelet_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/wavelet_adapter.py
@@ -38,20 +38,21 @@ ContinuousWaveletTransform Analyzer.
 """
 
 import uuid
+
 import numpy
-from tvb.adapters.datatypes.h5.time_series_h5 import TimeSeriesH5
-from tvb.basic.neotraits.api import Float
-from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
-from tvb.analyzers.wavelet import ContinuousWaveletTransform
-from tvb.datatypes.time_series import TimeSeries
-from tvb.core.adapters.abcadapter import ABCAsynchronous, ABCAdapterForm
-from tvb.core.entities.filters.chain import FilterChain
-from tvb.adapters.datatypes.h5.spectral_h5 import WaveletCoefficientsH5
 from tvb.adapters.datatypes.db.spectral import WaveletCoefficientsIndex
 from tvb.adapters.datatypes.db.time_series import TimeSeriesIndex
-from tvb.core.neotraits.forms import ScalarField, FormField, Form, TraitDataTypeSelectField, FloatField
-from tvb.core.neotraits.db import from_ndarray
+from tvb.adapters.datatypes.h5.spectral_h5 import WaveletCoefficientsH5
+from tvb.adapters.datatypes.h5.time_series_h5 import TimeSeriesH5
+from tvb.analyzers.wavelet import ContinuousWaveletTransform
+from tvb.basic.neotraits.api import Float
+from tvb.core.adapters.abcadapter import ABCAdapterForm, ABCAdapter
+from tvb.core.entities.filters.chain import FilterChain
 from tvb.core.neocom import h5
+from tvb.core.neotraits.db import from_ndarray
+from tvb.core.neotraits.forms import ScalarField, FormField, Form, TraitDataTypeSelectField, FloatField
+from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
+from tvb.datatypes.time_series import TimeSeries
 
 
 class WaveletAdapterModel(ViewModel, ContinuousWaveletTransform):
@@ -62,12 +63,19 @@ class WaveletAdapterModel(ViewModel, ContinuousWaveletTransform):
         doc="""The timeseries to which the wavelet is to be applied."""
     )
 
+
 class RangeForm(Form):
     def __init__(self, prefix=''):
         super(RangeForm, self).__init__(prefix)
-        self.lo = FloatField(Float(label='Lo', default=ContinuousWaveletTransform.frequencies.default.lo, doc='start of range'), self, name='Lo')
-        self.hi = FloatField(Float(label='Hi', default=ContinuousWaveletTransform.frequencies.default.hi, doc='end of range'), self, name='Hi')
-        self.step = FloatField(Float(label='Step', default=ContinuousWaveletTransform.frequencies.default.step, doc='step of range'), self, name='Step')
+        self.lo = FloatField(
+            Float(label='Lo', default=ContinuousWaveletTransform.frequencies.default.lo, doc='start of range'), self,
+            name='Lo')
+        self.hi = FloatField(
+            Float(label='Hi', default=ContinuousWaveletTransform.frequencies.default.hi, doc='end of range'), self,
+            name='Hi')
+        self.step = FloatField(
+            Float(label='Step', default=ContinuousWaveletTransform.frequencies.default.step, doc='step of range'), self,
+            name='Step')
 
 
 class ContinuousWaveletTransformAdapterForm(ABCAdapterForm):
@@ -111,7 +119,7 @@ class ContinuousWaveletTransformAdapterForm(ABCAdapterForm):
         return FilterChain(fields=[FilterChain.datatype + '.data_ndim'], operations=["=="], values=[4])
 
 
-class ContinuousWaveletTransformAdapter(ABCAsynchronous):
+class ContinuousWaveletTransformAdapter(ABCAdapter):
     """
     TVB adapter for calling the ContinuousWaveletTransform algorithm.
     """

--- a/framework_tvb/tvb/adapters/creators/connectivity_creator.py
+++ b/framework_tvb/tvb/adapters/creators/connectivity_creator.py
@@ -33,22 +33,21 @@
 """
 
 import numpy
-from tvb.basic.neotraits.api import Attr, NArray
-from tvb.core.adapters.abcadapter import ABCAdapterForm, ABCAsynchronous
 from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
 from tvb.adapters.datatypes.db.region_mapping import RegionMappingIndex
 from tvb.adapters.datatypes.db.surface import SurfaceIndex
+from tvb.basic.neotraits.api import Attr, NArray
+from tvb.core.adapters.abcadapter import ABCAdapterForm, ABCAdapter
 from tvb.core.entities.load import load_entity_by_gid
 from tvb.core.entities.storage import dao
-from tvb.core.neotraits.forms import ArrayField, BoolField, TraitDataTypeSelectField
 from tvb.core.neocom import h5
+from tvb.core.neotraits.forms import ArrayField, BoolField, TraitDataTypeSelectField
 from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
 from tvb.datatypes.connectivity import Connectivity
 from tvb.datatypes.region_mapping import RegionMapping
 
 
 class ConnectivityCreatorModel(ViewModel):
-
     original_connectivity = DataTypeGidAttr(
         linked_datatype=Connectivity,
         default=None,
@@ -81,12 +80,14 @@ class ConnectivityCreatorModel(ViewModel):
         required=False,
         doc="""""")
 
+
 class ConnectivityCreatorForm(ABCAdapterForm):
 
     def __init__(self, prefix='', project_id=None):
         super(ConnectivityCreatorForm, self).__init__(prefix, project_id)
         self.original_connectivity = TraitDataTypeSelectField(ConnectivityCreatorModel.original_connectivity, self,
-                                                         name='original_connectivity', conditions=self.get_filters())
+                                                              name='original_connectivity',
+                                                              conditions=self.get_filters())
         self.new_weights = ArrayField(ConnectivityCreatorModel.new_weights, self)
         self.new_tracts = ArrayField(ConnectivityCreatorModel.new_tracts, self)
         self.interest_area_indexes = ArrayField(ConnectivityCreatorModel.interest_area_indexes, self)
@@ -109,7 +110,7 @@ class ConnectivityCreatorForm(ABCAdapterForm):
         return 'original_connectivity'
 
 
-class ConnectivityCreator(ABCAsynchronous):
+class ConnectivityCreator(ABCAdapter):
     """
     This adapter creates a Connectivity.
     """

--- a/framework_tvb/tvb/adapters/creators/local_connectivity_creator.py
+++ b/framework_tvb/tvb/adapters/creators/local_connectivity_creator.py
@@ -33,17 +33,17 @@
 .. moduleauthor:: Ionel Ortelecan <ionel.ortelecan@codemart.ro>
 """
 
-from tvb.adapters.simulator.equation_forms import GaussianEquationForm, get_form_for_equation
 from tvb.adapters.datatypes.db.local_connectivity import LocalConnectivityIndex
 from tvb.adapters.datatypes.db.surface import SurfaceIndex
+from tvb.adapters.simulator.equation_forms import GaussianEquationForm, get_form_for_equation
 from tvb.basic.neotraits.api import Attr
-from tvb.core.adapters.abcadapter import ABCAsynchronous, ABCAdapterForm
+from tvb.core.adapters.abcadapter import ABCAdapterForm, ABCAdapter
 from tvb.core.entities.filters.chain import FilterChain
-from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr, Str
-from tvb.core.neotraits.forms import ScalarField, FormField, SelectField, TraitDataTypeSelectField
 from tvb.core.neocom import h5
-from tvb.datatypes.surfaces import Surface, CorticalSurface, CORTICAL
+from tvb.core.neotraits.forms import ScalarField, FormField, SelectField, TraitDataTypeSelectField
+from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr, Str
 from tvb.datatypes.local_connectivity import LocalConnectivity
+from tvb.datatypes.surfaces import Surface, CORTICAL
 
 
 class LocalConnectivitySelectorForm(ABCAdapterForm):
@@ -132,7 +132,7 @@ class LocalConnectivityCreatorForm(ABCAdapterForm):
                 'equation_params_div': self.NAME_EQUATION_PARAMS_DIV, 'legend': 'Local connectivity parameters'}
 
 
-class LocalConnectivityCreator(ABCAsynchronous):
+class LocalConnectivityCreator(ABCAdapter):
     """
     The purpose of this adapter is create a LocalConnectivity.
     """

--- a/framework_tvb/tvb/adapters/creators/stimulus_creator.py
+++ b/framework_tvb/tvb/adapters/creators/stimulus_creator.py
@@ -33,14 +33,15 @@
 """
 
 import uuid
+
 from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
-from tvb.adapters.datatypes.db.surface import SurfaceIndex
 from tvb.adapters.datatypes.db.patterns import StimuliRegionIndex, StimuliSurfaceIndex
+from tvb.adapters.datatypes.db.surface import SurfaceIndex
 from tvb.adapters.simulator.equation_forms import get_form_for_equation
-from tvb.adapters.simulator.subforms_mapping import get_ui_name_to_equation_dict, GAUSSIAN_EQUATION
 from tvb.adapters.simulator.subforms_mapping import DOUBLE_GAUSSIAN_EQUATION, SIGMOID_EQUATION
+from tvb.adapters.simulator.subforms_mapping import get_ui_name_to_equation_dict, GAUSSIAN_EQUATION
 from tvb.basic.neotraits.api import Attr
-from tvb.core.adapters.abcadapter import ABCSynchronous, ABCAdapterForm
+from tvb.core.adapters.abcadapter import ABCAdapterForm, AdapterLaunchModeEnum, ABCAdapter
 from tvb.core.entities.filters.chain import FilterChain
 from tvb.core.neocom import h5
 from tvb.core.neotraits.forms import FormField, SimpleStrField, TraitDataTypeSelectField, SelectField
@@ -129,7 +130,7 @@ class SurfaceStimulusCreatorForm(ABCAdapterForm):
                 'temporal_params_div': self.NAME_TEMPORAL_PARAMS_DIV, 'legend': 'Stimulus interface'}
 
 
-class SurfaceStimulusCreator(ABCSynchronous):
+class SurfaceStimulusCreator(ABCAdapter):
     """
     The purpose of this adapter is to create a StimuliSurface.
     """
@@ -137,6 +138,7 @@ class SurfaceStimulusCreator(ABCSynchronous):
     KEY_SPATIAL = 'spatial'
     KEY_TEMPORAL = 'temporal'
     KEY_FOCAL_POINTS_TRIANGLES = 'focal_points_triangles'
+    launch_mode = AdapterLaunchModeEnum.SYNC_SAME_MEM
 
     def get_form_class(self):
         return SurfaceStimulusCreatorForm
@@ -263,10 +265,11 @@ class RegionStimulusCreatorForm(ABCAdapterForm):
                 'temporal_params_div': self.NAME_TEMPORAL_PARAMS_DIV, 'legend': 'Stimulus interface'}
 
 
-class RegionStimulusCreator(ABCSynchronous):
+class RegionStimulusCreator(ABCAdapter):
     """
     The purpose of this adapter is to create a StimuliRegion.
     """
+    launch_mode = AdapterLaunchModeEnum.SYNC_SAME_MEM
 
     def get_form_class(self):
         return RegionStimulusCreatorForm

--- a/framework_tvb/tvb/adapters/simulator/simulator_adapter.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_adapter.py
@@ -42,22 +42,23 @@ Few supplementary steps are done here:
 """
 
 import json
+
+from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
+from tvb.adapters.datatypes.db.region_mapping import RegionMappingIndex, RegionVolumeMappingIndex
+from tvb.adapters.datatypes.db.simulation_history import SimulationHistoryIndex
+from tvb.adapters.datatypes.db.time_series import TimeSeriesIndex
+from tvb.adapters.simulator.coupling_forms import get_ui_name_to_coupling_dict
 from tvb.adapters.simulator.model_forms import get_model_to_form_dict
 from tvb.adapters.simulator.monitor_forms import get_monitor_to_form_dict
 from tvb.adapters.simulator.simulator_fragments import *
-from tvb.adapters.simulator.coupling_forms import get_ui_name_to_coupling_dict
-from tvb.adapters.datatypes.db.simulation_history import SimulationHistoryIndex
-from tvb.adapters.datatypes.db.region_mapping import RegionMappingIndex, RegionVolumeMappingIndex
-from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
-from tvb.adapters.datatypes.db.time_series import TimeSeriesIndex
 from tvb.basic.neotraits.api import Attr
+from tvb.core.adapters.abcadapter import ABCAdapterForm, ABCAdapter
+from tvb.core.adapters.exceptions import LaunchException
 from tvb.core.entities.file.simulator.simulation_history_h5 import SimulationHistory
 from tvb.core.entities.file.simulator.view_model import SimulatorAdapterModel
 from tvb.core.entities.storage import dao
-from tvb.core.adapters.abcadapter import ABCAsynchronous, ABCAdapterForm
-from tvb.core.adapters.exceptions import LaunchException
-from tvb.core.neotraits.forms import FloatField, SelectField
 from tvb.core.neocom import h5
+from tvb.core.neotraits.forms import FloatField, SelectField
 from tvb.simulator.coupling import Coupling
 from tvb.simulator.simulator import Simulator
 
@@ -115,7 +116,7 @@ class SimulatorAdapterForm(ABCAdapterForm):
         pass
 
 
-class SimulatorAdapter(ABCAsynchronous):
+class SimulatorAdapter(ABCAdapter):
     """
     Interface between the Simulator and the Framework.
     """

--- a/framework_tvb/tvb/core/adapters/abcadapter.py
+++ b/framework_tvb/tvb/core/adapters/abcadapter.py
@@ -44,6 +44,7 @@ import numpy
 import psutil
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
+from enum import Enum
 from functools import wraps
 from six import add_metaclass
 from tvb.basic.logger.builder import get_logger
@@ -165,6 +166,12 @@ class ABCAdapterForm(Form):
                 field.fill_from_post(form_data)
 
 
+class AdapterLaunchModeEnum(Enum):
+    SYNC_SAME_MEM = 'sync_same_mem'
+    SYNC_DIFF_MEM = 'sync_diff_mem'
+    ASYNC_DIFF_MEM = 'async_diff_mem'
+
+
 @add_metaclass(ABCMeta)
 class ABCAdapter(object):
     """
@@ -172,6 +179,7 @@ class ABCAdapter(object):
     """
     # model.Algorithm instance that will be set for each adapter class created by in build_adapter method
     stored_adapter = None
+    launch_mode = AdapterLaunchModeEnum.ASYNC_DIFF_MEM
 
     def __init__(self):
         self.generic_attributes = GenericAttributes()
@@ -544,23 +552,9 @@ class ABCAdapter(object):
         input_gid = json.loads(operation.parameters)['gid']
         return h5.load_view_model(input_gid, storage_path)
 
-
-@add_metaclass(ABCMeta)
-class ABCAsynchronous(ABCAdapter):
-    """
-    Abstract class, for marking adapters that are prone to be executed  on Cluster.
-    """
-
     def array_size2kb(self, size):
         """
         :param size: size in bytes
         :return: size in kB
         """
         return size * TvbProfile.current.MAGIC_NUMBER / 8 / 2 ** 10
-
-
-@add_metaclass(ABCMeta)
-class ABCSynchronous(ABCAdapter):
-    """
-    Abstract class, for marking adapters that are prone to be NOT executed on Cluster.
-    """

--- a/framework_tvb/tvb/core/adapters/abcadapter.py
+++ b/framework_tvb/tvb/core/adapters/abcadapter.py
@@ -40,17 +40,17 @@ import json
 import os
 import typing
 import uuid
-import numpy
-import psutil
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
 from enum import Enum
 from functools import wraps
+
+import numpy
+import psutil
 from six import add_metaclass
 from tvb.basic.logger.builder import get_logger
 from tvb.basic.neotraits.api import Attr, HasTraits, List
 from tvb.basic.profile import TvbProfile
-from tvb.core.adapters import constants
 from tvb.core.adapters.exceptions import IntrospectionException, LaunchException, InvalidParameterException
 from tvb.core.adapters.exceptions import NoMemoryAvailableException
 from tvb.core.entities.file.files_helper import FilesHelper

--- a/framework_tvb/tvb/core/adapters/abcdisplayer.py
+++ b/framework_tvb/tvb/core/adapters/abcdisplayer.py
@@ -33,11 +33,12 @@
 import importlib
 import json
 import os
-from threading import Lock
 from abc import ABCMeta
+from threading import Lock
 from uuid import UUID
+
 from six import add_metaclass
-from tvb.core.adapters.abcadapter import ABCSynchronous
+from tvb.core.adapters.abcadapter import AdapterLaunchModeEnum, ABCAdapter
 from tvb.core.adapters.exceptions import LaunchException
 from tvb.core.neocom import h5
 from tvb.core.neotraits.view_model import ViewModel
@@ -98,13 +99,14 @@ class URLGenerator(object):
 
 
 @add_metaclass(ABCMeta)
-class ABCDisplayer(ABCSynchronous, metaclass=ABCMeta):
+class ABCDisplayer(ABCAdapter, metaclass=ABCMeta):
     """
     Abstract class, for marking Adapters used for UI display only.
     """
     KEY_CONTENT = "mainContent"
     KEY_IS_ADAPTER = "isAdapter"
     VISUALIZERS_ROOT = ''
+    launch_mode = AdapterLaunchModeEnum.SYNC_SAME_MEM
 
     def get_output(self):
         return []

--- a/framework_tvb/tvb/core/adapters/abcuploader.py
+++ b/framework_tvb/tvb/core/adapters/abcuploader.py
@@ -43,7 +43,7 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from scipy import io as scipy_io
 from tvb.basic.logger.builder import get_logger
 from tvb.basic.profile import TvbProfile
-from tvb.core.adapters.abcadapter import ABCSynchronous, ABCAdapterForm
+from tvb.core.adapters.abcadapter import ABCAsynchronous, ABCAdapterForm
 from tvb.core.adapters.exceptions import LaunchException
 from tvb.core.neotraits.forms import StrField, TraitUploadField
 from tvb.core.neotraits.uploader_view_model import UploaderViewModel
@@ -80,7 +80,7 @@ class ABCUploaderForm(ABCAdapterForm):
         return None
 
 
-class ABCUploader(ABCSynchronous, metaclass=ABCMeta):
+class ABCUploader(ABCAsynchronous, metaclass=ABCMeta):
     """
     Base class of the uploading algorithms
     """
@@ -97,7 +97,7 @@ class ABCUploader(ABCSynchronous, metaclass=ABCMeta):
             for upload_field_name in trait_upload_field_names:
                 self._decrypt_content(view_model, upload_field_name)
 
-        return ABCSynchronous._prelaunch(self, operation, view_model, uid, available_disk_space)
+        return ABCAsynchronous._prelaunch(self, operation, view_model, uid, available_disk_space)
 
     @staticmethod
     def get_path_to_encrypt(input_path):

--- a/framework_tvb/tvb/core/adapters/abcuploader.py
+++ b/framework_tvb/tvb/core/adapters/abcuploader.py
@@ -43,7 +43,7 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from scipy import io as scipy_io
 from tvb.basic.logger.builder import get_logger
 from tvb.basic.profile import TvbProfile
-from tvb.core.adapters.abcadapter import ABCAsynchronous, ABCAdapterForm
+from tvb.core.adapters.abcadapter import AdapterLaunchModeEnum, ABCAdapterForm, ABCAdapter
 from tvb.core.adapters.exceptions import LaunchException
 from tvb.core.neotraits.forms import StrField, TraitUploadField
 from tvb.core.neotraits.uploader_view_model import UploaderViewModel
@@ -80,11 +80,12 @@ class ABCUploaderForm(ABCAdapterForm):
         return None
 
 
-class ABCUploader(ABCAsynchronous, metaclass=ABCMeta):
+class ABCUploader(ABCAdapter, metaclass=ABCMeta):
     """
     Base class of the uploading algorithms
     """
     LOGGER = get_logger(__name__)
+    launch_mode = AdapterLaunchModeEnum.SYNC_DIFF_MEM
 
     def _prelaunch(self, operation, view_model, uid=None, available_disk_space=0):
         """
@@ -97,7 +98,7 @@ class ABCUploader(ABCAsynchronous, metaclass=ABCMeta):
             for upload_field_name in trait_upload_field_names:
                 self._decrypt_content(view_model, upload_field_name)
 
-        return ABCAsynchronous._prelaunch(self, operation, view_model, uid, available_disk_space)
+        return ABCAdapter._prelaunch(self, operation, view_model, uid, available_disk_space)
 
     @staticmethod
     def get_path_to_encrypt(input_path):

--- a/framework_tvb/tvb/core/services/backend_clients/standalone_client.py
+++ b/framework_tvb/tvb/core/services/backend_clients/standalone_client.py
@@ -41,6 +41,7 @@ import sys
 from subprocess import Popen, PIPE
 from threading import Thread, Event
 
+from tvb.basic.exceptions import TVBException
 from tvb.basic.logger.builder import get_logger
 from tvb.basic.profile import TvbProfile
 from tvb.core.adapters.abcadapter import AdapterLaunchModeEnum
@@ -162,6 +163,9 @@ class StandAloneClient(BackendClient):
         CURRENT_ACTIVE_THREADS.append(thread)
         if adapter_instance.launch_mode is AdapterLaunchModeEnum.SYNC_DIFF_MEM:
             thread.run()
+            operation = dao.get_operation_by_id(operation_id)
+            if operation.additional_info and operation.status == STATUS_ERROR:
+                raise TVBException(operation.additional_info)
         else:
             thread.start()
 

--- a/framework_tvb/tvb/core/services/backend_clients/standalone_client.py
+++ b/framework_tvb/tvb/core/services/backend_clients/standalone_client.py
@@ -43,7 +43,7 @@ from threading import Thread, Event
 
 from tvb.basic.logger.builder import get_logger
 from tvb.basic.profile import TvbProfile
-from tvb.core.adapters.abcuploader import ABCUploader
+from tvb.core.adapters.abcadapter import AdapterLaunchModeEnum
 from tvb.core.entities.model.model_operation import OperationProcessIdentifier, STATUS_ERROR, STATUS_CANCELED
 from tvb.core.entities.storage import dao
 from tvb.core.services.backend_clients.backend_client import BackendClient
@@ -160,7 +160,7 @@ class StandAloneClient(BackendClient):
         """Start asynchronous operation locally"""
         thread = OperationExecutor(operation_id)
         CURRENT_ACTIVE_THREADS.append(thread)
-        if isinstance(adapter_instance, ABCUploader):
+        if adapter_instance.launch_mode is AdapterLaunchModeEnum.SYNC_DIFF_MEM:
             thread.run()
         else:
             thread.start()

--- a/framework_tvb/tvb/core/services/backend_clients/standalone_client.py
+++ b/framework_tvb/tvb/core/services/backend_clients/standalone_client.py
@@ -43,6 +43,7 @@ from threading import Thread, Event
 
 from tvb.basic.logger.builder import get_logger
 from tvb.basic.profile import TvbProfile
+from tvb.core.adapters.abcuploader import ABCUploader
 from tvb.core.entities.model.model_operation import OperationProcessIdentifier, STATUS_ERROR, STATUS_CANCELED
 from tvb.core.entities.storage import dao
 from tvb.core.services.backend_clients.backend_client import BackendClient
@@ -159,7 +160,10 @@ class StandAloneClient(BackendClient):
         """Start asynchronous operation locally"""
         thread = OperationExecutor(operation_id)
         CURRENT_ACTIVE_THREADS.append(thread)
-        thread.start()
+        if isinstance(adapter_instance, ABCUploader):
+            thread.run()
+        else:
+            thread.start()
 
     @staticmethod
     def stop_operation(operation_id):

--- a/framework_tvb/tvb/core/services/operation_service.py
+++ b/framework_tvb/tvb/core/services/operation_service.py
@@ -49,7 +49,7 @@ from tvb.basic.neotraits.api import Range
 from tvb.basic.profile import TvbProfile
 from tvb.config import choices, MEASURE_METRICS_MODULE, MEASURE_METRICS_CLASS, MEASURE_METRICS_MODEL_CLASS
 from tvb.core.adapters import constants
-from tvb.core.adapters.abcadapter import ABCAdapter, ABCSynchronous
+from tvb.core.adapters.abcadapter import ABCAdapter, AdapterLaunchModeEnum
 from tvb.core.adapters.exceptions import LaunchException
 from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.entities.generic_attributes import GenericAttributes
@@ -106,7 +106,7 @@ class OperationService:
         operations = self.prepare_operations(current_user.id, project, algo, algo_category,
                                              visible, view_model=model_view, **kwargs)[0]
 
-        if isinstance(adapter_instance, ABCSynchronous):
+        if adapter_instance.launch_mode == AdapterLaunchModeEnum.SYNC_SAME_MEM:
             if len(operations) > 1:
                 raise LaunchException("Synchronous operations are not supporting ranges!")
             if len(operations) < 1:

--- a/framework_tvb/tvb/core/services/operation_service.py
+++ b/framework_tvb/tvb/core/services/operation_service.py
@@ -317,6 +317,8 @@ class OperationService:
         for operation in operations:
             try:
                 BackendClientFactory.execute(str(operation.id), current_username, adapter_instance)
+            except TVBException as ex:
+                self._handle_exception(ex, {}, ex.message, operation)
             except Exception as excep:
                 self._handle_exception(excep, {}, "Could not start operation!", operation)
 

--- a/framework_tvb/tvb/tests/framework/adapters/testadapter1.py
+++ b/framework_tvb/tvb/tests/framework/adapters/testadapter1.py
@@ -73,10 +73,11 @@ class TestAdapter1Form(abcadapter.ABCAdapterForm):
         pass
 
 
-class TestAdapter1(abcadapter.ABCSynchronous):
+class TestAdapter1(abcadapter.ABCAdapter):
     """
         This class is used for testing purposes.
     """
+    launch_mode = abcadapter.AdapterLaunchModeEnum.SYNC_SAME_MEM
 
     def __init__(self):
         super(TestAdapter1, self).__init__()
@@ -106,7 +107,7 @@ class TestAdapter1(abcadapter.ABCSynchronous):
 
     def launch(self, view_model):
         """
-        Tests successful launch of an ABCSynchronous adapter
+        Tests successful launch of a synchronous adapter
 
         :param test1_val1: a dummy integer value
         :param test1_val2: a dummy integer value

--- a/framework_tvb/tvb/tests/framework/adapters/testadapter2.py
+++ b/framework_tvb/tvb/tests/framework/adapters/testadapter2.py
@@ -35,15 +35,18 @@ Created on Jul 21, 2011
 """
 
 from time import sleep
+
 import tvb.core.adapters.abcadapter as abcadapter
 from tvb.basic.neotraits.api import Int
+from tvb.core.adapters.abcadapter import AdapterLaunchModeEnum
 from tvb.core.neotraits.forms import IntField
 from tvb.core.neotraits.view_model import ViewModel
 from tvb.tests.framework.datatypes.dummy_datatype_index import DummyDataTypeIndex
 
-class TestModel(ViewModel):
 
+class TestModel(ViewModel):
     test = Int(default=0)
+
 
 class TestAdapter2Form(abcadapter.ABCAdapterForm):
     """
@@ -71,36 +74,38 @@ class TestAdapter2Form(abcadapter.ABCAdapterForm):
         pass
 
 
-class TestAdapter2(abcadapter.ABCAsynchronous):
+class TestAdapter2(abcadapter.ABCAdapter):
     """
         This class is used for testing purposes.
-    """    
+    """
+    launch_mode = AdapterLaunchModeEnum.ASYNC_DIFF_MEM
+
     def __init__(self):
         super(TestAdapter2, self).__init__()
 
     @staticmethod
     def get_view_model():
         return TestModel
-        
+
     def get_form_class(self):
         return TestAdapter2Form
-                
+
     def get_output(self):
         return [DummyDataTypeIndex]
-    
+
     def get_required_memory_size(self, view_model):
         """
         Return the required memory to run this algorithm.
         """
         # Don't know how much memory is needed.
-        return -1   
-    
+        return -1
+
     def get_required_disk_size(self, view_model):
         """
         Returns the required disk size to be able to run the adapter.
         """
-        return 0 
-    
+        return 0
+
     def launch(self, view_model):
         """
         Mimics launching with a long delay

--- a/framework_tvb/tvb/tests/framework/adapters/testadapter3.py
+++ b/framework_tvb/tvb/tests/framework/adapters/testadapter3.py
@@ -32,8 +32,9 @@
 .. moduleauthor:: Bogdan Neacsa <bogdan.neacsa@codemart.ro>
 """
 
-from tvb.core.adapters import abcadapter
 from tvb.basic.neotraits.api import Int
+from tvb.core.adapters import abcadapter
+from tvb.core.adapters.abcadapter import AdapterLaunchModeEnum
 from tvb.core.neotraits.forms import IntField
 from tvb.core.neotraits.view_model import ViewModel
 from tvb.tests.framework.datatypes.dummy_datatype_index import DummyDataTypeIndex
@@ -75,11 +76,12 @@ class TestAdapter3Form(abcadapter.ABCAdapterForm):
         pass
 
 
-class TestAdapter3(abcadapter.ABCAsynchronous):
+class TestAdapter3(abcadapter.ABCAdapter):
     """
     This class is used for testing purposes.
     It will be used as an adapter for testing Groups of operations. For ranges to work, it need to be asynchronous.
     """
+    launch_mode = AdapterLaunchModeEnum.ASYNC_DIFF_MEM
 
     def __init__(self):
         super(TestAdapter3, self).__init__()
@@ -144,10 +146,11 @@ class TestAdapterHugeMemoryRequiredForm(abcadapter.ABCAdapterForm):
         pass
 
 
-class TestAdapterHugeMemoryRequired(abcadapter.ABCAsynchronous):
+class TestAdapterHugeMemoryRequired(abcadapter.ABCAdapter):
     """
     Adapter used for testing launch when a lot of memory is required.
     """
+    launch_mode = AdapterLaunchModeEnum.ASYNC_DIFF_MEM
 
     def __init__(self):
         super(TestAdapterHugeMemoryRequired, self).__init__()
@@ -196,10 +199,11 @@ class TestAdapterHDDRequiredForm(abcadapter.ABCAdapterForm):
         pass
 
 
-class TestAdapterHDDRequired(abcadapter.ABCSynchronous):
+class TestAdapterHDDRequired(abcadapter.ABCAdapter):
     """
     Adapter used for testing launch when a lot of memory is required.
     """
+    launch_mode = abcadapter.AdapterLaunchModeEnum.SYNC_SAME_MEM
 
     def __init__(self):
         super(TestAdapterHDDRequired, self).__init__()

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/connectivity_measure_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/connectivity_measure_importer_test.py
@@ -67,7 +67,7 @@ class TestConnectivityMeasureImporter(TransactionalTestCase):
         view_model.data_file = path
         view_model.dataset_name = "M"
         view_model.connectivity = self.connectivity.gid
-        TestFactory.launch_importer(ConnectivityMeasureImporter, view_model, self.test_user, self.test_project.id)
+        TestFactory.launch_importer(ConnectivityMeasureImporter, view_model, self.test_user, self.test_project, False)
 
     def test_happy_flow(self):
         assert 0 == TestFactory.get_entity_count(self.test_project, ConnectivityMeasureIndex)

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/connectivity_measure_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/connectivity_measure_importer_test.py
@@ -33,31 +33,33 @@
 .. moduleauthor:: Mihai Andrei <mihai.andrei@codemart.ro>
 """
 
-import pytest
 import os.path
+
+import pytest
 import tvb_data
-from tvb.adapters.uploaders.connectivity_measure_importer import ConnectivityMeasureImporterModel
-from tvb.adapters.uploaders.connectivity_measure_importer import ConnectivityMeasureImporter
 from tvb.adapters.datatypes.db.graph import ConnectivityMeasureIndex
+from tvb.adapters.uploaders.connectivity_measure_importer import ConnectivityMeasureImporter
+from tvb.adapters.uploaders.connectivity_measure_importer import ConnectivityMeasureImporterModel
 from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.services.exceptions import OperationException
-from tvb.tests.framework.core.base_testcase import TransactionalTestCase
-from tvb.tests.framework.core.factory import TestFactory
 from tvb.tests.framework.adapters.uploaders import test_data
+from tvb.tests.framework.core.base_testcase import BaseTestCase
+from tvb.tests.framework.core.factory import TestFactory
 
 
-class TestConnectivityMeasureImporter(TransactionalTestCase):
+class TestConnectivityMeasureImporter(BaseTestCase):
     """
     Unit-tests for ConnectivityMeasureImporter
     """
 
-    def transactional_setup_method(self):
+    def setup_method(self):
         zip_path = os.path.join(os.path.dirname(tvb_data.__file__), 'connectivity', 'connectivity_66.zip')
         self.test_user = TestFactory.create_user('Test_User_CM')
         self.test_project = TestFactory.create_project(self.test_user, "Test_Project_CM")
         self.connectivity = TestFactory.import_zip_connectivity(self.test_user, self.test_project, zip_path, "John")
 
-    def transactional_teardown_method(self):
+    def teardown_method(self):
+        self.clean_database()
         FilesHelper().remove_project_structure(self.test_project.name)
 
     def _import(self, import_file_name):

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/connectivity_zip_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/connectivity_zip_importer_test.py
@@ -64,6 +64,6 @@ class TestConnectivityZipImporter(TransactionalTestCase):
         """
         zip_path = path.join(path.dirname(tvb_data.__file__), 'connectivity', 'connectivity_96.zip')
         dt_count_before = TestFactory.get_entity_count(self.test_project, ConnectivityIndex)
-        TestFactory.import_zip_connectivity(self.test_user, self.test_project, zip_path, "John")
+        TestFactory.import_zip_connectivity(self.test_user, self.test_project, zip_path, "John", False)
         dt_count_after = TestFactory.get_entity_count(self.test_project, ConnectivityIndex)
         assert dt_count_before + 1 == dt_count_after

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/connectivity_zip_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/connectivity_zip_importer_test.py
@@ -33,29 +33,31 @@
 
 """
 from os import path
+
 import tvb_data
 from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
 from tvb.core.entities.file.files_helper import FilesHelper
-from tvb.tests.framework.core.base_testcase import TransactionalTestCase
+from tvb.tests.framework.core.base_testcase import BaseTestCase
 from tvb.tests.framework.core.factory import TestFactory
 
 
-class TestConnectivityZipImporter(TransactionalTestCase):
+class TestConnectivityZipImporter(BaseTestCase):
     """
     Unit-tests for CFF-importer.
     """
 
-    def transactional_setup_method(self):
+    def setup_method(self):
         """
         Reset the database before each test.
         """
         self.test_user = TestFactory.create_user('CFF_User')
         self.test_project = TestFactory.create_project(self.test_user, "CFF_Project")
 
-    def transactional_teardown_method(self):
+    def teardown_method(self):
         """
         Clean-up tests data
         """
+        self.clean_database()
         FilesHelper().remove_project_structure(self.test_project.name)
 
     def test_happy_flow_import(self):

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/csv_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/csv_importer_test.py
@@ -95,7 +95,7 @@ class TestCSVConnectivityImporter(TransactionalTestCase):
         view_model.tracts = tracts_tmp
         view_model.data_subject = subject
         view_model.input_data = reference_connectivity_gid
-        TestFactory.launch_importer(CSVConnectivityImporter, view_model, self.test_user, self.test_project.id)
+        TestFactory.launch_importer(CSVConnectivityImporter, view_model, self.test_user, self.test_project, False)
 
     def test_happy_flow_import(self):
         """

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/csv_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/csv_importer_test.py
@@ -32,17 +32,18 @@
 .. moduleauthor:: Mihai Andrei <mihai.andrei@codemart.ro>
 """
 
+from os import path
+
 import pytest
 import tvb_data
-from os import path
 from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
-from tvb.adapters.uploaders.csv_connectivity_importer import CSVConnectivityParser, CSVConnectivityImporterModel
 from tvb.adapters.uploaders.csv_connectivity_importer import CSVConnectivityImporter
+from tvb.adapters.uploaders.csv_connectivity_importer import CSVConnectivityParser, CSVConnectivityImporterModel
+from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.entities.filters.chain import FilterChain
 from tvb.core.neocom import h5
-from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.services.exceptions import OperationException
-from tvb.tests.framework.core.base_testcase import TransactionalTestCase, BaseTestCase
+from tvb.tests.framework.core.base_testcase import BaseTestCase
 from tvb.tests.framework.core.factory import TestFactory
 
 TEST_SUBJECT_A = "TEST_SUBJECT_A"
@@ -62,20 +63,21 @@ class TestCSVConnectivityParser(BaseTestCase):
                 assert 0 == result_conn[i][i]
 
 
-class TestCSVConnectivityImporter(TransactionalTestCase):
+class TestCSVConnectivityImporter(BaseTestCase):
     """
     Unit-tests for csv connectivity importer.
     """
 
-    def transactional_setup_method(self):
+    def setup_method(self):
         self.test_user = TestFactory.create_user()
         self.test_project = TestFactory.create_project(self.test_user)
         self.helper = FilesHelper()
 
-    def transactional_teardown_method(self):
+    def teardown_method(self):
         """
         Clean-up tests data
         """
+        self.clean_database()
         FilesHelper().remove_project_structure(self.test_project.name)
 
     def _import_csv_test_connectivity(self, reference_connectivity_gid, subject):

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/gifti_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/gifti_importer_test.py
@@ -33,15 +33,16 @@
 """
 
 import os
-from tvb.tests.framework.core.base_testcase import TransactionalTestCase
-from tvb.core.entities.file.files_helper import FilesHelper
-from tvb.tests.framework.core.factory import TestFactory
-from tvb.core.services.exceptions import OperationException
-from tvb.adapters.uploaders.gifti.parser import GIFTIParser
+
 import tvb_data.gifti as demo_data
+from tvb.adapters.uploaders.gifti.parser import GIFTIParser
+from tvb.core.entities.file.files_helper import FilesHelper
+from tvb.core.services.exceptions import OperationException
+from tvb.tests.framework.core.base_testcase import BaseTestCase
+from tvb.tests.framework.core.factory import TestFactory
 
 
-class TestGIFTISurfaceImporter(TransactionalTestCase):
+class TestGIFTISurfaceImporter(BaseTestCase):
     """
     Unit-tests for GIFTI Surface importer.
     """
@@ -50,14 +51,15 @@ class TestGIFTISurfaceImporter(TransactionalTestCase):
     GIFTI_TIME_SERIES_FILE = os.path.join(os.path.dirname(demo_data.__file__), 'sample.time_series.gii')
     WRONG_GII_FILE = os.path.abspath(__file__)
 
-    def transactional_setup_method(self):
+    def setup_method(self):
         self.test_user = TestFactory.create_user('Gifti_User')
         self.test_project = TestFactory.create_project(self.test_user, "Gifti_Project")
 
-    def transactional_teardown_method(self):
+    def teardown_method(self):
         """
         Clean-up tests data
         """
+        self.clean_database()
         FilesHelper().remove_project_structure(self.test_project.name)
 
     def test_import_surface_gifti_data(self, operation_factory):
@@ -104,4 +106,3 @@ class TestGIFTISurfaceImporter(TransactionalTestCase):
         except OperationException:
             # Expected exception
             pass
-

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/mat_timeseries_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/mat_timeseries_importer_test.py
@@ -64,7 +64,7 @@ class TestMatTimeSeriesImporter(TransactionalTestCase):
         view_model.data_subject = "QL"
         view_model.datatype = self.connectivity.gid
 
-        TestFactory.launch_importer(RegionTimeSeriesImporter, view_model, self.test_user, self.test_project.id)
+        TestFactory.launch_importer(RegionTimeSeriesImporter, view_model, self.test_user, self.test_project, False)
 
         tsr = TestFactory.get_entity(self.test_project, TimeSeriesRegionIndex)
         assert (661, 1, 68, 1) == (tsr.data_length_1d, tsr.data_length_2d, tsr.data_length_3d, tsr.data_length_4d)

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/mat_timeseries_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/mat_timeseries_importer_test.py
@@ -35,26 +35,28 @@ Unit-test for mat_timeseries_importer and mat_parser.
 """
 
 import os
+
 import tvb_data
 from tvb.adapters.datatypes.db.time_series import TimeSeriesRegionIndex
 from tvb.adapters.uploaders.mat_timeseries_importer import RegionMatTimeSeriesImporterModel, RegionTimeSeriesImporter
 from tvb.core.entities.file.files_helper import FilesHelper
+from tvb.tests.framework.core.base_testcase import BaseTestCase
 from tvb.tests.framework.core.factory import TestFactory
-from tvb.tests.framework.core.base_testcase import TransactionalTestCase
 
 
-class TestMatTimeSeriesImporter(TransactionalTestCase):
+class TestMatTimeSeriesImporter(BaseTestCase):
     base_pth = os.path.join(os.path.dirname(tvb_data.__file__), 'berlinSubjects', 'QL_20120814')
     bold_path = os.path.join(base_pth, 'QL_BOLD_regiontimecourse.mat')
     connectivity_path = os.path.join(base_pth, 'QL_20120814_Connectivity.zip')
 
-    def transactional_setup_method(self):
+    def setup_method(self):
         self.test_user = TestFactory.create_user('Mat_Timeseries_User')
         self.test_project = TestFactory.create_project(self.test_user, "Mat_Timeseries_Project")
         self.connectivity = TestFactory.import_zip_connectivity(self.test_user, self.test_project,
                                                                 self.connectivity_path)
 
-    def transactional_teardown_method(self):
+    def teardown_method(self):
+        self.clean_database()
         FilesHelper().remove_project_structure(self.test_project.name)
 
     def test_import_bold(self):

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/networkx_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/networkx_importer_test.py
@@ -61,7 +61,7 @@ class TestNetworkxImporter(TransactionalTestCase):
 
         view_model = NetworkxImporterModel()
         view_model.data_file = self.upload_file
-        TestFactory.launch_importer(NetworkxConnectivityImporter, view_model, self.test_user, self.test_project.id)
+        TestFactory.launch_importer(NetworkxConnectivityImporter, view_model, self.test_user, self.test_project, False)
 
         count_after = self.count_all_entities(ConnectivityIndex)
         assert 1 == count_after

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/networkx_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/networkx_importer_test.py
@@ -34,25 +34,27 @@
 """
 
 import os
-from tvb.adapters.uploaders.networkx_importer import NetworkxImporterModel, NetworkxConnectivityImporter
+
 from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
+from tvb.adapters.uploaders.networkx_importer import NetworkxImporterModel, NetworkxConnectivityImporter
 from tvb.core.entities.file.files_helper import FilesHelper
-from tvb.tests.framework.core.base_testcase import TransactionalTestCase
+from tvb.tests.framework.core.base_testcase import BaseTestCase
 from tvb.tests.framework.core.factory import TestFactory
 
 
-class TestNetworkxImporter(TransactionalTestCase):
+class TestNetworkxImporter(BaseTestCase):
     """
     Unit-tests for NetworkxImporter
     """
 
     upload_file = os.path.join(os.path.dirname(__file__), "test_data", 'connectome_83.gpickle')
 
-    def transactional_setup_method(self):
+    def setup_method(self):
         self.test_user = TestFactory.create_user('Networkx_User')
         self.test_project = TestFactory.create_project(self.test_user, "Networkx_Project")
 
-    def transactional_teardown_method(self):
+    def teardown_method(self):
+        self.clean_database()
         FilesHelper().remove_project_structure(self.test_project.name)
 
     def test_import(self):

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/nifti_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/nifti_importer_test.py
@@ -86,7 +86,7 @@ class TestNIFTIImporter(TransactionalTestCase):
         view_model.connectivity = connectivity_gid
         view_model.data_subject = "Bla Bla"
 
-        TestFactory.launch_importer(NIFTIImporter, view_model, self.test_user, self.test_project.id)
+        TestFactory.launch_importer(NIFTIImporter, view_model, self.test_user, self.test_project, False)
 
         dts, count = dao.get_values_of_datatype(self.test_project.id, expected_result_class, None)
         assert 1, count == "Project should contain only one data type."

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/nifti_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/nifti_importer_test.py
@@ -33,24 +33,25 @@
 """
 import json
 import os
+
 import numpy
-import tvb_data.nifti as demo_data
 import tvb_data
-from tvb.adapters.uploaders.nifti_importer import NIFTIImporterModel, NIFTIImporter
+import tvb_data.nifti as demo_data
 from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
 from tvb.adapters.datatypes.db.region_mapping import RegionVolumeMappingIndex
 from tvb.adapters.datatypes.db.structural import StructuralMRIIndex
 from tvb.adapters.datatypes.db.time_series import TimeSeriesVolumeIndex
-from tvb.core.neocom import h5
+from tvb.adapters.uploaders.nifti_importer import NIFTIImporterModel, NIFTIImporter
+from tvb.core.adapters.abcadapter import ABCAdapter
 from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.entities.storage import dao
+from tvb.core.neocom import h5
 from tvb.core.services.exceptions import OperationException
-from tvb.core.adapters.abcadapter import ABCAdapter
-from tvb.tests.framework.core.base_testcase import TransactionalTestCase
+from tvb.tests.framework.core.base_testcase import BaseTestCase
 from tvb.tests.framework.core.factory import TestFactory
 
 
-class TestNIFTIImporter(TransactionalTestCase):
+class TestNIFTIImporter(BaseTestCase):
     """
     Unit-tests for NIFTI importer.
     """
@@ -64,14 +65,15 @@ class TestNIFTIImporter(TransactionalTestCase):
     DEFAULT_ORIGIN = [[0.0, 0.0, 0.0]]
     UNKNOWN_STR = "unknown"
 
-    def transactional_setup_method(self):
+    def setup_method(self):
         self.test_user = TestFactory.create_user('Nifti_Importer_User')
         self.test_project = TestFactory.create_project(self.test_user, "Nifti_Importer_Project")
 
-    def transactional_teardown_method(self):
+    def teardown_method(self):
         """
         Clean-up tests data
         """
+        self.clean_database()
         FilesHelper().remove_project_structure(self.test_project.name)
 
     def _import(self, import_file_path=None, expected_result_class=StructuralMRIIndex, connectivity_gid=None):

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/obj_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/obj_importer_test.py
@@ -60,7 +60,7 @@ class TestObjSurfaceImporter(TransactionalTestCase):
         """
         Test that import works with a file which contains quads and no normals
         """
-        surface_index = TestFactory.import_surface_obj(self.test_user, self.test_project, self.face, FACE)
+        surface_index = TestFactory.import_surface_obj(self.test_user, self.test_project, self.face, FACE, False)
 
         surface = h5.load_from_index(surface_index)
         assert 8614 == len(surface.vertex_normals)
@@ -71,7 +71,7 @@ class TestObjSurfaceImporter(TransactionalTestCase):
         """
         Test that import works with an OBJ file which includes normals
         """
-        surface_index = TestFactory.import_surface_obj(self.test_user, self.test_project, self.torus, FACE)
+        surface_index = TestFactory.import_surface_obj(self.test_user, self.test_project, self.torus, FACE, False)
         assert 441 == surface_index.number_of_vertices
         assert 800 == surface_index.number_of_triangles
 

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/obj_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/obj_importer_test.py
@@ -33,15 +33,16 @@
 """
 
 import os
-from tvb.core.neocom import h5
-from tvb.core.entities.file.files_helper import FilesHelper
-from tvb.datatypes.surfaces import FACE
-from tvb.tests.framework.core.base_testcase import TransactionalTestCase
-from tvb.tests.framework.core.factory import TestFactory
+
 import tvb_data.obj
+from tvb.core.entities.file.files_helper import FilesHelper
+from tvb.core.neocom import h5
+from tvb.datatypes.surfaces import FACE
+from tvb.tests.framework.core.base_testcase import BaseTestCase
+from tvb.tests.framework.core.factory import TestFactory
 
 
-class TestObjSurfaceImporter(TransactionalTestCase):
+class TestObjSurfaceImporter(BaseTestCase):
     """
     Unit-tests for Obj Surface importer.
     """
@@ -49,11 +50,12 @@ class TestObjSurfaceImporter(TransactionalTestCase):
     torus = os.path.join(os.path.dirname(tvb_data.obj.__file__), 'test_torus.obj')
     face = os.path.join(os.path.dirname(tvb_data.obj.__file__), 'face_surface.obj')
 
-    def transactional_setup_method(self):
+    def setup_method(self):
         self.test_user = TestFactory.create_user('Obj_Importer_User')
         self.test_project = TestFactory.create_project(self.test_user, "Obj_Importer_Project")
 
-    def transactional_teardown_method(self):
+    def teardown_method(self):
+        self.clean_database()
         FilesHelper().remove_project_structure(self.test_project.name)
 
     def test_import_quads_no_normals(self):

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/projection_matrix_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/projection_matrix_importer_test.py
@@ -80,7 +80,7 @@ class TestProjectionMatrix(TransactionalTestCase):
 
         try:
             TestFactory.import_projection_matrix(self.test_user, self.test_project, file_path, self.sensors.gid,
-                                                 self.surface.gid)
+                                                 self.surface.gid, False)
             raise AssertionError("This was expected not to run! 62 rows in proj matrix, but 65 sensors")
         except OperationException:
             pass
@@ -94,7 +94,7 @@ class TestProjectionMatrix(TransactionalTestCase):
                                  'projection_eeg_65_surface_16k.npy')
 
         TestFactory.import_projection_matrix(self.test_user, self.test_project, file_path, self.sensors.gid,
-                                             self.surface.gid)
+                                             self.surface.gid, False)
 
         dt_count_after = TestFactory.get_entity_count(self.test_project, ProjectionMatrixIndex)
         assert dt_count_before + 1 == dt_count_after

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/projection_matrix_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/projection_matrix_importer_test.py
@@ -34,24 +34,25 @@
 """
 
 import os
+
+import tvb_data.projectionMatrix as dataset
 import tvb_data.sensors
 import tvb_data.surfaceData
-import tvb_data.projectionMatrix as dataset
 from tvb.adapters.datatypes.db.projections import ProjectionMatrixIndex
 from tvb.adapters.uploaders.sensors_importer import SensorsImporterModel
-from tvb.core.services.exceptions import OperationException
 from tvb.core.entities.file.files_helper import FilesHelper
+from tvb.core.services.exceptions import OperationException
 from tvb.datatypes.surfaces import CORTICAL
-from tvb.tests.framework.core.base_testcase import TransactionalTestCase
+from tvb.tests.framework.core.base_testcase import BaseTestCase
 from tvb.tests.framework.core.factory import TestFactory
 
 
-class TestProjectionMatrix(TransactionalTestCase):
+class TestProjectionMatrix(BaseTestCase):
     """
     Unit-tests for CFF-importer.
     """
 
-    def transactional_setup_method(self):
+    def setup_method(self):
         """
         Reset the database before each test.
         """
@@ -65,10 +66,11 @@ class TestProjectionMatrix(TransactionalTestCase):
         zip_path = os.path.join(os.path.dirname(tvb_data.surfaceData.__file__), 'cortex_16384.zip')
         self.surface = TestFactory.import_surface_zip(self.test_user, self.test_project, zip_path, CORTICAL, True)
 
-    def transactional_teardown_method(self):
+    def teardown_method(self):
         """
         Clean-up tests data
         """
+        self.clean_database()
         FilesHelper().remove_project_structure(self.test_project.name)
 
     def test_wrong_shape(self):

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/region_mapping_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/region_mapping_importer_test.py
@@ -94,14 +94,14 @@ class TestRegionMappingImporter(TransactionalTestCase):
         This method tests import of region mapping without providing a surface or connectivity
         """
         try:
-            TestFactory.import_region_mapping(self.test_user, self. test_project, self.TXT_FILE, None, self.connectivity.gid)
+            TestFactory.import_region_mapping(self.test_user, self. test_project, self.TXT_FILE, None, self.connectivity.gid, False)
             raise AssertionError("Import should fail in case Surface is missing")
         except TraitValueError:
             # Expected error
             pass
 
         try:
-            TestFactory.import_region_mapping(self.test_user, self.test_project, self.TXT_FILE, self.surface.gid, None)
+            TestFactory.import_region_mapping(self.test_user, self.test_project, self.TXT_FILE, self.surface.gid, None, False)
             raise AssertionError("Import should fail in case Connectivity is missing")
         except TraitValueError:
             # Expected error
@@ -129,7 +129,7 @@ class TestRegionMappingImporter(TransactionalTestCase):
         """
         This method tests import of region mapping from TXT file
         """
-        region_mapping_index = TestFactory.import_region_mapping(self.test_user, self.test_project, import_file, self.surface.gid, self.connectivity.gid)
+        region_mapping_index = TestFactory.import_region_mapping(self.test_user, self.test_project, import_file, self.surface.gid, self.connectivity.gid, False)
 
         surface_index = ABCAdapter.load_entity_by_gid(region_mapping_index.fk_surface_gid)
         assert surface_index is not None
@@ -151,21 +151,21 @@ class TestRegionMappingImporter(TransactionalTestCase):
             - negative region number
         """
         try:
-            TestFactory.import_region_mapping(self.test_user, self.test_project, self.WRONG_FILE_1, self.surface.gid, self.connectivity.gid)
+            TestFactory.import_region_mapping(self.test_user, self.test_project, self.WRONG_FILE_1, self.surface.gid, self.connectivity.gid, False)
             raise AssertionError("Import should fail in case of invalid region number")
         except OperationException:
             # Expected exception
             pass
 
         try:
-            TestFactory.import_region_mapping(self.test_user, self.test_project, self.WRONG_FILE_2, self.surface.gid, self.connectivity.gid)
+            TestFactory.import_region_mapping(self.test_user, self.test_project, self.WRONG_FILE_2, self.surface.gid, self.connectivity.gid, False)
             raise AssertionError("Import should fail in case of invalid regions number")
         except OperationException:
             # Expected exception
             pass
 
         try:
-            TestFactory.import_region_mapping(self.test_user, self.test_project, self.WRONG_FILE_3, self.surface.gid, self.connectivity.gid)
+            TestFactory.import_region_mapping(self.test_user, self.test_project, self.WRONG_FILE_3, self.surface.gid, self.connectivity.gid, False)
             raise AssertionError("Import should fail in case of invalid region number (negative number)")
         except OperationException:
             # Expected exception

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/region_mapping_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/region_mapping_importer_test.py
@@ -32,25 +32,25 @@
 .. moduleauthor:: Calin Pavel <calin.pavel@codemart.ro>
 """
 
-import tvb_data.surfaceData
 import os
 
-from tvb.basic.neotraits.ex import TraitValueError
-from tvb.datatypes.surfaces import CORTICAL
-from tvb.core.entities.filters.chain import FilterChain
+import tvb.tests.framework.adapters.uploaders.test_data as test_data
+import tvb_data.regionMapping as demo_data
+import tvb_data.surfaceData
 from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
 from tvb.adapters.datatypes.db.surface import SurfaceIndex
-from tvb.core.neocom import h5
-from tvb.tests.framework.core.base_testcase import TransactionalTestCase
-import tvb_data.regionMapping as demo_data
-import tvb.tests.framework.adapters.uploaders.test_data as test_data
-from tvb.tests.framework.core.factory import TestFactory
-from tvb.core.entities.file.files_helper import FilesHelper
-from tvb.core.services.exceptions import OperationException
+from tvb.basic.neotraits.ex import TraitValueError
 from tvb.core.adapters.abcadapter import ABCAdapter
+from tvb.core.entities.file.files_helper import FilesHelper
+from tvb.core.entities.filters.chain import FilterChain
+from tvb.core.neocom import h5
+from tvb.core.services.exceptions import OperationException
+from tvb.datatypes.surfaces import CORTICAL
+from tvb.tests.framework.core.base_testcase import BaseTestCase
+from tvb.tests.framework.core.factory import TestFactory
 
 
-class TestRegionMappingImporter(TransactionalTestCase):
+class TestRegionMappingImporter(BaseTestCase):
     """
     Unit-tests for RegionMapping importer.
     """
@@ -64,7 +64,7 @@ class TestRegionMappingImporter(TransactionalTestCase):
     WRONG_FILE_2 = os.path.join(os.path.dirname(test_data.__file__), 'region_mapping_wrong_2.txt')
     WRONG_FILE_3 = os.path.join(os.path.dirname(test_data.__file__), 'region_mapping_wrong_3.txt')
 
-    def transactional_setup_method(self):
+    def setup_method(self):
         """
         Sets up the environment for running the tests;
         creates a test user, a test project, a connectivity and a surface;
@@ -83,10 +83,11 @@ class TestRegionMappingImporter(TransactionalTestCase):
         TestFactory.import_surface_zip(self.test_user, self.test_project, cortex, CORTICAL)
         self.surface = TestFactory.get_entity(self.test_project, SurfaceIndex, filters)
 
-    def transactional_teardown_method(self):
+    def teardown_method(self):
         """
         Clean-up tests data
         """
+        self.clean_database()
         FilesHelper().remove_project_structure(self.test_project.name)
 
     def test_import_no_surface_or_connectivity(self):
@@ -94,14 +95,16 @@ class TestRegionMappingImporter(TransactionalTestCase):
         This method tests import of region mapping without providing a surface or connectivity
         """
         try:
-            TestFactory.import_region_mapping(self.test_user, self. test_project, self.TXT_FILE, None, self.connectivity.gid, False)
+            TestFactory.import_region_mapping(self.test_user, self.test_project, self.TXT_FILE, None,
+                                              self.connectivity.gid, False)
             raise AssertionError("Import should fail in case Surface is missing")
         except TraitValueError:
             # Expected error
             pass
 
         try:
-            TestFactory.import_region_mapping(self.test_user, self.test_project, self.TXT_FILE, self.surface.gid, None, False)
+            TestFactory.import_region_mapping(self.test_user, self.test_project, self.TXT_FILE, self.surface.gid, None,
+                                              False)
             raise AssertionError("Import should fail in case Connectivity is missing")
         except TraitValueError:
             # Expected error
@@ -129,7 +132,8 @@ class TestRegionMappingImporter(TransactionalTestCase):
         """
         This method tests import of region mapping from TXT file
         """
-        region_mapping_index = TestFactory.import_region_mapping(self.test_user, self.test_project, import_file, self.surface.gid, self.connectivity.gid, False)
+        region_mapping_index = TestFactory.import_region_mapping(self.test_user, self.test_project, import_file,
+                                                                 self.surface.gid, self.connectivity.gid, False)
 
         surface_index = ABCAdapter.load_entity_by_gid(region_mapping_index.fk_surface_gid)
         assert surface_index is not None
@@ -151,23 +155,25 @@ class TestRegionMappingImporter(TransactionalTestCase):
             - negative region number
         """
         try:
-            TestFactory.import_region_mapping(self.test_user, self.test_project, self.WRONG_FILE_1, self.surface.gid, self.connectivity.gid, False)
+            TestFactory.import_region_mapping(self.test_user, self.test_project, self.WRONG_FILE_1, self.surface.gid,
+                                              self.connectivity.gid, False)
             raise AssertionError("Import should fail in case of invalid region number")
         except OperationException:
             # Expected exception
             pass
 
         try:
-            TestFactory.import_region_mapping(self.test_user, self.test_project, self.WRONG_FILE_2, self.surface.gid, self.connectivity.gid, False)
+            TestFactory.import_region_mapping(self.test_user, self.test_project, self.WRONG_FILE_2, self.surface.gid,
+                                              self.connectivity.gid, False)
             raise AssertionError("Import should fail in case of invalid regions number")
         except OperationException:
             # Expected exception
             pass
 
         try:
-            TestFactory.import_region_mapping(self.test_user, self.test_project, self.WRONG_FILE_3, self.surface.gid, self.connectivity.gid, False)
+            TestFactory.import_region_mapping(self.test_user, self.test_project, self.WRONG_FILE_3, self.surface.gid,
+                                              self.connectivity.gid, False)
             raise AssertionError("Import should fail in case of invalid region number (negative number)")
         except OperationException:
             # Expected exception
             pass
-

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/sensors_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/sensors_importer_test.py
@@ -69,7 +69,7 @@ class TestSensorsImporter(TransactionalTestCase):
         This method tests import of a file containing EEG sensors.
         """
         eeg_sensors_index = TestFactory.import_sensors(self.test_user, self.test_project, self.EEG_FILE,
-                                                       SensorsImporterModel.OPTIONS['EEG Sensors'])
+                                                       SensorsImporterModel.OPTIONS['EEG Sensors'], False)
 
         expected_size = 62
         assert expected_size == eeg_sensors_index.number_of_sensors
@@ -85,7 +85,7 @@ class TestSensorsImporter(TransactionalTestCase):
         This method tests import of a file containing MEG sensors.
         """
         meg_sensors_index = TestFactory.import_sensors(self.test_user, self.test_project, self.MEG_FILE,
-                                                       SensorsImporterModel.OPTIONS['MEG Sensors'])
+                                                       SensorsImporterModel.OPTIONS['MEG Sensors'], False)
 
         expected_size = 151
         assert expected_size == meg_sensors_index.number_of_sensors
@@ -105,7 +105,7 @@ class TestSensorsImporter(TransactionalTestCase):
         """
         try:
             TestFactory.import_sensors(self.test_user, self.test_project, self.EEG_FILE,
-                                       SensorsImporterModel.OPTIONS['MEG Sensors'])
+                                       SensorsImporterModel.OPTIONS['MEG Sensors'], False)
             raise AssertionError("Import should fail in case of a MEG import without orientation.")
         except OperationException:
             # Expected exception
@@ -116,7 +116,7 @@ class TestSensorsImporter(TransactionalTestCase):
         This method tests import of a file containing internal sensors.
         """
         internal_sensors_index = TestFactory.import_sensors(self.test_user, self.test_project, self.EEG_FILE,
-                                                            SensorsImporterModel.OPTIONS['Internal Sensors'])
+                                                            SensorsImporterModel.OPTIONS['Internal Sensors'], False)
 
         expected_size = 62
         assert expected_size == internal_sensors_index.number_of_sensors

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/sensors_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/sensors_importer_test.py
@@ -33,23 +33,24 @@
 """
 
 import os
-from tvb.core.neocom import h5
-from tvb.tests.framework.core.base_testcase import TransactionalTestCase
-from tvb.core.entities.file.files_helper import FilesHelper
-from tvb.core.services.exceptions import OperationException
-from tvb.adapters.uploaders.sensors_importer import SensorsImporter, SensorsImporterModel
-from tvb.tests.framework.core.factory import TestFactory
+
 import tvb_data.sensors as demo_data
+from tvb.adapters.uploaders.sensors_importer import SensorsImporter, SensorsImporterModel
+from tvb.core.entities.file.files_helper import FilesHelper
+from tvb.core.neocom import h5
+from tvb.core.services.exceptions import OperationException
+from tvb.tests.framework.core.base_testcase import BaseTestCase
+from tvb.tests.framework.core.factory import TestFactory
 
 
-class TestSensorsImporter(TransactionalTestCase):
+class TestSensorsImporter(BaseTestCase):
     """
     Unit-tests for Sensors importer.
     """
     EEG_FILE = os.path.join(os.path.dirname(demo_data.__file__), 'eeg_unitvector_62.txt.bz2')
     MEG_FILE = os.path.join(os.path.dirname(demo_data.__file__), 'meg_151.txt.bz2')
 
-    def transactional_setup_method(self):
+    def setup_method(self):
         """
         Sets up the environment for running the tests;
         creates a test user, a test project and a `Sensors_Importer`
@@ -58,10 +59,11 @@ class TestSensorsImporter(TransactionalTestCase):
         self.test_project = TestFactory.create_project(self.test_user, "Sensors_Project")
         self.importer = SensorsImporter()
 
-    def transactional_teardown_method(self):
+    def teardown_method(self):
         """
         Clean-up tests data
         """
+        self.clean_database()
         FilesHelper().remove_project_structure(self.test_project.name)
 
     def test_import_eeg_sensors(self):
@@ -126,5 +128,3 @@ class TestSensorsImporter(TransactionalTestCase):
         assert expected_size == len(internal_sensors.labels)
         assert expected_size == len(internal_sensors.locations)
         assert (expected_size, 3) == internal_sensors.locations.shape
-
-

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/tvb_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/tvb_importer_test.py
@@ -36,19 +36,20 @@
 
 import os
 import shutil
+
 import pytest
-from tvb.adapters.uploaders.tvb_importer import TVBImporterModel, TVBImporter
 from tvb.adapters.exporters.export_manager import ExportManager
+from tvb.adapters.uploaders.tvb_importer import TVBImporterModel, TVBImporter
 from tvb.basic.profile import TvbProfile
-from tvb.core.entities.load import get_filtered_datatypes
-from tvb.core.entities.file.files_helper import FilesHelper
-from tvb.core.services.exceptions import OperationException
 from tvb.core.adapters.abcadapter import ABCAdapter
+from tvb.core.entities.file.files_helper import FilesHelper
+from tvb.core.entities.load import get_filtered_datatypes
+from tvb.core.services.exceptions import OperationException
+from tvb.tests.framework.core.base_testcase import BaseTestCase
 from tvb.tests.framework.core.factory import TestFactory
-from tvb.tests.framework.core.base_testcase import TransactionalTestCase
 
 
-class TestTVBImporter(TransactionalTestCase):
+class TestTVBImporter(BaseTestCase):
     """
     Unit-tests for TVB importer.
     """
@@ -89,10 +90,11 @@ class TestTVBImporter(TransactionalTestCase):
         self.test_user = user_factory()
         self.test_project = project_factory(self.test_user)
 
-    def transactional_teardown_method(self):
+    def teardown_method(self):
         """
         Clean-up tests data
         """
+        self.clean_database()
         FilesHelper().remove_project_structure(self.test_project.name)
 
     def _import(self, import_file_path=None):

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/tvb_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/tvb_importer_test.py
@@ -99,7 +99,7 @@ class TestTVBImporter(TransactionalTestCase):
 
         view_model = TVBImporterModel()
         view_model.data_file = import_file_path
-        TestFactory.launch_importer(TVBImporter, view_model, self.test_user, self.test_project.id)
+        TestFactory.launch_importer(TVBImporter, view_model, self.test_user, self.test_project, False)
 
     def test_zip_import(self, prepare_importer_data):
         """

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/zip_surface_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/zip_surface_importer_test.py
@@ -57,7 +57,8 @@ class TestZIPSurfaceImporter(BaseTestCase):
         FilesHelper().remove_project_structure(self.test_project.name)
 
     def test_import_surf_zip(self):
-        surface = TestFactory.import_surface_zip(self.test_user, self.test_project, self.surf_skull, CORTICAL, sync=False)
+        surface = TestFactory.import_surface_zip(self.test_user, self.test_project, self.surf_skull, CORTICAL,
+                                                 same_process=False)
         assert 4096 == surface.number_of_vertices
         assert 8188 == surface.number_of_triangles
         assert surface.valid_for_simulations

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/zip_surface_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/zip_surface_importer_test.py
@@ -55,7 +55,7 @@ class TestZIPSurfaceImporter(TransactionalTestCase):
         FilesHelper().remove_project_structure(self.test_project.name)
 
     def test_import_surf_zip(self):
-        surface = TestFactory.import_surface_zip(self.test_user, self.test_project, self.surf_skull, CORTICAL)
+        surface = TestFactory.import_surface_zip(self.test_user, self.test_project, self.surf_skull, CORTICAL, False)
         assert 4096 == surface.number_of_vertices
         assert 8188 == surface.number_of_triangles
         assert surface.valid_for_simulations

--- a/framework_tvb/tvb/tests/framework/adapters/uploaders/zip_surface_importer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/uploaders/zip_surface_importer_test.py
@@ -33,30 +33,31 @@
 """
 
 import os
-from tvb.tests.framework.core.base_testcase import TransactionalTestCase
-from tvb.tests.framework.core.factory import TestFactory
+
+import tvb_data.surfaceData
 from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.datatypes.surfaces import CORTICAL
-import tvb_data.surfaceData
+from tvb.tests.framework.core.base_testcase import BaseTestCase
+from tvb.tests.framework.core.factory import TestFactory
 
 
-class TestZIPSurfaceImporter(TransactionalTestCase):
+class TestZIPSurfaceImporter(BaseTestCase):
     """
     Unit-tests for Zip Surface importer.
     """
 
     surf_skull = os.path.join(os.path.dirname(tvb_data.surfaceData.__file__), 'outer_skull_4096.zip')
 
-    def transactional_setup_method(self):
+    def setup_method(self):
         self.test_user = TestFactory.create_user('Zip_Surface_User')
         self.test_project = TestFactory.create_project(self.test_user, 'Zip_Surface_Project')
 
-    def transactional_teardown_method(self):
+    def teardown_method(self):
+        self.clean_database()
         FilesHelper().remove_project_structure(self.test_project.name)
 
     def test_import_surf_zip(self):
-        surface = TestFactory.import_surface_zip(self.test_user, self.test_project, self.surf_skull, CORTICAL, False)
+        surface = TestFactory.import_surface_zip(self.test_user, self.test_project, self.surf_skull, CORTICAL, sync=False)
         assert 4096 == surface.number_of_vertices
         assert 8188 == surface.number_of_triangles
         assert surface.valid_for_simulations
-

--- a/framework_tvb/tvb/tests/framework/adapters/visualizers/sensorsviewer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/visualizers/sensorsviewer_test.py
@@ -84,7 +84,7 @@ class TestSensorViewers(TransactionalTestCase):
         # Import Sensors
         zip_path = os.path.join(os.path.dirname(tvb_data.sensors.__file__), 'eeg_unitvector_62.txt.bz2')
         TestFactory.import_sensors(self.test_user, self.test_project, zip_path,
-                                   SensorsImporterModel.OPTIONS['EEG Sensors'], False)
+                                   SensorsImporterModel.OPTIONS['EEG Sensors'])
         field = FilterChain.datatype + '.sensors_type'
         filters = FilterChain('', [field], [SensorTypes.TYPE_EEG.value], ['=='])
         sensors_index = TestFactory.get_entity(self.test_project, SensorsIndex, filters)
@@ -119,7 +119,7 @@ class TestSensorViewers(TransactionalTestCase):
 
         zip_path = os.path.join(os.path.dirname(tvb_data.sensors.__file__), 'meg_151.txt.bz2')
         TestFactory.import_sensors(self.test_user, self.test_project, zip_path,
-                                   SensorsImporterModel.OPTIONS['MEG Sensors'], False)
+                                   SensorsImporterModel.OPTIONS['MEG Sensors'])
 
         field = FilterChain.datatype + '.sensors_type'
         filters = FilterChain('', [field], [SensorTypes.TYPE_MEG.value], ['=='])

--- a/framework_tvb/tvb/tests/framework/adapters/visualizers/sensorsviewer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/visualizers/sensorsviewer_test.py
@@ -84,7 +84,7 @@ class TestSensorViewers(TransactionalTestCase):
         # Import Sensors
         zip_path = os.path.join(os.path.dirname(tvb_data.sensors.__file__), 'eeg_unitvector_62.txt.bz2')
         TestFactory.import_sensors(self.test_user, self.test_project, zip_path,
-                                   SensorsImporterModel.OPTIONS['EEG Sensors'])
+                                   SensorsImporterModel.OPTIONS['EEG Sensors'], False)
         field = FilterChain.datatype + '.sensors_type'
         filters = FilterChain('', [field], [SensorTypes.TYPE_EEG.value], ['=='])
         sensors_index = TestFactory.get_entity(self.test_project, SensorsIndex, filters)
@@ -119,7 +119,7 @@ class TestSensorViewers(TransactionalTestCase):
 
         zip_path = os.path.join(os.path.dirname(tvb_data.sensors.__file__), 'meg_151.txt.bz2')
         TestFactory.import_sensors(self.test_user, self.test_project, zip_path,
-                                   SensorsImporterModel.OPTIONS['MEG Sensors'])
+                                   SensorsImporterModel.OPTIONS['MEG Sensors'], False)
 
         field = FilterChain.datatype + '.sensors_type'
         filters = FilterChain('', [field], [SensorTypes.TYPE_MEG.value], ['=='])

--- a/framework_tvb/tvb/tests/framework/core/factory.py
+++ b/framework_tvb/tvb/tests/framework/core/factory.py
@@ -41,7 +41,6 @@ Project, User, Operation, basic imports (e.g. CFF).
 import os
 import random
 import uuid
-from time import sleep
 
 import tvb_data
 from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
@@ -242,44 +241,44 @@ class TestFactory(object):
         return import_service.created_projects[0]
 
     @staticmethod
-    def launch_importer(importer_class, view_model, user, project, sync=True):
+    def launch_importer(importer_class, view_model, user, project, same_process=True):
         # type: (type, ViewModel, User, Project, bool) -> None
         """
-        sync = False will do the normal flow, with Uploaders running synchronously but in a different process. This
-        branch won't be compatible with usage in subclasses of TransactionalTestCase because the upload results won't
-        be available for the unit-test running.
-        sync = True for usage in subclasses of TransactionalTestCase, as data preparation, for example. Won't test the
-        "real" upload flow, but it is very close to that.
+        same_process = False will do the normal flow, with Uploaders running synchronously but in a different process.
+        This branch won't be compatible with usage in subclasses of TransactionalTestCase because the upload results
+        won't be available for the unit-test running.
+        same_process = True for usage in subclasses of TransactionalTestCase, as data preparation, for example. Won't
+        test the "real" upload flow, but it is very close to that.
         """
         importer = ABCAdapter.build_adapter_from_class(importer_class)
-        if sync:
+        if same_process:
             TestFactory.launch_synchronously(user, project, importer, view_model)
         else:
             OperationService().fire_operation(importer, user, project.id, view_model=view_model)
 
     @staticmethod
-    def import_region_mapping(user, project, import_file_path, surface_gid, connectivity_gid, sync=True):
+    def import_region_mapping(user, project, import_file_path, surface_gid, connectivity_gid, same_process=True):
 
         view_model = RegionMappingImporterModel()
         view_model.mapping_file = import_file_path
         view_model.surface = surface_gid
         view_model.connectivity = connectivity_gid
-        TestFactory.launch_importer(RegionMappingImporter, view_model, user, project, sync)
+        TestFactory.launch_importer(RegionMappingImporter, view_model, user, project, same_process)
 
         return TestFactory._assert_one_more_datatype(project, RegionMappingIndex)
 
     @staticmethod
-    def import_surface_gifti(user, project, path, sync=False):
+    def import_surface_gifti(user, project, path, same_process=False):
 
         view_model = GIFTISurfaceImporterModel()
         view_model.data_file = path
         view_model.should_center = False
-        TestFactory.launch_importer(GIFTISurfaceImporter, view_model, user, project, sync)
+        TestFactory.launch_importer(GIFTISurfaceImporter, view_model, user, project, same_process)
 
         return TestFactory._assert_one_more_datatype(project, SurfaceIndex)
 
     @staticmethod
-    def import_surface_zip(user, project, zip_path, surface_type, zero_based=True, sync=True):
+    def import_surface_zip(user, project, zip_path, surface_type, zero_based=True, same_process=True):
 
         count = dao.count_datatypes(project.id, SurfaceIndex)
 
@@ -288,43 +287,43 @@ class TestFactory(object):
         view_model.should_center = True
         view_model.zero_based_triangles = zero_based
         view_model.surface_type = surface_type
-        TestFactory.launch_importer(ZIPSurfaceImporter, view_model, user, project, sync)
+        TestFactory.launch_importer(ZIPSurfaceImporter, view_model, user, project, same_process)
 
         return TestFactory._assert_one_more_datatype(project, SurfaceIndex, count)
 
     @staticmethod
-    def import_surface_obj(user, project, obj_path, surface_type, sync=True):
+    def import_surface_obj(user, project, obj_path, surface_type, same_process=True):
 
         view_model = ObjSurfaceImporterModel()
         view_model.data_file = obj_path
         view_model.surface_type = surface_type
-        TestFactory.launch_importer(ObjSurfaceImporter, view_model, user, project, sync)
+        TestFactory.launch_importer(ObjSurfaceImporter, view_model, user, project, same_process)
 
         return TestFactory._assert_one_more_datatype(project, SurfaceIndex)
 
     @staticmethod
-    def import_sensors(user, project, zip_path, sensors_type, sync=True):
+    def import_sensors(user, project, zip_path, sensors_type, same_process=True):
 
         view_model = SensorsImporterModel()
         view_model.sensors_file = zip_path
         view_model.sensors_type = sensors_type
-        TestFactory.launch_importer(SensorsImporter, view_model, user, project, sync)
+        TestFactory.launch_importer(SensorsImporter, view_model, user, project, same_process)
 
         return TestFactory._assert_one_more_datatype(project, SensorsIndex)
 
     @staticmethod
-    def import_projection_matrix(user, project, file_path, sensors_gid, surface_gid, sync=True):
+    def import_projection_matrix(user, project, file_path, sensors_gid, surface_gid, same_process=True):
 
         view_model = ProjectionMatrixImporterModel()
         view_model.projection_file = file_path
         view_model.sensors = sensors_gid
         view_model.surface = surface_gid
-        TestFactory.launch_importer(ProjectionMatrixSurfaceEEGImporter, view_model, user, project, sync)
+        TestFactory.launch_importer(ProjectionMatrixSurfaceEEGImporter, view_model, user, project, same_process)
 
         return TestFactory._assert_one_more_datatype(project, ProjectionMatrixIndex)
 
     @staticmethod
-    def import_zip_connectivity(user, project, zip_path=None, subject=DataTypeMetaData.DEFAULT_SUBJECT, sync=True):
+    def import_zip_connectivity(user, project, zip_path=None, subject=DataTypeMetaData.DEFAULT_SUBJECT, same_process=True):
 
         if zip_path is None:
             zip_path = os.path.join(os.path.dirname(tvb_data.__file__), 'connectivity', 'connectivity_76.zip')
@@ -333,7 +332,7 @@ class TestFactory(object):
         view_model = ZIPConnectivityImporterModel()
         view_model.uploaded = zip_path
         view_model.data_subject = subject
-        TestFactory.launch_importer(ZIPConnectivityImporter, view_model, user, project, sync)
+        TestFactory.launch_importer(ZIPConnectivityImporter, view_model, user, project, same_process)
 
         return TestFactory._assert_one_more_datatype(project, ConnectivityIndex, count)
 

--- a/framework_tvb/tvb/tests/framework/core/factory.py
+++ b/framework_tvb/tvb/tests/framework/core/factory.py
@@ -41,37 +41,39 @@ Project, User, Operation, basic imports (e.g. CFF).
 import os
 import random
 import uuid
+from time import sleep
+
 import tvb_data
 from tvb.adapters.datatypes.db.connectivity import ConnectivityIndex
 from tvb.adapters.datatypes.db.projections import ProjectionMatrixIndex
 from tvb.adapters.datatypes.db.region_mapping import RegionMappingIndex
+from tvb.adapters.datatypes.db.sensors import SensorsIndex
+from tvb.adapters.datatypes.db.surface import SurfaceIndex
 from tvb.adapters.datatypes.h5.mapped_value_h5 import ValueWrapper
+from tvb.adapters.uploaders.gifti_surface_importer import GIFTISurfaceImporter, GIFTISurfaceImporterModel
+from tvb.adapters.uploaders.obj_importer import ObjSurfaceImporter, ObjSurfaceImporterModel
 from tvb.adapters.uploaders.projection_matrix_importer import ProjectionMatrixImporterModel
 from tvb.adapters.uploaders.projection_matrix_importer import ProjectionMatrixSurfaceEEGImporter
 from tvb.adapters.uploaders.region_mapping_importer import RegionMappingImporterModel, RegionMappingImporter
-from tvb.adapters.uploaders.gifti_surface_importer import GIFTISurfaceImporter, GIFTISurfaceImporterModel
-from tvb.adapters.uploaders.obj_importer import ObjSurfaceImporter, ObjSurfaceImporterModel
 from tvb.adapters.uploaders.sensors_importer import SensorsImporterModel, SensorsImporter
 from tvb.adapters.uploaders.zip_connectivity_importer import ZIPConnectivityImporterModel, ZIPConnectivityImporter
 from tvb.adapters.uploaders.zip_surface_importer import ZIPSurfaceImporter, ZIPSurfaceImporterModel
-from tvb.adapters.datatypes.db.sensors import SensorsIndex
-from tvb.adapters.datatypes.db.surface import SurfaceIndex
+from tvb.core.adapters.abcadapter import ABCAdapter
 from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.entities.load import try_get_last_datatype
 from tvb.core.entities.model.model_burst import BurstConfiguration
+from tvb.core.entities.model.model_burst import RANGE_PARAMETER_1
 from tvb.core.entities.model.model_datatype import DataType
-from tvb.core.neocom import h5
-from tvb.core.services.burst_service import BurstService
-from tvb.core.neotraits.view_model import ViewModel
-from tvb.core.utils import hash_password
 from tvb.core.entities.model.model_operation import *
 from tvb.core.entities.storage import dao
-from tvb.core.entities.model.model_burst import RANGE_PARAMETER_1
 from tvb.core.entities.transient.structure_entities import DataTypeMetaData
-from tvb.core.services.project_service import ProjectService
+from tvb.core.neocom import h5
+from tvb.core.neotraits.view_model import ViewModel
+from tvb.core.services.burst_service import BurstService
 from tvb.core.services.import_service import ImportService
 from tvb.core.services.operation_service import OperationService
-from tvb.core.adapters.abcadapter import ABCAdapter
+from tvb.core.services.project_service import ProjectService
+from tvb.core.utils import hash_password
 
 
 class TestFactory(object):
@@ -240,34 +242,44 @@ class TestFactory(object):
         return import_service.created_projects[0]
 
     @staticmethod
-    def launch_importer(importer_class, view_model, user, project_id):
-        # type: (type, ViewModel, User, int) -> None
+    def launch_importer(importer_class, view_model, user, project, sync=True):
+        # type: (type, ViewModel, User, Project, bool) -> None
         importer = ABCAdapter.build_adapter_from_class(importer_class)
-        OperationService().fire_operation(importer, user, project_id, view_model=view_model)
+        if sync:
+            TestFactory.launch_synchronously(user, project, importer, view_model)
+        else:
+            op = OperationService().fire_operation(importer, user, project.id, view_model=view_model)[0]
+            # wait for the operation to finish
+            # TODO: wait for launch to finish and launch without transaction
+            tries = 5
+            while not op.has_finished and tries > 0:
+                sleep(15)
+                tries -= 1
+                op = dao.get_operation_by_id(op.id)
 
     @staticmethod
-    def import_region_mapping(user, project, import_file_path, surface_gid, connectivity_gid):
+    def import_region_mapping(user, project, import_file_path, surface_gid, connectivity_gid, sync=True):
 
         view_model = RegionMappingImporterModel()
         view_model.mapping_file = import_file_path
         view_model.surface = surface_gid
         view_model.connectivity = connectivity_gid
-        TestFactory.launch_importer(RegionMappingImporter, view_model, user, project.id)
+        TestFactory.launch_importer(RegionMappingImporter, view_model, user, project, sync)
 
         return TestFactory._assert_one_more_datatype(project, RegionMappingIndex)
 
     @staticmethod
-    def import_surface_gifti(user, project, path):
+    def import_surface_gifti(user, project, path, sync=False):
 
         view_model = GIFTISurfaceImporterModel()
         view_model.data_file = path
         view_model.should_center = False
-        TestFactory.launch_importer(GIFTISurfaceImporter, view_model, user, project.id)
+        TestFactory.launch_importer(GIFTISurfaceImporter, view_model, user, project, sync)
 
         return TestFactory._assert_one_more_datatype(project, SurfaceIndex)
 
     @staticmethod
-    def import_surface_zip(user, project, zip_path, surface_type, zero_based=True):
+    def import_surface_zip(user, project, zip_path, surface_type, zero_based=True, sync=True):
 
         count = dao.count_datatypes(project.id, SurfaceIndex)
 
@@ -276,43 +288,43 @@ class TestFactory(object):
         view_model.should_center = True
         view_model.zero_based_triangles = zero_based
         view_model.surface_type = surface_type
-        TestFactory.launch_importer(ZIPSurfaceImporter, view_model, user, project.id)
+        TestFactory.launch_importer(ZIPSurfaceImporter, view_model, user, project, sync)
 
         return TestFactory._assert_one_more_datatype(project, SurfaceIndex, count)
 
     @staticmethod
-    def import_surface_obj(user, project, obj_path, surface_type):
+    def import_surface_obj(user, project, obj_path, surface_type, sync=True):
 
         view_model = ObjSurfaceImporterModel()
         view_model.data_file = obj_path
         view_model.surface_type = surface_type
-        TestFactory.launch_importer(ObjSurfaceImporter, view_model, user, project.id)
+        TestFactory.launch_importer(ObjSurfaceImporter, view_model, user, project, sync)
 
         return TestFactory._assert_one_more_datatype(project, SurfaceIndex)
 
     @staticmethod
-    def import_sensors(user, project, zip_path, sensors_type):
+    def import_sensors(user, project, zip_path, sensors_type, sync=True):
 
         view_model = SensorsImporterModel()
         view_model.sensors_file = zip_path
         view_model.sensors_type = sensors_type
-        TestFactory.launch_importer(SensorsImporter, view_model, user, project.id)
+        TestFactory.launch_importer(SensorsImporter, view_model, user, project, sync)
 
         return TestFactory._assert_one_more_datatype(project, SensorsIndex)
 
     @staticmethod
-    def import_projection_matrix(user, project, file_path, sensors_gid, surface_gid):
+    def import_projection_matrix(user, project, file_path, sensors_gid, surface_gid, sync=True):
 
         view_model = ProjectionMatrixImporterModel()
         view_model.projection_file = file_path
         view_model.sensors = sensors_gid
         view_model.surface = surface_gid
-        TestFactory.launch_importer(ProjectionMatrixSurfaceEEGImporter, view_model, user, project.id)
+        TestFactory.launch_importer(ProjectionMatrixSurfaceEEGImporter, view_model, user, project, sync)
 
         return TestFactory._assert_one_more_datatype(project, ProjectionMatrixIndex)
 
     @staticmethod
-    def import_zip_connectivity(user, project, zip_path=None, subject=DataTypeMetaData.DEFAULT_SUBJECT):
+    def import_zip_connectivity(user, project, zip_path=None, subject=DataTypeMetaData.DEFAULT_SUBJECT, sync=True):
 
         if zip_path is None:
             zip_path = os.path.join(os.path.dirname(tvb_data.__file__), 'connectivity', 'connectivity_76.zip')
@@ -321,7 +333,7 @@ class TestFactory(object):
         view_model = ZIPConnectivityImporterModel()
         view_model.uploaded = zip_path
         view_model.data_subject = subject
-        TestFactory.launch_importer(ZIPConnectivityImporter, view_model, user, project.id)
+        TestFactory.launch_importer(ZIPConnectivityImporter, view_model, user, project, sync)
 
         return TestFactory._assert_one_more_datatype(project, ConnectivityIndex, count)
 

--- a/framework_tvb/tvb/tests/framework/core/factory.py
+++ b/framework_tvb/tvb/tests/framework/core/factory.py
@@ -244,6 +244,13 @@ class TestFactory(object):
     @staticmethod
     def launch_importer(importer_class, view_model, user, project, sync=True):
         # type: (type, ViewModel, User, Project, bool) -> None
+        """
+        sync = False will do the normal flow, with Uploaders running synchronously but in a different process. This
+        branch won't be compatible with usage in subclasses of TransactionalTestCase because the upload results won't
+        be available for the unit-test running.
+        sync = True for usage in subclasses of TransactionalTestCase, as data preparation, for example. Won't test the
+        "real" upload flow, but it is very close to that.
+        """
         importer = ABCAdapter.build_adapter_from_class(importer_class)
         if sync:
             TestFactory.launch_synchronously(user, project, importer, view_model)

--- a/framework_tvb/tvb/tests/framework/core/factory.py
+++ b/framework_tvb/tvb/tests/framework/core/factory.py
@@ -248,14 +248,7 @@ class TestFactory(object):
         if sync:
             TestFactory.launch_synchronously(user, project, importer, view_model)
         else:
-            op = OperationService().fire_operation(importer, user, project.id, view_model=view_model)[0]
-            # wait for the operation to finish
-            # TODO: wait for launch to finish and launch without transaction
-            tries = 5
-            while not op.has_finished and tries > 0:
-                sleep(15)
-                tries -= 1
-                op = dao.get_operation_by_id(op.id)
+            OperationService().fire_operation(importer, user, project.id, view_model=view_model)
 
     @staticmethod
     def import_region_mapping(user, project, import_file_path, surface_gid, connectivity_gid, sync=True):


### PR DESCRIPTION
Follow-up on PR #204
- uploaders tests are not transactional and follow the real flow (sync but in diff process)
- uploads done by other tests are sync in the main process

TVB-2765:
- removed ABCAsync and ABCSync
- added AdapterLaunchModeEnum to describe the new 3 launching modes for adapters
- added a way to handle exception that are thrown in the subprocess and we want to display them in the GUI for uploaders