### PR TITLE
TVB-2746: Fix Reload Simulation from web page

### DIFF
--- a/framework_tvb/tvb/core/neocom/h5.py
+++ b/framework_tvb/tvb/core/neocom/h5.py
@@ -232,7 +232,7 @@ def determine_filepath(gid, base_dir):
 
 
 def load_view_model(gid, base_dir):
-    # type: (uuid.UUID, str) -> ViewModel
+    # type: (typing.Union[uuid.UUID, str], str) -> ViewModel
     """
     Load a ViewModel object by reading the H5 file with the given GID, from the directory specified by base_dir.
     """

--- a/framework_tvb/tvb/core/services/backend_client_factory.py
+++ b/framework_tvb/tvb/core/services/backend_client_factory.py
@@ -64,4 +64,4 @@ class BackendClientFactory(object):
     @staticmethod
     def stop_operation(operation_id):
         backend_client = BackendClientFactory._get_backend_client()
-        backend_client.stop_operation(operation_id)
+        return backend_client.stop_operation(operation_id)

--- a/framework_tvb/tvb/core/services/backend_clients/backend_client.py
+++ b/framework_tvb/tvb/core/services/backend_clients/backend_client.py
@@ -53,3 +53,4 @@ class BackendClient(object):
         """
         Stop the thread for a given operation id
         """
+        return True

--- a/framework_tvb/tvb/core/services/backend_clients/standalone_client.py
+++ b/framework_tvb/tvb/core/services/backend_clients/standalone_client.py
@@ -168,7 +168,7 @@ class StandAloneClient(BackendClient):
         """
         operation = dao.try_get_operation_by_id(operation_id)
         if not operation or operation.has_finished:
-            LOGGER.warning("Operation already stopped or not found is given to stop job: %s" % operation_id)
+            LOGGER.info("Operation already stopped or not found at ID: %s" % operation_id)
             return True
 
         LOGGER.debug("Stopping operation: %s" % str(operation_id))

--- a/framework_tvb/tvb/core/services/project_service.py
+++ b/framework_tvb/tvb/core/services/project_service.py
@@ -602,8 +602,11 @@ class ProjectService:
             datatypes_for_op = dao.get_results_for_operation(operation_id)
             for dt in reversed(datatypes_for_op):
                 self.remove_datatype(operation.project.id, dt.gid, False)
+            # Here the Operation is mot probably already removed - in case DTs were found inside
+            # but we still remove it for the case when no DTs exist
             dao.remove_entity(Operation, operation.id)
             self.structure_helper.remove_operation_data(operation.project.name, operation_id)
+
             self.logger.debug("Finished deleting operation %s " % operation)
         else:
             self.logger.warning("Attempt to delete operation with id=%s which no longer exists." % operation_id)
@@ -645,15 +648,15 @@ class ProjectService:
             self.logger.debug("Removing datatype %s" % datatype)
             self._remove_project_node_files(project_id, datatype.gid, skip_validation)
 
-        ## Remove Operation entity in case no other DataType needs them.
+        # Remove Operation entity in case no other DataType needs them.
         project = dao.get_project_by_id(project_id)
         for operation_id in operations_set:
             dependent_dt = dao.get_generic_entity(DataType, operation_id, "fk_from_operation")
             if len(dependent_dt) > 0:
-                ### Do not remove Operation in case DataType still exist referring it.
+                # Do not remove Operation in case DataType still exist referring it.
                 continue
             correct = correct and dao.remove_entity(Operation, operation_id)
-            ## Make sure Operation folder is removed
+            # Make sure Operation folder is removed
             self.structure_helper.remove_operation_data(project.name, datatype.fk_from_operation)
 
         if not correct:

--- a/framework_tvb/tvb/interfaces/web/controllers/flow_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/flow_controller.py
@@ -560,6 +560,8 @@ class FlowController(BaseController):
         """
         operation_id = int(operation_id)
         is_group = int(is_group) != 0
+        if isinstance(remove_after_stop, str):
+            remove_after_stop = bool(remove_after_stop)
         return SimulatorController.cancel_or_remove_operation(operation_id, is_group, remove_after_stop)
 
     def fill_default_attributes(self, template_dictionary, title='-'):

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
@@ -242,9 +242,7 @@ class SimulatorController(BurstBaseController):
         self.last_loaded_form_url = current_url
         common.add2session(common.KEY_LAST_LOADED_FORM_URL, self.last_loaded_form_url)
 
-    @cherrypy.expose
-    @handle_error(redirect=False)
-    @check_user
+    @expose_json
     def cancel_or_remove_burst(self, burst_id):
         """
         Cancel or Remove the burst entity given by burst_id (and all linked entities: op, DTs)
@@ -277,7 +275,8 @@ class SimulatorController(BurstBaseController):
             current_burst = common.get_from_session(common.KEY_BURST_CONFIG)
             if current_burst is not None and burst_config is not None and current_burst.id == burst_config.id:
                 common.remove_from_session(common.KEY_BURST_CONFIG)
-                common.add2session(common.KEY_BURST_CONFIG, BurstConfiguration(burst_config.project.id))
+                project = common.get_current_project()
+                common.add2session(common.KEY_BURST_CONFIG, BurstConfiguration(project.id))
         return result
 
     @expose_page

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator_controller.py
@@ -226,7 +226,6 @@ class SimulatorFragmentRenderingRules(object):
 @traced
 class SimulatorController(BurstBaseController):
     KEY_IS_LOAD_AFTER_REDIRECT = "is_load_after_redirect"
-    DEFAULT_COPY_PREFIX = "copy_of_"
 
     def __init__(self):
         BurstBaseController.__init__(self)
@@ -1009,18 +1008,7 @@ class SimulatorController(BurstBaseController):
 
     @expose_fragment('simulator_fragment')
     def copy_simulator_configuration(self, burst_config_id):
-        burst_config = self.burst_service.load_burst_configuration(burst_config_id)
-        burst_config_copy = burst_config.clone()
-        burst_config_copy.name = self.DEFAULT_COPY_PREFIX + burst_config.name
-
-        project = common.get_current_project()
-        storage_path = self.files_helper.get_project_folder(project, str(burst_config.fk_simulation))
-        simulator = h5.load_view_model(burst_config.simulator_gid, storage_path)
-
-        common.add2session(common.KEY_SIMULATOR_CONFIG, simulator)
-        common.add2session(common.KEY_IS_SIMULATOR_COPY, True)
-        common.add2session(common.KEY_IS_SIMULATOR_LOAD, False)
-        common.add2session(common.KEY_BURST_CONFIG, burst_config_copy)
+        burst_config_copy = FlowController().get_burst_config_copy(burst_config_id)
 
         self._update_last_loaded_fragment_url(self._prepare_last_fragment_by_burst_type(burst_config_copy))
         form = self.prepare_first_fragment()


### PR DESCRIPTION
In TVB Web GUI page Project -> Operations click or the button "play" in case of an operation.
You should be taken to the Simulator page, and the clicked operation should be loaded in memory as a copy (same as when you would click "copy" in the Simulator History left column).
It should work regardless what Simulation was previously selected on the Simulator page.