### PR TITLE
TVB-2661 (with subtasks TVB-2774 and TVB-2779) Project Export and Import

### DIFF
--- a/framework_tvb/tvb/core/entities/model/model_operation.py
+++ b/framework_tvb/tvb/core/entities/model/model_operation.py
@@ -432,18 +432,15 @@ class ResultFigure(Base, Exportable):
     __tablename__ = 'RESULT_FIGURES'
 
     id = Column(Integer, primary_key=True)
-    fk_from_operation = Column(Integer, ForeignKey('OPERATIONS.id', ondelete="CASCADE"))
     fk_for_user = Column(Integer, ForeignKey('USERS.id', ondelete="CASCADE"))
     fk_in_project = Column(Integer, ForeignKey('PROJECTS.id', ondelete="CASCADE"))
     project = relationship(Project, backref=backref('RESULT_FIGURES', order_by=id, cascade="delete"))
-    operation = relationship(Operation, backref=backref('RESULT_FIGURES', order_by=id, cascade="delete"))
     session_name = Column(String)
     name = Column(String)
     file_path = Column(String)
     file_format = Column(String)
 
-    def __init__(self, operation_id, user_id, project_id, session_name, name, path, file_format="PNG"):
-        self.fk_from_operation = operation_id
+    def __init__(self, user_id, project_id, session_name, name, path, file_format="PNG"):
         self.fk_for_user = user_id
         self.fk_in_project = project_id
         self.session_name = session_name
@@ -452,17 +449,14 @@ class ResultFigure(Base, Exportable):
         self.file_format = file_format.lower()  # some platforms have difficulties if it's not lower case
 
     def __repr__(self):
-        return "<ResultFigure(%s, %s, %s, %s, %s, %s, %s)>" % (self.fk_from_operation, self.fk_for_user,
-                                                               self.fk_in_project, self.session_name, self.name,
-                                                               self.file_path, self.file_format)
+        return "<ResultFigure(%s, %s, %s, %s, %s, %s)>" % (self.fk_for_user, self.fk_in_project, self.session_name,
+                                                           self.name, self.file_path, self.file_format)
 
     def to_dict(self):
         """
         Overwrite superclass method with required additional data.
         """
-        _, base_dict = super(ResultFigure, self).to_dict(excludes=['id', 'fk_from_operation', 'fk_for_user',
-                                                                   'fk_in_project', 'operation', 'project'])
-        base_dict['fk_from_operation'] = self.operation.gid if self.operation is not None else None
+        _, base_dict = super(ResultFigure, self).to_dict(excludes=['id', 'fk_for_user', 'fk_in_project', 'project'])
         base_dict['fk_in_project'] = self.project.gid
         return self.__class__.__name__, base_dict
 
@@ -470,7 +464,6 @@ class ResultFigure(Base, Exportable):
         """
         Add specific attributes from a input dictionary.
         """
-        self.fk_from_operation = dictionary['fk_op_id']
         self.fk_for_user = dictionary['fk_user_id']
         self.fk_in_project = dictionary['fk_project_id']
         self.session_name = dictionary['session_name']

--- a/framework_tvb/tvb/core/entities/storage/operation_dao.py
+++ b/framework_tvb/tvb/core/entities/storage/operation_dao.py
@@ -469,12 +469,10 @@ class OperationDAO(RootDAO):
         try:
             figure = self.session.query(ResultFigure).filter_by(id=figure_id).one()
             figure.project
-            figure.operation
             return figure
         except SQLAlchemyError as excep:
             self.logger.exception(excep)
             return None
-
 
     def get_previews(self, project_id, user_id=None, selected_session_name='all_sessions'):
         """
@@ -509,13 +507,11 @@ class OperationDAO(RootDAO):
                 # Force loading of project and operation - needed to compute image path
                 for figure in figures_list:
                     figure.project
-                    figure.operation
                 result[session_name] = figures_list
             return result, previews_info
         except SQLAlchemyError as excep:
             self.logger.exception(excep)
             return {}, {}
-
 
     def _get_previews_info(self, project_id, user_id):
         """
@@ -540,7 +536,6 @@ class OperationDAO(RootDAO):
             self.logger.exception(excep)
             return {}
 
-
     def get_figure_count(self, project_id, user_id):
         """
         Used to generate sequential image names.
@@ -554,16 +549,3 @@ class OperationDAO(RootDAO):
         except SQLAlchemyError as excep:
             self.logger.exception(excep)
             return {}
-
-
-    def get_figures_for_operation(self, operation_id):
-        """Retrieve Figure entities, resulted after executing an operation."""
-        try:
-            result = self.session.query(ResultFigure).filter_by(fk_from_operation=operation_id).all()
-            for figure in result:
-                figure.project
-                figure.operation
-            return result
-        except SQLAlchemyError as excep:
-            self.logger.exception(excep)
-            return None

--- a/framework_tvb/tvb/core/services/import_service.py
+++ b/framework_tvb/tvb/core/services/import_service.py
@@ -389,9 +389,6 @@ class ImportService(object):
         if not os.path.exists(actual_figure):
             self.logger.warning("Expected to find image path %s .Skipping" % actual_figure)
             return
-        # TODO: this will never match in the current form. What to do ?
-        op = dao.get_operation_by_gid(figure_dict['fk_from_operation'])
-        figure_dict['fk_op_id'] = op.id if op is not None else None
         figure_dict['fk_user_id'] = self.user_id
         figure_dict['fk_project_id'] = project_id
         figure_entity = manager_of_class(ResultFigure).new_instance()

--- a/framework_tvb/tvb/core/services/project_service.py
+++ b/framework_tvb/tvb/core/services/project_service.py
@@ -35,10 +35,8 @@ Service Layer for the Project entity.
 .. moduleauthor:: Bogdan Neacsa <bogdan.neacsa@codemart.ro>
 """
 
-import os
 import formencode
 from tvb.basic.logger.builder import get_logger
-from tvb.core import utils
 from tvb.core.adapters.abcadapter import ABCAdapter
 from tvb.core.adapters.inputs_processor import review_operation_inputs_from_adapter
 from tvb.core.entities.load import load_entity_by_gid
@@ -236,7 +234,6 @@ class ProjectService:
                 result["additional"] = one_op[10]
                 result["visible"] = True if one_op[11] > 0 else False
                 result['operation_tag'] = one_op[12]
-                result['figures'] = None
                 if not result['group']:
                     datatype_results = dao.get_results_for_operation(result['id'])
                     result['results'] = []
@@ -247,16 +244,6 @@ class ProjectService:
                         else:
                             self.logger.warning("Could not retrieve datatype %s" % str(dt))
 
-                    operation_figures = dao.get_figures_for_operation(result['id'])
-
-                    # Compute the full path to the figure / image on disk
-                    for figure in operation_figures:
-                        figures_folder = self.structure_helper.get_images_folder(figure.project.name)
-                        figure_full_path = os.path.join(figures_folder, figure.file_path)
-                        # Compute the path available from browser
-                        figure.figure_path = utils.path2url_part(figure_full_path)
-
-                    result['figures'] = operation_figures
                 else:
                     result['results'] = None
                 operations.append(result)

--- a/framework_tvb/tvb/interfaces/web/controllers/common.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/common.py
@@ -66,7 +66,6 @@ KEY_LINK_ANALYZE = "analyzeCategoryLink"
 KEY_LINK_CONNECTIVITY_TAB = "connectivityTabLink"
 KEY_TITLE = "title"
 KEY_ADAPTER = "currentAlgoId"
-KEY_OPERATION_ID = "currentOperationId"
 KEY_SECTION = "section_name"
 KEY_SUB_SECTION = 'subsection_name'
 KEY_INCLUDE_RESOURCES = 'includedResources'

--- a/framework_tvb/tvb/interfaces/web/controllers/flow_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/flow_controller.py
@@ -347,7 +347,6 @@ class FlowController(BaseController):
                                                                submit_url, should_reset)
         if (errors is not None) and (template_specification is not None):
             template_specification[common.KEY_ERRORS] = errors
-        template_specification[common.KEY_OPERATION_ID] = adapter_instance.operation_id
         return template_specification
 
     def get_template_for_adapter(self, project_id, step_key, stored_adapter, submit_url, session_reset=True,

--- a/framework_tvb/tvb/interfaces/web/controllers/project/figure_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/project/figure_controller.py
@@ -40,7 +40,6 @@ import cherrypy
 import formencode
 from formencode import validators
 from cherrypy.lib.static import serve_file
-
 from tvb.core import utils
 from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.services.figure_service import FigureService
@@ -72,10 +71,8 @@ class FigureController(ProjectController):
         store image in current session, for future comparison."""
         project = common.get_current_project()
         user = common.get_logged_user()
-        operation_id = kwargs.get("operationId")
         suggested_name = kwargs.get("suggestedName")
-        self.figure_service.store_result_figure(project, user, img_type, kwargs['export_data'],
-                                                image_name=suggested_name, operation_id=operation_id)
+        self.figure_service.store_result_figure(project, user, img_type, kwargs['export_data'], suggested_name)
 
 
     @expose_page

--- a/framework_tvb/tvb/interfaces/web/static/js/canvas2image.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/canvas2image.js
@@ -23,9 +23,8 @@ var C2I_EXPORT_HEIGHT = 1080;
 var canvasAndSvg=false;
 /**
  * Function called on any visualizer, to export canvases into image/svg downloadable files..
- * @param kwargs an object with 2 optional keys
- *   operationId  : The operation which created the figure
- *   suggestedName: A name for the figure
+ * @param kwargs an object with currently only one optional key:
+ *   suggestedName: A name prefix for the figure
  */
 function C2I_exportFigures(kwargs) {
     if ($("canvas, svg").filter(":visible").length === 0) {

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/flow/call_out_control.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/flow/call_out_control.html
@@ -17,7 +17,7 @@
                         '{{ "" if ("back_page=" not in submitLink) else submitLink.split("back_page=")[-1] }}');
                     var saveFigureBtn = document.getElementById("ctrl-action-export");
                     saveFigureBtn.onclick = function () {
-                        C2I_exportFigures({operationId: '{{ currentOperationId }}'});
+                        C2I_exportFigures({});
                         return false;
                     };
                 });

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/project/viewoperations.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/project/viewoperations.html
@@ -4,9 +4,8 @@
 
     {% macro displayOperationResults(operation_row) -%}
         <!--! Function for displaying a given Operation's result column:
-              - list of icons for results,
-              - expand button in case of a group, or
-              - figures in case of Visualizers with saved images.
+              - list of icons for results, or
+              - expand button in case of a group.
         -->
         {% if operation_row['datatype_group_gid'] is not none %}
             <nav class="inline-menu">
@@ -52,16 +51,6 @@
             </div>
         {% endif %}
 
-        {% if operation_row['figures'] is not none %}
-            {% for figure in operation_row['figures'] %}
-                <div class="image-container">
-                    <a href="/project/figure/displayresultfigures/" title="View this figure in your figure list"
-                       class="action action-crosslink crosslink-s-project crosslink-ss-figures">
-                        <div><img src="/flow/readserverstaticfile/{{ figure.figure_path }}"/></div>
-                    </a>
-                </div>
-            {% endfor %}
-        {% endif %}
     {%- endmacro %}
 
     <form id="operationsForm" method="post" action="/project/viewoperations/{{ selectedProject.id }}">

--- a/framework_tvb/tvb/tests/framework/adapters/exporters/exporters_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/exporters/exporters_test.py
@@ -114,7 +114,7 @@ class TestExporters(TransactionalTestCase):
         """
         This method checks export of a data type group
         """
-        datatype_group = datatype_group_factory(project=self.test_project)
+        datatype_group = datatype_group_factory(project=self.test_project, store_vm=True)
         file_name, file_path, _ = self.export_manager.export_data(datatype_group, self.TVB_EXPORTER, self.test_project)
 
         assert file_name is not None, "Export process should return a file name"

--- a/framework_tvb/tvb/tests/framework/adapters/exporters/exporters_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/exporters/exporters_test.py
@@ -183,7 +183,7 @@ class TestExporters(TransactionalTestCase):
         """
         Test export of a simulator configuration
         """
-        operation = operation_factory(is_simulation=True)
+        operation = operation_factory(is_simulation=True, store_vm=True)
 
         burst_configuration = BurstConfiguration(self.test_project.id)
         burst_configuration.fk_simulation = operation.id

--- a/framework_tvb/tvb/tests/framework/adapters/visualizers/pse_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/visualizers/pse_test.py
@@ -62,7 +62,7 @@ class TestPSE(TransactionalTestCase):
                          'has_started_ops', 'datatype_group_gid', 'color_metric', 'values_x', 'values_y']
         for key in expected_keys:
             assert key in result
-        assert json.loads(result['values_x']) == [1, 3, 5, 7, 9]
+        assert json.loads(result['values_x']) == [1, 3, 5]
         assert json.loads(result['values_y']) == [0.1, 0.4]
         assert dt_group.gid == result["datatype_group_gid"]
         assert 'false' == result["has_started_ops"]
@@ -102,7 +102,7 @@ class TestPSE(TransactionalTestCase):
                          'has_started_ops', 'datatype_group_gid', 'color_metric', 'values_x', 'values_y']
         for key in expected_keys:
             assert key in result
-        assert json.loads(result['values_x']) == [1, 2, 3, 5, 7, 9]
+        assert json.loads(result['values_x']) == [1, 2, 3, 5]
         assert json.loads(result['values_y']) == [0.1, 0.4]
         d3_data = json.loads(result['d3_data'])
         assert d3_data['3']['0.1']['color_weight'] == 3

--- a/framework_tvb/tvb/tests/framework/conftest.py
+++ b/framework_tvb/tvb/tests/framework/conftest.py
@@ -27,6 +27,7 @@
 #   Frontiers in Neuroinformatics (7:10. doi: 10.3389/fninf.2013.00010)
 #
 #
+
 import copy
 import json
 import os
@@ -165,7 +166,7 @@ def project_factory():
 
 @pytest.fixture()
 def operation_factory(user_factory, project_factory, connectivity_factory):
-    def build(test_user=None, test_project=None, is_simulation=False,
+    def build(test_user=None, test_project=None, is_simulation=False, store_vm=False,
               operation_status=STATUS_FINISHED, range_values=None):
         """
         Create persisted operation with a ViewModel stored
@@ -176,24 +177,33 @@ def operation_factory(user_factory, project_factory, connectivity_factory):
         if test_project is None:
             test_project = project_factory(test_user)
 
+        vm_gid = uuid.uuid4()
+        view_model = None
+
         if is_simulation:
             algorithm = dao.get_algorithm_by_module(SIMULATOR_MODULE, SIMULATOR_CLASS)
-            adapter = ABCAdapter.build_adapter(algorithm)
-            view_model = adapter.get_view_model_class()()
-            view_model.connectivity = connectivity_factory(4).gid
+            if store_vm:
+                adapter = ABCAdapter.build_adapter(algorithm)
+                view_model = adapter.get_view_model_class()()
+                view_model.connectivity = connectivity_factory(4).gid
+                vm_gid = view_model.gid
 
         else:
             algorithm = dao.get_algorithm_by_module(TVB_IMPORTER_MODULE, TVB_IMPORTER_CLASS)
-            adapter = ABCAdapter.build_adapter(algorithm)
-            view_model = adapter.get_view_model_class()()
-            view_model.data_file = "."
+            if store_vm:
+                adapter = ABCAdapter.build_adapter(algorithm)
+                view_model = adapter.get_view_model_class()()
+                view_model.data_file = "."
+                vm_gid = view_model.gid
 
-        operation = Operation(view_model.gid.hex, test_user.id, test_project.id, algorithm.id,
+        operation = Operation(vm_gid.hex, test_user.id, test_project.id, algorithm.id,
                               status=operation_status, range_values=range_values)
         dao.store_entity(operation)
 
-        op_folder = FilesHelper().get_project_folder(test_project, str(operation.id))
-        h5.store_view_model(view_model, op_folder)
+        if store_vm:
+            op_folder = FilesHelper().get_project_folder(test_project, str(operation.id))
+            h5.store_view_model(view_model, op_folder)
+
         # Make sure lazy attributes are correctly loaded.
         return dao.get_operation_by_id(operation.id)
 
@@ -523,12 +533,12 @@ def datatype_measure_factory():
 @pytest.fixture()
 def datatype_group_factory(connectivity_factory, time_series_index_factory, datatype_measure_factory,
                            project_factory, user_factory, operation_factory):
-    def build(project=None):
+    def build(project=None, store_vm=False):
         # there store the name and the (hi, lo, step) value of the range parameters
-        range_1 = ["row1", [1, 2, 10]]
+        range_1 = ["row1", [1, 2, 6]]
         range_2 = ["row2", [0.1, 0.3, 0.5]]
         # there are the actual numbers in the interval
-        range_values_1 = [1, 3, 5, 7, 9]
+        range_values_1 = [1, 3, 5]
         range_values_2 = [0.1, 0.4]
 
         user = user_factory()
@@ -537,8 +547,11 @@ def datatype_group_factory(connectivity_factory, time_series_index_factory, data
 
         algorithm = dao.get_algorithm_by_module(SIMULATOR_MODULE, SIMULATOR_CLASS)
         adapter = ABCAdapter.build_adapter(algorithm)
-        view_model = adapter.get_view_model_class()()
-        view_model.connectivity = connectivity_factory(4).gid
+        if store_vm:
+            view_model = adapter.get_view_model_class()()
+            view_model.connectivity = connectivity_factory(4).gid
+        else:
+            view_model = None
 
         algorithm_ms = dao.get_algorithm_by_module(MEASURE_METRICS_MODULE, MEASURE_METRICS_CLASS)
         adapter = ABCAdapter.build_adapter(algorithm_ms)
@@ -551,45 +564,48 @@ def datatype_group_factory(connectivity_factory, time_series_index_factory, data
 
         datatype_group = DataTypeGroup(op_group, state="RAW_DATA")
         datatype_group.no_of_ranges = 2
-        datatype_group.count_results = 10
+        datatype_group.count_results = 6
         datatype_group = dao.store_entity(datatype_group)
 
         dt_group_ms = DataTypeGroup(op_group_ms, state="RAW_DATA")
         dt_group_ms.no_of_ranges = 2
-        dt_group_ms.count_results = 10
+        dt_group_ms.count_results = 6
         dao.store_entity(dt_group_ms)
 
         # Now create some data types and add them to group
         for range_val1 in range_values_1:
             for range_val2 in range_values_2:
-                view_model = copy.deepcopy(view_model)
-                view_model.gid = uuid.uuid4()
 
-                op = Operation(view_model.gid.hex, user.id, project.id, algorithm.id,
+                view_model_gid = uuid.uuid4()
+                view_model_ms_gid = uuid.uuid4()
+
+                op = Operation(view_model_gid.hex, user.id, project.id, algorithm.id,
                                status=STATUS_FINISHED, op_group_id=op_group.id,
                                range_values=json.dumps({range_1[0]: range_val1,
                                                         range_2[0]: range_val2}))
                 op = dao.store_entity(op)
-                op_path = FilesHelper().get_project_folder(project, str(op.id))
-                h5.store_view_model(view_model, op_path)
-
                 ts_index = time_series_index_factory(op=op)
                 ts_index.fk_datatype_group = datatype_group.id
                 dao.store_entity(ts_index)
 
-                view_model_ms = copy.deepcopy(view_model_ms)
-                view_model_ms.gid = uuid.uuid4()
-                view_model_ms.time_series = ts_index.gid
-
-                op_ms = Operation(view_model_ms.gid.hex, user.id, project.id, algorithm.id,
+                op_ms = Operation(view_model_ms_gid.hex, user.id, project.id, algorithm.id,
                                   status=STATUS_FINISHED, op_group_id=op_group_ms.id,
                                   range_values=json.dumps({range_1[0]: range_val1,
                                                            range_2[0]: range_val2}))
                 op_ms = dao.store_entity(op_ms)
-                op_ms_path = FilesHelper().get_project_folder(project, str(op_ms.id))
-                h5.store_view_model(view_model_ms, op_ms_path)
-
                 datatype_measure_factory(ts_index, op_ms, dt_group_ms)
+
+                if store_vm:
+                    view_model = copy.deepcopy(view_model)
+                    view_model.gid = view_model_gid
+                    op_path = FilesHelper().get_project_folder(project, str(op.id))
+                    h5.store_view_model(view_model, op_path)
+
+                    view_model_ms = copy.deepcopy(view_model_ms)
+                    view_model_ms.gid = view_model_ms_gid
+                    view_model_ms.time_series = ts_index.gid
+                    op_ms_path = FilesHelper().get_project_folder(project, str(op_ms.id))
+                    h5.store_view_model(view_model_ms, op_ms_path)
 
                 if not datatype_group.fk_from_operation:
                     # Mark first operation ID

--- a/framework_tvb/tvb/tests/framework/core/factory.py
+++ b/framework_tvb/tvb/tests/framework/core/factory.py
@@ -133,13 +133,11 @@ class TestFactory(object):
         return ProjectService().store_project(admin, True, None, **data)
 
     @staticmethod
-    def create_figure(operation_id, user_id, project_id, session_name=None,
-                      name=None, path=None, file_format='PNG'):
+    def create_figure(user_id, project_id, session_name=None, name=None, path=None, file_format='PNG'):
         """
         :returns: the `ResultFigure` for a result with the given specifications
         """
-        figure = ResultFigure(operation_id, user_id, project_id,
-                              session_name, name, path, file_format)
+        figure = ResultFigure(user_id, project_id, session_name, name, path, file_format)
         return dao.store_entity(figure)
 
     @staticmethod

--- a/framework_tvb/tvb/tests/framework/core/services/figure_service_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/figure_service_test.py
@@ -32,15 +32,12 @@
 .. moduleauthor:: Mihai Andrei <mihai.andrei@codemart.ro>
 """
 
-import os
 from PIL import Image
 from tvb.tests.framework.core.base_testcase import TransactionalTestCase
 from tvb.core import utils
 from tvb.core.entities.file.files_helper import FilesHelper
-from tvb.core.entities.storage import dao
 from tvb.core.services.figure_service import FigureService
 from tvb.tests.framework.core.factory import TestFactory
-
 
 IMG_DATA = ("iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAJElEQVQYV2Pcv3"
             "//fwYk4OjoyIjMZ6SDAmT7QGx0K1EcRBsFAFAcHPlrTpAmAAAAAElFTkSuQmCC")
@@ -50,16 +47,15 @@ class TestFigureService(TransactionalTestCase):
     """
     Tests for the figure service
     """
+
     def transactional_setup_method(self):
         self.figure_service = FigureService()
         self.user = TestFactory.create_user()
         self.project = TestFactory.create_project(admin=self.user)
         self.files_helper = FilesHelper()
 
-
     def transactional_teardown_method(self):
         self.delete_project_folders()
-
 
     def assertCanReadImage(self, image_path):
         try:
@@ -67,10 +63,8 @@ class TestFigureService(TransactionalTestCase):
         except (IOError, ValueError):
             raise AssertionError("Could not open %s as a image" % image_path)
 
-
     def store_test_png(self):
-        self.figure_service.store_result_figure(self.project, self.user, "png", IMG_DATA, image_name="test-figure")
-
+        self.figure_service.store_result_figure(self.project, self.user, "png", IMG_DATA, "test-figure")
 
     def retrieve_images(self):
         figures_by_session, _ = self.figure_service.retrieve_result_figures(self.project, self.user)
@@ -80,23 +74,8 @@ class TestFigureService(TransactionalTestCase):
             figures.extend(fg)
         return figures
 
-
     def test_store_image(self):
         self.store_test_png()
-
-
-    def test_store_image_from_operation(self):
-        # test that image can be retrieved from operation
-        test_operation = TestFactory.create_operation(test_user=self.user, test_project=self.project)
-
-        self.figure_service.store_result_figure(self.project, self.user, "png",
-                                                IMG_DATA, operation_id=test_operation.id)
-        figures = dao.get_figures_for_operation(test_operation.id)
-        assert 1 == len(figures)
-        image_path = self.files_helper.get_images_folder(self.project.name)
-        image_path = os.path.join(image_path, figures[0].file_path)
-        self.assertCanReadImage(image_path)
-
 
     def test_store_and_retrieve_image(self):
         self.store_test_png()
@@ -105,12 +84,10 @@ class TestFigureService(TransactionalTestCase):
         image_path = utils.url2path(figures[0].file_path)
         self.assertCanReadImage(image_path)
 
-
     def test_load_figure(self):
         self.store_test_png()
         figures = self.retrieve_images()
         self.figure_service.load_figure(figures[0].id)
-
 
     def test_edit_figure(self):
         session_name = 'the altered ones'
@@ -121,7 +98,6 @@ class TestFigureService(TransactionalTestCase):
         figures_by_session, _ = self.figure_service.retrieve_result_figures(self.project, self.user)
         assert [session_name] == list(figures_by_session)
         assert name == list(figures_by_session.values())[0][0].name
-
 
     def test_remove_figure(self):
         self.store_test_png()

--- a/framework_tvb/tvb/tests/framework/core/services/project_structure_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/project_structure_test.py
@@ -177,7 +177,8 @@ class TestProjectStructure(TransactionalTestCase):
         """ Test that counting dataTypes is correct. Happy flow."""
         group = datatype_group_factory()
         count = dao.count_datatypes_in_group(group.id)
-        assert count == 10
+        assert count == group.count_results
+        assert count == 6
         datatypes = dao.get_datatypes_from_datatype_group(group.id)
         count = dao.count_datatypes_in_group(datatypes[0].id)
         assert count == 0, "There should be no dataType."
@@ -241,7 +242,7 @@ class TestProjectStructure(TransactionalTestCase):
         group = datatype_group_factory()
         exp_datatypes = dao.get_datatypes_from_datatype_group(group.id)
         datatypes = self.project_service.get_datatypes_from_datatype_group(group.id)
-        assert len(datatypes) == 10, "There should be 10 datatypes into the datatype group."
+        assert len(datatypes) == group.count_results, "There should be 10 datatypes into the datatype group."
         expected_dict = {exp_datatypes[0].id: exp_datatypes[0], exp_datatypes[1].id: exp_datatypes[1]}
         actual_dict = {datatypes[0].id: datatypes[0], datatypes[1].id: datatypes[1]}
 

--- a/framework_tvb/tvb/tests/framework/interfaces/web/controllers/exploration_controller_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/web/controllers/exploration_controller_test.py
@@ -60,10 +60,10 @@ class TestExplorationController(BaseTransactionalControllerTest):
         assert result['available_metrics'] == ["v"]
         assert result['color_metric'] == "v"
         assert result['size_metric'] == "v"
-        assert [1, 3, 5, 7, 9] == json.loads(result['labels_x'])
+        assert [1, 3, 5] == json.loads(result['labels_x'])
         assert [0.1, 0.4] == json.loads(result['labels_y'])
         data = json.loads(result['d3_data'])
-        assert len(data) == 5
+        assert len(data) == 3
         for row in data.values():
             assert len(row) == 2
             for entry in row.values():


### PR DESCRIPTION
TVB-2661 Project Export Import complete

Subtask TVB-2774:
- improve speed in some unit-tests
- test that export + import of some special properties (e.g. `Datatype.visible` and `DataType.fk_parent_burst`) works correctly
- test that `ResultFigure` instances are correctly restored after export + import

Subtask TVB-2779:
- cleanup `ResultFigure.op_gid`

