### PR TITLE
TVB-2762: Fixed Complex numbers problem in Postgres

### DIFF
--- a/framework_tvb/tvb/adapters/analyzers/node_covariance_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/node_covariance_adapter.py
@@ -167,12 +167,6 @@ class NodeCovarianceAdapter(ABCAdapter):
         covariance_index.fk_source_gid = self.input_time_series_index.gid
         covariance_index.subtype = type(covariance_index).__name__
         covariance_index.array_has_complex = array_metadata.has_complex
-
-        if not covariance_index.array_has_complex:
-            covariance_index.array_data_min = array_metadata.min
-            covariance_index.array_data_max = array_metadata.max
-            covariance_index.array_data_mean = array_metadata.mean
-
         covariance_index.array_is_finite = array_metadata.is_finite
         covariance_index.shape = json.dumps(covariance_h5.array_data.shape)
         covariance_index.ndim = len(covariance_h5.array_data.shape)

--- a/framework_tvb/tvb/adapters/analyzers/node_covariance_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/node_covariance_adapter.py
@@ -167,6 +167,12 @@ class NodeCovarianceAdapter(ABCAdapter):
         covariance_index.fk_source_gid = self.input_time_series_index.gid
         covariance_index.subtype = type(covariance_index).__name__
         covariance_index.array_has_complex = array_metadata.has_complex
+
+        if not covariance_index.array_has_complex:
+            covariance_index.array_data_min = float(array_metadata.min)
+            covariance_index.array_data_max = float(array_metadata.max)
+            covariance_index.array_data_mean = float(array_metadata.mean)
+
         covariance_index.array_is_finite = array_metadata.is_finite
         covariance_index.shape = json.dumps(covariance_h5.array_data.shape)
         covariance_index.ndim = len(covariance_h5.array_data.shape)

--- a/framework_tvb/tvb/adapters/analyzers/node_covariance_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/node_covariance_adapter.py
@@ -166,9 +166,9 @@ class NodeCovarianceAdapter(ABCAdapter):
 
         covariance_index.fk_source_gid = self.input_time_series_index.gid
         covariance_index.subtype = type(covariance_index).__name__
-        covariance_index.array_data_min = array_metadata.min
-        covariance_index.array_data_max = array_metadata.max
-        covariance_index.array_data_mean = array_metadata.mean
+        covariance_index.array_data_min = str(array_metadata.min)
+        covariance_index.array_data_max = str(array_metadata.max)
+        covariance_index.array_data_mean = str(array_metadata.mean)
         covariance_index.array_is_finite = array_metadata.is_finite
         covariance_index.array_has_complex = array_metadata.has_complex
         covariance_index.shape = json.dumps(covariance_h5.array_data.shape)

--- a/framework_tvb/tvb/adapters/analyzers/node_covariance_adapter.py
+++ b/framework_tvb/tvb/adapters/analyzers/node_covariance_adapter.py
@@ -166,11 +166,14 @@ class NodeCovarianceAdapter(ABCAdapter):
 
         covariance_index.fk_source_gid = self.input_time_series_index.gid
         covariance_index.subtype = type(covariance_index).__name__
-        covariance_index.array_data_min = str(array_metadata.min)
-        covariance_index.array_data_max = str(array_metadata.max)
-        covariance_index.array_data_mean = str(array_metadata.mean)
-        covariance_index.array_is_finite = array_metadata.is_finite
         covariance_index.array_has_complex = array_metadata.has_complex
+
+        if not covariance_index.array_has_complex:
+            covariance_index.array_data_min = array_metadata.min
+            covariance_index.array_data_max = array_metadata.max
+            covariance_index.array_data_mean = array_metadata.mean
+
+        covariance_index.array_is_finite = array_metadata.is_finite
         covariance_index.shape = json.dumps(covariance_h5.array_data.shape)
         covariance_index.ndim = len(covariance_h5.array_data.shape)
         # TODO write this part better, by moving into the Model fill_from...

--- a/framework_tvb/tvb/core/entities/model/model_datatype.py
+++ b/framework_tvb/tvb/core/entities/model/model_datatype.py
@@ -238,9 +238,9 @@ class DataTypeMatrix(DataType):
 
     ndim = Column(Integer, default=0)
     shape = Column(String, nullable=True)
-    array_data_min = Column(Float)
-    array_data_max = Column(Float)
-    array_data_mean = Column(Float)
+    array_data_min = Column(String)
+    array_data_max = Column(String)
+    array_data_mean = Column(String)
     array_is_finite = Column(Boolean, default=True)
     array_has_complex = Column(Boolean, default=False)
     # has_volume_mapping will currently be changed for ConnectivityMeasureIndex subclass
@@ -251,7 +251,10 @@ class DataTypeMatrix(DataType):
         self.subtype = datatype.__class__.__name__
 
         if hasattr(datatype, "array_data"):
-            self.array_data_min, self.array_data_max, self.array_data_mean = from_ndarray(datatype.array_data)
+            array_data_min, array_data_max, array_data_mean = from_ndarray(datatype.array_data)
+            self.array_data_min = str(array_data_min)
+            self.array_data_max = str(array_data_max)
+            self.array_data_mean = str(array_data_mean)
             self.array_is_finite = numpy.isfinite(datatype.array_data).all().item()
             self.array_has_complex = numpy.iscomplex(datatype.array_data).any().item()
             self.shape = json.dumps(datatype.array_data.shape)

--- a/framework_tvb/tvb/core/entities/model/model_datatype.py
+++ b/framework_tvb/tvb/core/entities/model/model_datatype.py
@@ -238,9 +238,9 @@ class DataTypeMatrix(DataType):
 
     ndim = Column(Integer, default=0)
     shape = Column(String, nullable=True)
-    array_data_min = Column(String)
-    array_data_max = Column(String)
-    array_data_mean = Column(String)
+    array_data_min = Column(Float)
+    array_data_max = Column(Float)
+    array_data_mean = Column(Float)
     array_is_finite = Column(Boolean, default=True)
     array_has_complex = Column(Boolean, default=False)
     # has_volume_mapping will currently be changed for ConnectivityMeasureIndex subclass
@@ -251,12 +251,12 @@ class DataTypeMatrix(DataType):
         self.subtype = datatype.__class__.__name__
 
         if hasattr(datatype, "array_data"):
-            array_data_min, array_data_max, array_data_mean = from_ndarray(datatype.array_data)
-            self.array_data_min = str(array_data_min)
-            self.array_data_max = str(array_data_max)
-            self.array_data_mean = str(array_data_mean)
-            self.array_is_finite = numpy.isfinite(datatype.array_data).all().item()
             self.array_has_complex = numpy.iscomplex(datatype.array_data).any().item()
+
+            if not self.array_has_complex:
+                self.array_data_min, self.array_data_max, self.array_data_mean = from_ndarray(datatype.array_data)
+
+            self.array_is_finite = numpy.isfinite(datatype.array_data).all().item()
             self.shape = json.dumps(datatype.array_data.shape)
             self.ndim = len(datatype.array_data.shape)
 


### PR DESCRIPTION
Postgres db has no datatype for complex numbers, it can only be achieved through defining a new datatype, which is a little more complicated, it requires some code in C as explained here https://www.postgresql.org/docs/9.4/xtypes.html.

So we thought with Paula that it would be easier just to have strings instead of complex numbers where there were errors (for Covariance and Complex Coherence Analyzers, the others didn't have this problem).