### PR TITLE
TVB-2775. Avoid imports of werkzeug in core (FilesHelper)

### DIFF
--- a/framework_tvb/tvb/core/entities/file/files_helper.py
+++ b/framework_tvb/tvb/core/entities/file/files_helper.py
@@ -34,16 +34,15 @@
 
 import os
 import shutil
-import tempfile
 from threading import Lock
 from zipfile import ZipFile, ZIP_DEFLATED, BadZipfile
+
 from tvb.basic.logger.builder import get_logger
 from tvb.basic.profile import TvbProfile
 from tvb.core.decorators import synchronized
 from tvb.core.entities.file.exceptions import FileStructureException
 from tvb.core.entities.file.xml_metadata_handlers import XMLReader, XMLWriter
 from tvb.core.entities.transient.structure_entities import GenericMetaData
-from werkzeug.utils import secure_filename
 
 LOCK_CREATE_FOLDER = Lock()
 
@@ -418,23 +417,6 @@ class FilesHelper(object):
         if os.path.isfile(file_path):
             return int(os.path.getsize(file_path) / 1024)
         return 0
-
-    @staticmethod
-    def save_temporary_file(file, destination_folder=None):
-        filename = secure_filename(file.filename)
-        if destination_folder is None:
-            destination_folder = FilesHelper.create_temp_folder()
-        full_path = os.path.join(destination_folder, filename)
-        file.save(full_path)
-
-        return full_path
-
-    @staticmethod
-    def create_temp_folder():
-        temp_name = tempfile.mkdtemp(dir=TvbProfile.current.TVB_TEMP_FOLDER)
-        folder = os.path.join(TvbProfile.current.TVB_TEMP_FOLDER, temp_name)
-
-        return folder
 
 
 class TvbZip(ZipFile):

--- a/framework_tvb/tvb/interfaces/rest/client/datatype/datatype_api.py
+++ b/framework_tvb/tvb/interfaces/rest/client/datatype/datatype_api.py
@@ -36,11 +36,11 @@ from tvb.basic.neotraits.api import HasTraits
 from tvb.core.neocom import h5
 from tvb.core.neocom.h5 import REGISTRY, TVBLoader
 from tvb.interfaces.rest.client.client_decorators import handle_response
-from tvb.interfaces.rest.client.helpers.file_helper import save_file
 from tvb.interfaces.rest.client.main_api import MainApi
-from tvb.interfaces.rest.commons.strings import RestLink, LinkPlaceholder
 from tvb.interfaces.rest.commons.dtos import AlgorithmDto
 from tvb.interfaces.rest.commons.exceptions import ClientException
+from tvb.interfaces.rest.commons.files_helper import save_file
+from tvb.interfaces.rest.commons.strings import RestLink, LinkPlaceholder
 
 
 class DataTypeApi(MainApi):

--- a/framework_tvb/tvb/interfaces/rest/client/simulator/simulation_api.py
+++ b/framework_tvb/tvb/interfaces/rest/client/simulator/simulation_api.py
@@ -30,19 +30,21 @@
 
 import os
 import shutil
+
 from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.neocom import h5
 from tvb.interfaces.rest.client.client_decorators import handle_response
 from tvb.interfaces.rest.client.main_api import MainApi
 from tvb.interfaces.rest.commons.strings import RequestFileKey
 from tvb.interfaces.rest.commons.strings import RestLink, LinkPlaceholder
+from tvb.interfaces.rest.commons.files_helper import create_temp_folder
 
 
 class SimulationApi(MainApi):
 
     @handle_response
     def fire_simulation(self, project_gid, session_stored_simulator, temp_folder):
-        temporary_folder = FilesHelper.create_temp_folder()
+        temporary_folder = create_temp_folder()
 
         h5.store_view_model(session_stored_simulator, temporary_folder)
         zip_folder_path = os.path.join(temp_folder, RequestFileKey.SIMULATION_FILE_NAME.value)

--- a/framework_tvb/tvb/interfaces/rest/commons/files_helper.py
+++ b/framework_tvb/tvb/interfaces/rest/commons/files_helper.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 #
-# TheVirtualBrain-Framework Package. This package holds all Data Management, and 
+# TheVirtualBrain-Framework Package. This package holds all Data Management, and
 # Web-UI helpful to run brain-simulations. To use it, you also need do download
 # TheVirtualBrain-Scientific Package (for simulators). See content of the
 # documentation-folder for more details. See also http://www.thevirtualbrain.org
@@ -28,6 +28,12 @@
 #
 #
 
+import os
+import tempfile
+
+from tvb.basic.profile import TvbProfile
+from werkzeug.utils import secure_filename
+
 CHUNK_SIZE = 128
 
 
@@ -37,3 +43,20 @@ def save_file(file_path, response):
             if chunk:
                 local_file.write(chunk)
     return file_path
+
+
+def create_temp_folder():
+    temp_name = tempfile.mkdtemp(dir=TvbProfile.current.TVB_TEMP_FOLDER)
+    folder = os.path.join(TvbProfile.current.TVB_TEMP_FOLDER, temp_name)
+
+    return folder
+
+
+def save_temporary_file(file, destination_folder=None):
+    filename = secure_filename(file.filename)
+    if destination_folder is None:
+        destination_folder = create_temp_folder()
+    full_path = os.path.join(destination_folder, filename)
+    file.save(full_path)
+
+    return full_path

--- a/framework_tvb/tvb/interfaces/rest/server/facades/operation_facade.py
+++ b/framework_tvb/tvb/interfaces/rest/server/facades/operation_facade.py
@@ -29,18 +29,20 @@
 #
 import os
 import shutil
+
 from tvb.basic.logger.builder import get_logger
 from tvb.core.adapters.abcadapter import ABCAdapter
 from tvb.core.adapters.abcuploader import ABCUploader
 from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.neotraits.h5 import ViewModelH5
-from tvb.core.services.exceptions import ProjectServiceException
 from tvb.core.services.algorithm_service import AlgorithmService
+from tvb.core.services.exceptions import ProjectServiceException
 from tvb.core.services.operation_service import OperationService
 from tvb.core.services.project_service import ProjectService
 from tvb.core.services.user_service import UserService
 from tvb.interfaces.rest.commons.dtos import DataTypeDto
 from tvb.interfaces.rest.commons.exceptions import InvalidIdentifierException, ServiceException
+from tvb.interfaces.rest.commons.files_helper import create_temp_folder, save_temporary_file
 
 
 class OperationFacade:
@@ -49,7 +51,6 @@ class OperationFacade:
         self.operation_service = OperationService()
         self.project_service = ProjectService()
         self.user_service = UserService()
-        self.files_helper = FilesHelper()
 
     @staticmethod
     def get_operation_status(operation_gid):
@@ -75,8 +76,8 @@ class OperationFacade:
 
     def launch_operation(self, current_user_id, model_file, project_gid, algorithm_module, algorithm_classname,
                          fetch_file):
-        temp_folder = FilesHelper.create_temp_folder()
-        model_h5_path = FilesHelper.save_temporary_file(model_file, temp_folder)
+        temp_folder = create_temp_folder()
+        model_h5_path = save_temporary_file(model_file, temp_folder)
 
         try:
             project = self.project_service.find_project_lazy_by_gid(project_gid)
@@ -96,12 +97,12 @@ class OperationFacade:
 
             operation = self.operation_service.prepare_operation(current_user_id, project.id, algorithm,
                                                                  view_model_gid.hex)
-            storage_path = self.files_helper.get_project_folder(project, str(operation.id))
+            storage_path = FilesHelper().get_project_folder(project, str(operation.id))
 
             if isinstance(adapter_instance, ABCUploader):
                 for key, value in adapter_instance.get_form_class().get_upload_information().items():
                     data_file = fetch_file(request_file_key=key, file_extension=value)
-                    data_file_path = FilesHelper.save_temporary_file(data_file, temp_folder)
+                    data_file_path = save_temporary_file(data_file, temp_folder)
                     file_name = os.path.basename(data_file_path)
                     upload_field = getattr(view_model_h5, key)
                     upload_field.store(os.path.join(storage_path, file_name))

--- a/framework_tvb/tvb/interfaces/rest/server/resources/simulator/simulation_resource.py
+++ b/framework_tvb/tvb/interfaces/rest/server/resources/simulator/simulation_resource.py
@@ -33,6 +33,7 @@ import os
 from tvb.basic.logger.builder import get_logger
 from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.interfaces.rest.commons.exceptions import InvalidInputException
+from tvb.interfaces.rest.commons.files_helper import save_temporary_file
 from tvb.interfaces.rest.commons.status_codes import HTTP_STATUS_CREATED
 from tvb.interfaces.rest.commons.strings import RequestFileKey
 from tvb.interfaces.rest.server.access_permissions.permissions import ProjectAccessPermission
@@ -56,7 +57,7 @@ class FireSimulationResource(RestResource):
         """
         file = self.extract_file_from_request(request_file_key=RequestFileKey.SIMULATION_FILE_KEY.value,
                                               file_extension=FilesHelper.TVB_ZIP_FILE_EXTENSION)
-        zip_path = FilesHelper.save_temporary_file(file)
+        zip_path = save_temporary_file(file)
         result = FilesHelper().unpack_zip(zip_path, os.path.dirname(zip_path))
 
         if len(result) == 0:


### PR DESCRIPTION
Moved methods that were used only in the REST layer more closely to their usages.
Having a dependency of werkzeug at this level, makes our H5 layer a bit heavy to use in external modules, eg: tvb-multiscale need to install werkzeug library only for this.
This PR should keep our H5 layer more lightweight.