### PR TITLE
TVB-2745: Fix overriding of tvb folder

### DIFF
--- a/framework_tvb/setup.py
+++ b/framework_tvb/setup.py
@@ -40,7 +40,7 @@ import os
 import shutil
 import setuptools
 
-VERSION = "2.0.9.1"
+VERSION = "2.0.10"
 
 TVB_TEAM = "Mihai Andrei, Lia Domide, Stuart Knock, Bogdan Neacsa, Paula Popa, Paula Sansz Leon, Marmaduke Woodman"
 

--- a/framework_tvb/tvb/core/services/settings_service.py
+++ b/framework_tvb/tvb/core/services/settings_service.py
@@ -243,7 +243,8 @@ class SettingsService(object):
         """
         Check if the storage folder exists and is empty.
         """
-        if storage_path:
-            if os.path.isdir(storage_path):
-                if os.listdir(storage_path):
-                    raise InvalidStorageException('TVB Storage should be empty, please set another folder.')
+        if storage_path and TvbProfile.is_first_run():
+            for dirpath, dirnames, files in os.walk(storage_path):
+                if files:
+                    if os.listdir(storage_path):
+                        raise InvalidStorageException('TVB Storage should be empty, please set another folder.')

--- a/framework_tvb/tvb/interfaces/command/lab.py
+++ b/framework_tvb/tvb/interfaces/command/lab.py
@@ -39,6 +39,7 @@ from tvb.adapters.uploaders.zip_connectivity_importer import ZIPConnectivityImpo
 from tvb.basic.profile import TvbProfile
 from tvb.basic.logger.builder import get_logger
 from tvb.core.adapters.abcadapter import ABCAdapter
+from tvb.core.entities.file.simulator.view_model import SimulatorAdapterModel
 from tvb.core.entities.storage import dao
 from tvb.core.entities.model.model_burst import BurstConfiguration
 from tvb.core.entities.model.model_operation import STATUS_FINISHED
@@ -104,6 +105,10 @@ def fire_simulation(project_id, simulator):
     cached_simulator_algorithm = AlgorithmService().get_algorithm_by_module_and_class(IntrospectionRegistry.SIMULATOR_MODULE,
                                                                                       IntrospectionRegistry.SIMULATOR_CLASS)
 
+    simulator_model = SimulatorAdapterModel()
+    simulator_model.connectivity = simulator.connectivity.gid
+    simulator_model.simulation_length = simulator.simulation_length
+
     # Instantiate a SimulatorService and launch the configured simulation
     simulator_service = SimulatorService()
     burst = BurstConfiguration(project.id)
@@ -112,7 +117,7 @@ def fire_simulation(project_id, simulator):
     dao.store_entity(burst)
 
     launched_operation = simulator_service.async_launch_and_prepare_simulation(burst, project.administrator, project,
-                                                                               cached_simulator_algorithm, simulator)
+                                                                               cached_simulator_algorithm, simulator_model)
     LOG.info("Operation launched ....")
     return launched_operation
 

--- a/framework_tvb/tvb/interfaces/web/controllers/settings_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/settings_controller.py
@@ -35,13 +35,12 @@
 import os
 import subprocess
 import threading
-from time import sleep
-
 import cherrypy
 import formencode
+from time import sleep
 from formencode import validators
 from tvb.basic.profile import TvbProfile
-from tvb.core.services.exceptions import InvalidSettingsException, InvalidStorageException
+from tvb.core.services.exceptions import InvalidSettingsException
 from tvb.core.services.settings_service import SettingsService
 from tvb.core.utils import check_matlab_version
 from tvb.interfaces.web.controllers import common
@@ -83,9 +82,6 @@ class SettingsController(UserController):
                 # It will continue reloading when CherryPy restarts.
             except formencode.Invalid as excep:
                 template_specification[common.KEY_ERRORS] = excep.unpack_errors()
-            except InvalidStorageException as excep:
-                self.logger.error('Invalid settings!  Exception %s was raised' % (str(excep)))
-                common.set_error_message(excep.message)
             except InvalidSettingsException as excep:
                 self.logger.error('Invalid settings!  Exception %s was raised' % (str(excep)))
                 common.set_error_message(excep.message)

--- a/framework_tvb/tvb/interfaces/web/controllers/settings_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/settings_controller.py
@@ -41,7 +41,7 @@ import cherrypy
 import formencode
 from formencode import validators
 from tvb.basic.profile import TvbProfile
-from tvb.core.services.exceptions import InvalidSettingsException
+from tvb.core.services.exceptions import InvalidSettingsException, InvalidStorageException
 from tvb.core.services.settings_service import SettingsService
 from tvb.core.utils import check_matlab_version
 from tvb.interfaces.web.controllers import common
@@ -83,6 +83,9 @@ class SettingsController(UserController):
                 # It will continue reloading when CherryPy restarts.
             except formencode.Invalid as excep:
                 template_specification[common.KEY_ERRORS] = excep.unpack_errors()
+            except InvalidStorageException as excep:
+                self.logger.error('Invalid settings!  Exception %s was raised' % (str(excep)))
+                common.set_error_message(excep.message)
             except InvalidSettingsException as excep:
                 self.logger.error('Invalid settings!  Exception %s was raised' % (str(excep)))
                 common.set_error_message(excep.message)

--- a/scientific_library/tvb/basic/config/settings.py
+++ b/scientific_library/tvb/basic/config/settings.py
@@ -45,7 +45,7 @@ class VersionSettings(object):
     """
 
     # Current release number
-    BASE_VERSION = "2.0.9"
+    BASE_VERSION = "2.0.10"
 
     # Current DB version. Increment this and create a new xxx_update_db.py migrate script
     DB_STRUCTURE_VERSION = 18

--- a/tvb_build/build_step1.py
+++ b/tvb_build/build_step1.py
@@ -156,7 +156,7 @@ def _copy_demos_collapsed(to_copy):
                 if not (sub_folder.startswith('.') or sub_folder.endswith(".rst")):
                     shutil.copy(src, dest)
 
-            if os.path.isdir(src) and not sub_folder.startswith('.') and not os.path.exists(dest):
+            if os.path.isdir(src) and not sub_folder.startswith('.')and not sub_folder == 'sandbox' and not os.path.exists(dest):
                 ignore_patters = shutil.ignore_patterns('.svn', '*.rst')
                 shutil.copytree(src, dest, ignore=ignore_patters)
 


### PR DESCRIPTION
This was reported by an external user.
He was trying to use TVB in `~/TVB/TVB_Distribution` folder, and also keeping the default settings for TVB.
This means that folder `~/TVB` is overwritten when TVB starts after initialization, leaving the process in a bad shape (tvb running, but python files partially removed).
With this PR we want to validate on settings page that a user can not select a non empty folder for storing TVB data