### PR TITLE
TVB-2790: Make PSE Simulations run with surfaces as gid params

### DIFF
--- a/framework_tvb/tvb/adapters/simulator/range_parameters.py
+++ b/framework_tvb/tvb/adapters/simulator/range_parameters.py
@@ -53,11 +53,9 @@ class SimulatorRangeParameters(object):
                                           Range(lo=0.01, hi=100.0, step=1.0),
                                           isinstance(Simulator.conduction_speed, NArray))
         connectivity = RangeParameter(Simulator.connectivity.field_name, Connectivity, self.connectivity_filters)
-        surface = RangeParameter(Simulator.surface.field_name, Surface, self.connectivity_filters)
 
         return OrderedDict({Simulator.conduction_speed.field_name: conduction_speed,
-                            Simulator.connectivity.field_name: connectivity,
-                            Simulator.surface.field_name: surface})
+                            Simulator.connectivity.field_name: connectivity})
 
     def _ensure_correct_prefix_for_param_name(self, prefix, param):
         prefix = prefix + '.'

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/commons/scripts/regionSelector.js
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/commons/scripts/regionSelector.js
@@ -255,6 +255,7 @@ RegionSelectComponent.prototype.selectedIndices = function(arg){
         this._set_indices(arg);
         this._dropDown.val("[]");
         this.$dom.trigger("selectionChange", [this._selectedValues.slice()]);
+
     }
 };
 


### PR DESCRIPTION
The first problem is that there should be a filter to only run the simulations with cortical surfaces.

The second and bigger problem is that the way the code is written, in _set_simulator_range_parameter uuid's are expected, but the SimulatorAdapterModel not only wants CortexViewModels, but on those we also need to set region mappings and these are required, not optional. So taking these into consideration I guess that we can't run PSE on surfaces if we didn't choose a surface at the respective fragment. Also, if we have more cortical surfaces, we will just add the same region mapping even if the dimensions don't match?

If I know how this is supposed to work, I can finish this task.