### PR TITLE
TVB-2794: Fixed the problem of the missing question marks 

### DIFF
--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/flow/generate_help_tooltip.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/flow/generate_help_tooltip.html
@@ -7,14 +7,14 @@
                 <div class="extension">
                     <div class="dropdown-pane">
                         <mark>{{ inputRow.label if 'label' in inputRow else inputRow.name }}</mark>
-                        <div class="dropdown-pane-overlay">{{ inputRow.description | replace('\n', '<br/>') | safe }}</div>
+                        <div class="dropdown-pane-overlay">{{ inputRow.description }}</div>
                     </div>
                 </div>
             </nav>
         {% endif %}
 
         {% if inputRow.get('inline_description') is not none %}
-            <nav class="inline-description">{{ inputRow.inline_description | replace('\n', '<br/>') | safe }}</nav>
+            <nav class="inline-description">{{ inputRow.inline_description }}</nav>
         {% endif %}
     {% endif %}
 {%- endmacro %}

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/form.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/form.html
@@ -4,7 +4,7 @@
         <div class="extension">
             <div class="dropdown-pane">
                 <mark>{{ field.label }}</mark>
-                <div class="dropdown-pane-overlay">{{ field.doc.replace('\n', '<br/>' )}}</div>
+                <div class="dropdown-pane-overlay">{{ field.doc }}</div>
             </div>
         </div>
     </nav>
@@ -20,7 +20,9 @@
 {% for field in adapter_form.fields %}
     <dt {% if field.label_classes %} class="{{ field.label_classes|join(' ')}}" {% endif %}>
         <label for="{{ field.name }}">{{ field.label }}</label>
-{#        {{ generate_help_tooltip(field) }}#}
+        {% if field.doc %}
+            {{ generate_help_tooltip(field) }}
+        {% endif %}
     </dt>
     <dd>
         {{ field | safe }}

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/form_field.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/form_field.html
@@ -4,7 +4,7 @@
         <div class="extension">
             <div class="dropdown-pane">
                 <mark>{{ field.label }}</mark>
-                <div class="dropdown-pane-overlay">{{ field.doc.replace('\n', '<br/>' ) }}</div>
+                <div class="dropdown-pane-overlay">{{ field.doc }}</div>
             </div>
         </div>
     </nav>
@@ -15,7 +15,9 @@
         {% for field in adapter_form.fields %}
             <dt {% if field.label_classes %} class="{{ field.label_classes|join(' ') }}" {% endif %}>
                 <label for="{{ field.name }}">{{ field.label }}</label>
-                {# {{ generate_help_tooltip(field) }}#}
+                {% if field.doc %}
+                 {{ generate_help_tooltip(field) }}
+                {% endif %}
             </dt>
             <dd>
                 {{ field | safe }}

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/spatial/spatial_fragment.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/spatial/spatial_fragment.html
@@ -5,7 +5,6 @@
             {% for field in adapter_form.fields %}
                 <dt {% if field.label_classes %} class="{{ field.label_classes|join(' ') }}" {% endif %}>
                     <label for="{{ field.name }}">{{ field.label }}</label>
-                    {#        {{ generate_help_tooltip(field) }}#}
                 </dt>
                 <dd>
                     {{ field | safe }}


### PR DESCRIPTION
In the old version there were question marks all over the Simulator Cockpit page, but in the current version we don't have docs there, so of course we won't have the question marks either. The rest seems pretty much the same now. Also, that replacement of '\\n' to '\<br/>' was faulty (the \<br/> tags were appearing as part of the doc string) and not needed anyway.