### PR TITLE
TVB-2754: Fix issue with Topographic Visualizer

### DIFF
--- a/framework_tvb/tvb/adapters/visualizers/topographic.py
+++ b/framework_tvb/tvb/adapters/visualizers/topographic.py
@@ -277,7 +277,8 @@ class TopographicViewer(ABCDisplayer):
         for i, array_data in enumerate(arrays):
             try:
                 data_array = TopographyCalculations.compute_topography_data(array_data, sensor_locations)
-                if h5.load_from_index(connectivities_idx[0]).region_labels[0][0] == 'r':
+                first_label = h5.load_from_index(connectivities_idx[0]).region_labels[0]
+                if first_label.lower().startswith('r'):
                     data_array = numpy.rot90(data_array, k=1, axes=(0, 1))
                 else:
                     data_array = numpy.rot90(data_array, k=-1, axes=(0, 1))

--- a/framework_tvb/tvb/adapters/visualizers/topographic.py
+++ b/framework_tvb/tvb/adapters/visualizers/topographic.py
@@ -277,7 +277,10 @@ class TopographicViewer(ABCDisplayer):
         for i, array_data in enumerate(arrays):
             try:
                 data_array = TopographyCalculations.compute_topography_data(array_data, sensor_locations)
-                data_array = numpy.rot90(data_array, k=1, axes=(0, 1))
+                if h5.load_from_index(connectivities_idx[0]).region_labels[0][0] == 'r':
+                    data_array = numpy.rot90(data_array, k=1, axes=(0, 1))
+                else:
+                    data_array = numpy.rot90(data_array, k=-1, axes=(0, 1))
                 if numpy.any(numpy.isnan(array_data)):
                     titles[i] = titles[i] + " - Topography contains nan"
                 if not numpy.any(array_data):

--- a/framework_tvb/tvb/adapters/visualizers/topographic.py
+++ b/framework_tvb/tvb/adapters/visualizers/topographic.py
@@ -277,6 +277,7 @@ class TopographicViewer(ABCDisplayer):
         for i, array_data in enumerate(arrays):
             try:
                 data_array = TopographyCalculations.compute_topography_data(array_data, sensor_locations)
+                data_array = numpy.rot90(data_array, k=1, axes=(0, 1))
                 if numpy.any(numpy.isnan(array_data)):
                     titles[i] = titles[i] + " - Topography contains nan"
                 if not numpy.any(array_data):


### PR DESCRIPTION
The positions of the ears and nose  are hardcoded (section_visualizers.css lines 178-203). I thought not to mess with the css and try to rotate the matrix of values correctly. 

Paula gave me this idea to take a connectivity and hardcode 0s to the first 38 regions and 1 to the other 1 and this is how I reproduced the issue. The 1s are red, the 0s are white. I tried it out with 4 different connectivities and every time in the region_labels attribute the first half of the values where the right hemisphere nodes and then came the ones from the left hemisphere, but then there is an ordered_labels param where it is vice-versa. So this is why I think a right rotation of the matrix would solve the problem but I'm more than 50% sure that there could be some other cases as well, which I didn't find yet.