### PR TITLE
TVB-2781: Refactored a little the way we check for datatype references

### DIFF
--- a/framework_tvb/tvb/adapters/uploaders/tvb_importer.py
+++ b/framework_tvb/tvb/adapters/uploaders/tvb_importer.py
@@ -129,6 +129,7 @@ class TVBImporter(ABCUploader):
                     datatype = None
                     try:
                         datatype = service.load_datatype_from_file(view_model.data_file, self.operation_id)
+                        service.check_import_references(view_model.data_file, datatype)
                         service.store_datatype(datatype, view_model.data_file)
                         self.nr_of_datatypes += 1
                     except ImportException as excep:


### PR DESCRIPTION
Before we closed the previous PR for this task I was concentrated on getting this right for project imports but the changes affected the testing for singular files. Now both scenarios work fine.