### PR TITLE
TVB-2754: Use hemispheres instead of region labels to determine the direction of rotation.

### DIFF
--- a/framework_tvb/tvb/adapters/visualizers/topographic.py
+++ b/framework_tvb/tvb/adapters/visualizers/topographic.py
@@ -277,8 +277,10 @@ class TopographicViewer(ABCDisplayer):
         for i, array_data in enumerate(arrays):
             try:
                 data_array = TopographyCalculations.compute_topography_data(array_data, sensor_locations)
-                first_label = h5.load_from_index(connectivities_idx[0]).region_labels[0]
-                if first_label.lower().startswith('r'):
+
+                # We always access the first element because only one connectivity can be used at one time
+                first_label = h5.load_from_index(connectivities_idx[0]).hemispheres[0]
+                if first_label:
                     data_array = numpy.rot90(data_array, k=1, axes=(0, 1))
                 else:
                     data_array = numpy.rot90(data_array, k=-1, axes=(0, 1))


### PR DESCRIPTION
@liadomide I added your suggestions.