### PR TITLE
Issue encountered using stimulator on a neural fields model

### DIFF
--- a/scientific_library/tvb/simulator/simulator.py
+++ b/scientific_library/tvb/simulator/simulator.py
@@ -275,8 +275,6 @@ class Simulator(HasTraits):
                 new_parameters = region_parameters.reshape(spatial_reshape)
                 setattr(self.model, param, new_parameters)
         # Configure spatial component of any stimuli
-        # TODO FIXME here region_mapping should be specified
-        # to also include the subcortical regions
         self._configure_stimuli()
         # Set delays, provided in physical units, in integration steps.
         self.connectivity.set_idelays(self.integrator.dt)
@@ -547,8 +545,8 @@ class Simulator(HasTraits):
         """ Configure the defined Stimuli for this Simulator """
         if self.stimulus is not None:
             if self.surface:
-                # TODO FIXME the region mapping should be changed to one including also the subcortical areas
-                self.stimulus.configure_space(self.surface.region_mapping)
+                # NOTE the region mapping of the stimuli should also include the subcortical areas
+                self.stimulus.configure_space(region_mapping=numpy.r_[self.surface.region_mapping, self.connectivity.unmapped_indices(self.surface.region_mapping)])
             else:
                 self.stimulus.configure_space()
 

--- a/scientific_library/tvb/simulator/simulator.py
+++ b/scientific_library/tvb/simulator/simulator.py
@@ -275,6 +275,8 @@ class Simulator(HasTraits):
                 new_parameters = region_parameters.reshape(spatial_reshape)
                 setattr(self.model, param, new_parameters)
         # Configure spatial component of any stimuli
+        # TODO FIXME here region_mapping should be specified
+        # to also include the subcortical regions
         self._configure_stimuli()
         # Set delays, provided in physical units, in integration steps.
         self.connectivity.set_idelays(self.integrator.dt)
@@ -545,6 +547,7 @@ class Simulator(HasTraits):
         """ Configure the defined Stimuli for this Simulator """
         if self.stimulus is not None:
             if self.surface:
+                # TODO FIXME the region mapping should be changed to one including also the subcortical areas
                 self.stimulus.configure_space(self.surface.region_mapping)
             else:
                 self.stimulus.configure_space()

--- a/scientific_library/tvb/tests/library/simulator/stimulation_test.py
+++ b/scientific_library/tvb/tests/library/simulator/stimulation_test.py
@@ -1,0 +1,75 @@
+"""
+Tests stimulation when sub-cortical regions are present (in the connectivity matrix).
+
+.. moduleauthor:: Borana Dollomaja <borana.dollomaja@univ-amu.fr>
+"""
+import pytest
+import numpy
+import time
+# import TVB modules
+from tvb.simulator.lab import *
+from tvb.basic.neotraits.api import List
+from tvb.tests.library.base_testcase import BaseTestCase
+
+class PulseStimulation(object):
+    """
+    Stimulus test class
+    """
+    def __init__(self, con):
+        # Configure stimulus spatial pattern.
+        stim_node = [0] # target zone where we want to stimulate
+        stim_weights = numpy.zeros((con.number_of_regions, ))
+        stim_weights[stim_node] = numpy.array([2.0])
+
+        # Configure stimulus temporal profile.
+        eqn_t = equations.PulseTrain()
+        eqn_t.parameters['onset'] = 2e3       # onset time [ms]
+        eqn_t.parameters['T'] = 3000.0        # pulse repetition period [ms]
+        eqn_t.parameters['tau'] = 100.0       # pulse duration [ms]
+
+        # Configure Stimuli object.
+        self.stimulus = patterns.StimuliRegion(temporal = eqn_t,
+                                        connectivity = con, 
+                                        weight =stim_weights)
+
+class SetUpSimulator(object):
+    """
+    Stimulation test class
+    """
+    def __init__(self):
+        """
+        Initialize the structural information, coupling function, integrator, monitors, surface and stimulation.
+        """
+        # Connectome
+        con = connectivity.Connectivity.from_file("connectivity_192.zip")
+        con.configure()
+
+        # Surface and local connectivity kernel
+        surf = cortex.Cortex.from_file() #Initialise a surface
+        surf.local_connectivity = local_connectivity.LocalConnectivity.from_file()
+        surf.configure()
+
+        # Model
+        oscilator = models.Generic2dOscillator()
+
+        self.sim = simulator.Simulator(
+            conduction_speed=1.0,
+            coupling= coupling.Difference(a=numpy.array([0.01])),
+            surface=surf,
+            stimulus=PulseStimulation(con).stimulus,
+            integrator=integrators.Identity(dt=1.0),
+            simulation_length=10.0,
+            connectivity=con,
+            model=oscilator,
+            monitors=(monitors.Raw(),)
+        )
+        self.sim.configure()
+
+    def run_simulation(self):
+        return self.sim.run(simulation_length = 10)
+
+class TestStimulation(BaseTestCase):
+    def test_stimulation(self):
+        model = SetUpSimulator()
+        result = model.run_simulation()
+        assert result is not None


### PR DESCRIPTION
During the configuration of the simulator, the region mapping that the stimulator uses does not take into account the subcortical regions. Indeed, this is due to the fact that the stimulator uses a region mapping provided by the surface data, which only contains the cortical areas. This issue can be solved easily by specifying explicitly the region mapping the stimulator should use, but this is not user-friendly. 