### PR TITLE
TVB-2792: Solve some problems regarding PSE Viewers

### DIFF
--- a/framework_tvb/tvb/interfaces/web/static/js/bursts.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/bursts.js
@@ -382,7 +382,8 @@ function _computeRangeNumberForParamPrefix(prefix){
         return _getRangeValueForGuidParameter(pse_param_guid);
     }
 
-    return 1;
+    // We don't have a value chosen for this range param
+    return 0;
 }
 
 function _displayPseSimulationMessage() {
@@ -393,6 +394,19 @@ function _displayPseSimulationMessage() {
     pse_param2_number = _computeRangeNumberForParamPrefix('pse_param2');
 
     let nrOps = pse_param1_number * pse_param2_number;
+
+    // Only the first range been chosen
+    if(nrOps == 0){
+        nrOps = pse_param1_number;
+    }else{
+        if(pse_param1_number == 1 || pse_param2_number == 1){
+            message = "Can't launch PSE when one of the parameters has only one value," +
+                " instead of a range of values!";
+            displayMessage(message, "errorMessage");
+            throw message;
+        }
+    }
+
     let className = "infoMessage";
 
     if (nrOps > THREASHOLD_WARNING) {
@@ -404,6 +418,10 @@ function _displayPseSimulationMessage() {
     if (nrOps > 1) {
         // Unless greater than 1, it is not a range, so do not display a possible confusing message.
         displayMessage("Range configuration: " + nrOps + " operations.", className);
+    }else{
+        message = "Can't launch PSE with only one  operation!"
+        displayMessage(message, "errorMessage");
+        throw message;
     }
 }
 


### PR DESCRIPTION
I explained why I did what I did more detailed here: https://req.thevirtualbrain.org/browse/TVB-2792

Shortly:
1) I don't think it makes sence to launch a PSE with only one operation. Neither Visualizer will work on it. To solve this, I chose to not launch a PSE simulation and display a message from JS.
2) There are some JS errors in the Isocline Viewer when one of the two range params have only one value. I chose to add an extra param in the database which will tell us wether we display the Isocline Viewer or not.

If the solution gets accepted, I will extend the migration code with this extra db param as well.