### PR TITLE
Docs website design update

### DIFF
--- a/tvb_documentation/_static/tvb_design/base.css
+++ b/tvb_documentation/_static/tvb_design/base.css
@@ -1,6 +1,6 @@
 /* -------------------------------------------- */
 /* The Virtual Brain: DOCS website */
-/* Version: 6 */
+/* Version: 7 */
 /* -------------------------------------------- */
 /* Created by @twotribes, Germany */
 /* -------------------------------------------- */
@@ -862,25 +862,11 @@ body div.document ul {
     padding-left: 0;
 }
 
-/*
-body div.document ol {
-    counter-reset: li;
-}
-*/
-
 body div.document ul li {
     list-style: none;
     position: relative;
     padding-left: 15px;
 }
-
-/*
-body div.document ol li {
-    list-style: none;
-    position: relative;
-    padding-left: 20px;
-}
-*/
 
 body div.document ul li:before {
     content: "";
@@ -894,21 +880,11 @@ body div.document ul li:before {
     background-color: #627986;
 }
 
-/*
-body div.document ol li:before {
-    position: absolute;
-    content: counter(li) ".";
-    counter-increment: li;
-    top: -1px;
-    left: 0px;
-    height: 22px;
-    width: 22px;
-    border: none;
+body div.document ol li::marker {
+    font-family: "StandardCT", Helvetica, Arial, sans-serif;
     font-weight: bold;
-    line-height: 22px;
     color: #627986;
 }
-*/
 
 /* !-------------------------------------------- */
 /* !COMPONENT: Tables */
@@ -939,13 +915,18 @@ body div.document table.indextable td {
 }
 
 /* Modules index */
+body div.document table.indextable.modindextable tr.cap {
+    background: #627986;
+}
+
+
 body div.document table.indextable.modindextable td {
     padding-top: 5px;
 }
 
 body div.document table.indextable.modindextable strong {
     font-size: 18px;
-    color: #627986;
+    color: #fff;
 }
 
 /* Internal dl structures */

--- a/tvb_documentation/_templates/layout.html
+++ b/tvb_documentation/_templates/layout.html
@@ -16,7 +16,7 @@
 {% block relbar1 %}
 
 <div id="tvb_header">
-    <a class="header-logo" href="http://www.thevirtualbrain.org/" title="Visit The Virtual Brain main website…" target="_blank">
+    <a class="header-logo" href="{{ pathto('index') }}" title="Back to documentation homepage…">
         <img src="{{ pathto('_static/tvb_design/logo_tvb_main.svg', 1) }}" alt="The Virtual Brain logo"/>
     </a>
     

--- a/tvb_documentation/index.rst
+++ b/tvb_documentation/index.rst
@@ -23,21 +23,40 @@
 
 .. include:: /manuals/UserGuide/UserGuide-Overview.rst
 
-Download
---------
+Helpful external resources
+--------------------------
 
-To download it, check out the |download_site|.
+The **TVB main website** on `www.thevirtualbrain.org <https://www.thevirtualbrain.org/>`_ contains a lot of helpful resources:
 
-To get in touch with other users and developers, please head over to the |mailing_list|.
 
-Some more documents and artefacts for TVB can be found in this |sharing_area|
-(e.g. documentation from TVB Node# meetings, some team pictures).
+* `Download <https://www.thevirtualbrain.org/tvb/zwei/brainsimulator-software>`_ **TVB software packages** for macOS, Windows and Linux.
+* `Learn <https://www.thevirtualbrain.org/tvb/zwei/neuroscience-simulation>`_ about the **scientific background and clinical applications** of TVB.
+* `Read <https://www.thevirtualbrain.org/tvb/zwei/newswire-blog>`_ the **TVB blog** about the latest news and achievements.
+* `Follow <https://www.thevirtualbrain.org/tvb/zwei/newswire-event>`_ international **TVB events** to meet other developers and scientists working with TVB.
+
+
+If you're familiar with Docker and/or Python environments, you can try early releases of the TVB software:
+
+
+* We publish **Docker containers** on the `TVB DockerHub <https://hub.docker.com/u/thevirtualbrain>`_.
+* We publish **Python packages** on the `TVB PyPI profile <https://pypi.org/user/tvb/>`_.
+
+
+These versions of TVB are updated more frequently and contain all the latest new features and bugfixes. You can follow all the latest changes on our |our_github| page.
+
+
+If you have specific questions, also about how to use TVB for your current research activity, you can use our `public discussion forum <https://groups.google.com/g/tvb-users>`_, which doubles as a *mailing list* if you prefer this channel.
+
+
+In this forum, you can meet and discuss with other TVB users, as well as experts from our own support team. It's a perfect place to ask things like *"Does anyone else see that both the EEG and the BOLD have similar shape in terms of the 1/f type of drop off towards the higher frequency range?"*.
+
+
 
 We are grateful to
 ------------------
 
  - our contributors (check their names on |our_github|)
- - our sponsors (check their names on the |our_sponsors_page|
+ - our sponsors (check their names on the |our_sponsors_page|)
  - all |third_party| tools that we used (licenses are also included in TVB_Distribution)
  - JetBrains for |pycharm_ide|
  - |jenkins| team for their continuous integration tool
@@ -57,46 +76,31 @@ We are grateful to
         :height: 64px
 
 
-.. |download_site| raw:: html
-
-   <a href="http://www.thevirtualbrain.org/tvb/zwei/brainsimulator-software" target="_blank">TVB download site</a>
-
-
 .. |our_sponsors_page| raw:: html
 
-    <a href="http://www.thevirtualbrain.org/tvb/zwei/teamwork-sponsors" target="_blank"> our sponsors page </a>
-
-
-.. |mailing_list| raw:: html
-
-   <a href="https://groups.google.com/forum/#!forum/tvb-users" target="_blank">mailing list</a>
-
-
-.. |sharing_area| raw:: html
-
-    <a href="http://www.thevirtualbrain.org/tvb/zwei/client-area/public" target="_blank">share area</a>
+    <a href="http://www.thevirtualbrain.org/tvb/zwei/teamwork-sponsors" target="_blank">our sponsors page</a>
 
 
 .. |our_github| raw:: html
 
-   <a href="https://github.com/the-virtual-brain" target="_blank"> GitHub </a>
+   <a href="https://github.com/the-virtual-brain" target="_blank">GitHub</a>
 
 
 .. |third_party| raw:: html
 
-   <a href="http://www.thevirtualbrain.org/tvb/zwei/brainsimulator-requirements" target="_blank"> 3rd party </a>
+   <a href="http://www.thevirtualbrain.org/tvb/zwei/brainsimulator-requirements" target="_blank">3rd party</a>
 
 
 .. |pycharm_ide| raw:: html
 
-    <a href="https://www.jetbrains.com/pycharm/" target="_blank"> PyCharm IDE </a>
+    <a href="https://www.jetbrains.com/pycharm/" target="_blank">PyCharm IDE</a>
 
 
 .. |jenkins| raw:: html
 
-    <a href="https://www.jenkins.io/" target="_blank"> Jenkins </a>
+    <a href="https://www.jenkins.io/" target="_blank">Jenkins</a>
 
 
 .. |jira| raw:: html
 
-    <a href="https://www.atlassian.com/software/jira" target="_blank"> Jira </a>
+    <a href="https://www.atlassian.com/software/jira" target="_blank">Jira</a>

--- a/tvb_documentation/manuals/ContributorsManual/ContributorsManual.rst
+++ b/tvb_documentation/manuals/ContributorsManual/ContributorsManual.rst
@@ -8,25 +8,26 @@
    <a href="http://req.thevirtualbrain.org/issues/?filter=10421" target="_blank">open issues</a>
 
 
-.. _TVB Web Page: http://www.thevirtualbrain.org
+.. _TVB website: http://www.thevirtualbrain.org
 .. _mailing list: https://groups.google.com/forum/#!forum/tvb-users
 .. _contributors_manual:
 
 TVB Contributors manual
 =======================
 
-So you want to contribute to TVB, or simply use the latest code from sources.
-We welcome contributions, or using for testing. Thank you!
+So you want to contribute to TVB or simply use the latest code from sources. We welcome contributions, or using for testing. *Thank you!*
 
-Get in touch with the |TVB| team, we are glad to help tvb.admin@thevirtualbrain.org.
-Sign up for the `mailing list`_ and introduce yourself.
+* Get in touch with the |TVB| team, we are glad to help tvb.admin@thevirtualbrain.org. Sign up for the `mailing list`_ and introduce yourself.
+* Read trough these docs. Get to know TVB by installing a TVB Distribution (from the `TVB website`_) and playing with the GUI or following tutorials first.
+* Have a look at the open tasks in our Jira |open_issues|.
+* Finally revisit this document and find out how to set up |TVB| as a developer.
 
-Read trough these docs. Get to know TVB by installing a TVB Distribution
-(from `TVB Web Page`_) and playing with the GUI or following tutorials first.
+Once your changes haven been accepted and merged into the Master branch on `github`_, you will see them first on our pre-release platforms:
 
-Have a look at the open tasks in our Jira |open_issues|.
+* *Docker containers* on the `TVB DockerHub <https://hub.docker.com/u/thevirtualbrain>`_
+* *Python packages* on the `TVB PyPI profile <https://pypi.org/user/tvb/>`_
 
-Finally revisit this document and find out how to set up |TVB| as a developer.
+The TVB Distribution packages for multiple OS platforms are on a longer release cycle.
 
 
 Source code and working environment
@@ -87,28 +88,19 @@ We recommend running tests before submitting changes that touch code that you ha
 Contribution guidelines
 -----------------------
 
-You should put explanatory comments and documentation in your code.
-Document every public function with a docstring.
-Use english for both comments and names.
-
-Avoid cryptic short names. You may relax this if implementing a mathematical formula.
-But then please document it using latex docstrings.
-
-Try to adhere to the Python code style. Indent with 4 spaces. We are ok with 120 long lines.
-Naming: module_name, ClassName, function_name, CONSTANT_NAME function_parameter_name, local_var_name
-
-You should attach unit-tests for your new code, to prove that it is correct and that it fits into the overall architecture of TVB.
-
-Prefer small commits. Add a meaningful commit message.
-We strongly recommend that the commit message start with the Jira task id. (e.g. TVB-1963 Add FCT analyser).
-
-Use logging instead of print statements.
-
-If code is indented more than 6 levels your function is too complex.
-If a function has more than 50 lines it is too long. Split these functions.
-
-Do not copy paste code.
-Avoid reinventing the wheel. Use the python built in functions, the standard library and numpy.
+* You should put explanatory comments and documentation in your code.
+* Document every public function with a docstring.
+* Use english for both comments and names.
+* Avoid cryptic short names. You may relax this if implementing a mathematical formula. But then please document it using latex docstrings.
+* Try to adhere to the Python code style. Indent with 4 spaces. We are ok with 120 long lines.
+* Naming: module_name, ClassName, function_name, CONSTANT_NAME function_parameter_name, local_var_name
+* You should attach unit-tests for your new code, to prove that it is correct and that it fits into the overall architecture of TVB.
+* Aim for small commits. Add a meaningful commit message. *We strongly recommend that the commit message start with the Jira task id. (e.g. TVB-1963 Add FCT analyser)*.
+* Use logging instead of print statements.
+* If code is indented more than 6 levels your function is too complex.
+* If a function has more than 50 lines it is too long. Split these functions.
+* Do not copy/paste code.
+* Avoid reinventing the wheel. Use the python built in functions, the standard library and numpy.
 
 
 Git guidelines
@@ -131,22 +123,19 @@ We will later test that your changes are fit to be included, and notify you of t
 Tools
 -----
 
-We use pycharm to develop and debug TVB.
-To test quick ideas we like ipython notebooks.
+We use `pycharm` to develop and debug TVB.
+
+To test quick ideas we like `ipython` notebooks.
 
 
 Technologies used by TVB
 ------------------------
 
-TVB uses numpy extensively.
-Numpy is quite different from other python libraries.
-Learn a bit about it before trying to understand TVB code.
+TVB uses **numpy** extensively. Numpy is quite different from other python libraries. Learn a bit about it before trying to understand TVB code.
 
-The TVB framework uses sqlalchemy for ORM mapping, cherrypy as a web framework and server and jinja2 for html templating.
-Numeric arrays are stored in the hdf5 format.
-Client side we use jquery, d3 and webgl.
+The TVB framework uses **sqlalchemy** for ORM mapping, **cherrypy** as a web framework and server and **jinja2** for HTML templating. Numeric arrays are stored in the **hdf5** format. Client side we use **jQuery**, **d3** and **WebGL**.
 
-TVB uses some advanced python features to implement it's `Traits` system: metaclasses and data descriptors.
+TVB uses some advanced Python features to implement its `Traits` system: metaclasses and data descriptors.
 
 
 Glossary of terms used by TVB code

--- a/tvb_documentation/manuals/UserGuide/UserGuide-Overview.rst
+++ b/tvb_documentation/manuals/UserGuide/UserGuide-Overview.rst
@@ -9,10 +9,10 @@ brain networks. The connectivity matrix defines the connection strengths and
 time delays via signal transmission between all network nodes. Various neural
 mass models are available in the repertoire of |TVB| and define the dynamics of
 a network node.  Together, the neural mass models at the network nodes and the
-connectivity matrix define **the Virtual Brain**. |TVB| simulates and generates
-the time courses of various forms of neural activity including Local Field
-Potentials (LFP) and firing rate, as well as brain imaging data such as
-EEG, MEG and BOLD activations as observed in fMRI.
+connectivity matrix define **the Virtual Brain**.
+
+
+|TVB| simulates and generates the time courses of various forms of neural activity including Local Field Potentials (LFP) and firing rate, as well as brain imaging data such as EEG, MEG and BOLD activations as observed in fMRI.
 
 
 |TVB| is foremost a scientific simulation platform and provides all means


### PR DESCRIPTION
We've harmonized the backlinks to the TVB main website. Especially the TVB logo in the header now links back to the documentation website, as it's expected by almost all users.

The intro text on the homepage was updated + extended to provide more useful, deep backlinks to the main website and refer to the TVB platforms on DockerHub and PyPI.

Light reformatting was done to the Contributor's Manual lead page.

CSS now catches ordered lists and separator bars for the Module list.