### PR TITLE
Fix import of dt groups exported from TVB

### DIFF
--- a/framework_tvb/tvb/core/entities/storage/operation_dao.py
+++ b/framework_tvb/tvb/core/entities/storage/operation_dao.py
@@ -423,6 +423,14 @@ class OperationDAO(RootDAO):
     # ALGORITHM RELATED METHODS
     #
 
+    def get_all_algorithms(self):
+        try:
+            result = self.session.query(Algorithm).distinct().all()
+            return result
+        except SQLAlchemyError as ex:
+            self.logger.exception(ex)
+            return None
+
     def get_algorithm_by_id(self, algorithm_id):
         try:
             result = self.session.query(Algorithm).filter_by(id=algorithm_id).one()


### PR DESCRIPTION
As importers are now launched in a separate process, the import_service called by TVBImporter won't be able to access the VIEW_MODEL2ADAPTER we populate in the initializer.  