### PR TITLE
WIP TVB-2757: Add runtime filters for linked datatypes

### DIFF
--- a/framework_tvb/tvb/core/neotraits/forms.py
+++ b/framework_tvb/tvb/core/neotraits/forms.py
@@ -140,7 +140,7 @@ class TraitDataTypeSelectField(TraitField):
     template = 'form_fields/datatype_select_field.html'
     missing_value = 'explicit-None-value'
 
-    def __init__(self, trait_attribute, name=None, conditions=None,
+    def __init__(self, trait_attribute, name=None, conditions=None, runtime_conditions=None,
                  draw_dynamic_conditions_buttons=True, has_all_option=False,
                  show_only_all_option=False):
         super(TraitDataTypeSelectField, self).__init__(trait_attribute, name)
@@ -155,6 +155,7 @@ class TraitDataTypeSelectField(TraitField):
         else:
             self.datatype_index = REGISTRY.get_index_for_datatype(type_to_query)
         self.conditions = conditions
+        self.runtime_conditions = runtime_conditions
         self.draw_dynamic_conditions_buttons = draw_dynamic_conditions_buttons
         self.has_all_option = has_all_option
         self.show_only_all_option = show_only_all_option
@@ -173,6 +174,10 @@ class TraitDataTypeSelectField(TraitField):
     @property
     def get_form_filters(self):
         return self.conditions
+
+    @property
+    def get_runtime_filters(self):
+        return self.runtime_conditions
 
     def options(self):
         if not self.required:

--- a/framework_tvb/tvb/interfaces/web/controllers/flow_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/flow_controller.py
@@ -50,6 +50,7 @@ from tvb.core.adapters.exceptions import LaunchException
 from tvb.core.entities.file.files_helper import FilesHelper
 from tvb.core.entities.filters.chain import FilterChain
 from tvb.core.entities.load import load_entity_by_gid
+from tvb.core.entities.storage import dao
 from tvb.core.neocom import h5
 from tvb.core.neocom.h5 import REGISTRY
 from tvb.core.neotraits.forms import TraitDataTypeSelectField
@@ -266,6 +267,11 @@ class FlowController(BaseController):
         values = []
 
         for idx in range(len(filters_dict['fields'])):
+            if filters_dict['field_current_gids'][idx] is not None:
+                datatype_index = dao.get_datatype_by_gid(filters_dict['field_current_gids'][idx])
+                compare_to_value = getattr(datatype_index, filters_dict['field_names'][idx])
+                filters_dict['values'][idx] = compare_to_value
+
             fields.append(filters_dict['fields'][idx])
             operations.append(filters_dict['operations'][idx])
             values.append(filters_dict['values'][idx])

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/datatype_select_field.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/datatype_select_field.html
@@ -1,13 +1,16 @@
 <p class="field-data">
-<select name="{{ field.name }}" id="{{ field.name }}" class="dataset-selector" tabindex="1" title="Fully Loaded!">
+<select name="{{ field.name }}" id="{{ field.name }}" class="dataset-selector" tabindex="1" title="Fully Loaded!"
+onchange="applyRuntimeFilters(this.value, '{{ field.name }}' + 'data_select',
+ '{{ field.name }}')">
 {% for option in field.options() %}
     <option value="{{ option.value }}" {{ 'selected' if option.checked }} class="form-control">{{ option.label }}</option>
 {% endfor %}
 </select>
 {% if field.draw_dynamic_conditions_buttons %}
     <div class="field-adapters" id="{{ field.name }}data_select">
-        <input type="button" tabindex='1' value="Add Filter" onclick="addFilter('{{ field.name }}' + 'data_select', {{ field.get_dynamic_filters }})">
-        <input type="button" tabindex='1' value="Apply Filters" onclick="applyFilters('{{ (field.datatype_index | string)[8:-2] }}', '{{ field.name }}' + 'data_select', '{{ field.name }}')">
+        <input type="button" tabindex='1' value="Add Filter" onclick="addFilter('{{ field.name }}' + 'data_select',
+         {{ field.get_dynamic_filters }})">
+        <input type="button" tabindex='1' value="Apply Filters" onclick="applyUserFilters('{{ (field.datatype_index | string)[8:-2] }}', '{{ field.name }}' + 'data_select', '{{ field.name }}')">
 
         {% with %}
             {% set form_filters = field.get_form_filters %}
@@ -21,6 +24,21 @@
                 </div>
 
             {% endfor %}
+
+            {% set runtime_filters = field.get_runtime_filters %}
+
+            {% if runtime_filters %}
+                {% for key, value in runtime_filters.items() %}
+                    <div class='{{ key }}_runtime_trigger'>
+
+                    {% for idx in range(value.fields | length) %}
+                        <input type="hidden" value='{{ value.fields[idx] }}'>
+                        <input type="hidden" value='{{ value.operations[idx] }}'>
+                        <input type="hidden" value='{{ value.values[idx] }}'>
+                    {% endfor %}
+                    </div>
+                {% endfor %}
+            {% endif %}
         {% endwith %}
     </div>
 {% endif %}

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/datatype_select_field.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/form_fields/datatype_select_field.html
@@ -32,8 +32,9 @@ onchange="applyRuntimeFilters(this.value, '{{ field.name }}' + 'data_select',
                     <div class='{{ key }}_runtime_trigger'>
 
                     {% for idx in range(value.fields | length) %}
-                        <input type="hidden" value='{{ value.fields[idx] }}'>
-                        <input type="hidden" value='{{ value.operations[idx] }}'>
+                        <label></label>
+                        <select hidden><option value='{{ value.fields[idx] }}'></option></select>
+                        <select hidden><option value='{{ value.operations[idx] }}'></option></select>
                         <input type="hidden" value='{{ value.values[idx] }}'>
                     {% endfor %}
                     </div>


### PR DESCRIPTION
I wrote an incomplete solution for this task trying to build on what we already had with the user defined filters. So we can say that there are 3 types of filters:
1) "Implied filters" which are written in the code and can't be changed
2) User defined filters (added and applied by the users through the UI)
3) Runtime filters (where the value of the filter depends on some other value(s) from the UI)

We handled the second type of filters in TVB-2428: https://github.com/the-virtual-brain/tvb-root/pull/189. To apply both 1) and 2) filters there we added the 1) filters in the same HTML structure as the 2) filters as hidden fields so they can be handled in the same way. When the user hit the apply button the list of fields, operations and values was sent through an Ajax call to get_filtered_datatypes. There a new select field is created with the new conditions and then when we get back to JS, the field is redrawn by applying both types of filters.

For the runtime filters we have two types of fields, which I like to call the trigger fields and the triggered fields. A change of the value of a trigger field would mean that the possible values of the corresponding triggered field(s) should change. For example in the Connectivity Viewer if we change the connectivity then the node colors and the shapes diemnsions (which are ConnecitvityMeasures) should change such as their fk_connectivity_gid value should be equal to the gid of the chosen connectivity. 

The big problem is that there are more complicated filters. For example, in the Connectivity Annotations Viewer page the change in the Ontology Annotations field should mean the connectivity values are changed and then based on the connectivity values the region mapping should change too + if you choose a connectivity and no region mapping, the viewer launching fails. Here you change the onthology but the connectivity doesn't have an "fk_onthology_gid" field, it's vice versa. 

So what I tried to do for runtime filters is to return a dict where the key will be part of the div's class in HTML and it will give information about how to apply the filter and the value is the FilterChain object. Since the value part of the FilterChain will be replaced at runtime, I used it to store the index class of the select field that the filter should be applied on. 

Another problem is that the runtime and user defined filters should be applied at the same time, which currently would not work for every situation. Also let's say we add a user filter, then we trigger a runtime filter... should the user filter be applied as well even if the user did not press the apply button. If not, then what happens? Let's say we applied the filter and then we trigger a runtime filter, should the effect of the applied user filter stay or dissappear and would reappear only if pressed again?

My partial solution I think is too complicated but it shows us the things that we need to think about when solving this task and it could be a starting point to something simpler.