### PR TITLE
TVB-2855: Fixed Tracts Importers and Visualizer

### DIFF
--- a/framework_tvb/tvb/adapters/datatypes/h5/region_mapping_h5.py
+++ b/framework_tvb/tvb/adapters/datatypes/h5/region_mapping_h5.py
@@ -61,3 +61,15 @@ class RegionVolumeMappingH5(VolumetricDataMixin, DataTypeMatrixH5):
         self.array_data = DataSet(RegionVolumeMapping.array_data, self)
         self.connectivity = Reference(RegionVolumeMapping.connectivity, self)
         self.volume = Reference(RegionVolumeMapping.volume, self)
+
+    def read_data_shape(self):
+        """
+        The shape of the data
+        """
+        return self.array_data.shape
+
+    def read_data_slice(self, data_slice):
+        """
+        Expose chunked-data access.
+        """
+        return self.array_data[data_slice]

--- a/framework_tvb/tvb/adapters/datatypes/h5/tracts_h5.py
+++ b/framework_tvb/tvb/adapters/datatypes/h5/tracts_h5.py
@@ -49,7 +49,6 @@ class TractsH5(H5File):
         start, end = self.tract_start_idx[i:i + 2]
         return self.vertices[start:end]
 
-    # fixme: these are broken, they have to live at a higher level
     def _get_tract_ids(self, region_id):
         tract_ids = numpy.where(self.tract_region.load() == region_id)[0]
         return tract_ids
@@ -76,7 +75,7 @@ class TractsH5(H5File):
             track_len = end - start
 
             if track_len >= self.MAX_N_VERTICES:
-                raise ValueError('cannot yet handle very long tracts')
+                raise ValueError('Currently tracts are too long to be handled!')
 
             count += track_len
 
@@ -92,11 +91,6 @@ class TractsH5(H5File):
 
         if chunk:
             tract_id_chunks.append(chunk)
-
-        # q = []
-        # for a in tract_id_chunks:
-        #     q.extend(a)
-        # assert (numpy.array(q) == tract_ids).all()
 
         return tract_id_chunks
 
@@ -153,5 +147,3 @@ class TractsH5(H5File):
         Append a new value to the ``vertices`` attribute.
         """
         self.vertices.append(partial_result)
-
-

--- a/framework_tvb/tvb/adapters/uploaders/tract_importer.py
+++ b/framework_tvb/tvb/adapters/uploaders/tract_importer.py
@@ -233,8 +233,8 @@ class TrackvizTractsImporter(_TrackImporterBase):
             datatype.vertices = vox2ras.transform(vertices)
             tracts_h5.write_vertices_slice(datatype.vertices)
 
-        datatype.tract_start_idx = numpy.array(tract_start_indices, dtype=numpy.int16)
-        datatype.tract_region = numpy.array(tract_region, dtype=numpy.int16)
+        datatype.tract_start_idx = numpy.array(tract_start_indices)
+        datatype.tract_region = numpy.array(tract_region)
 
         tracts_index = TractsIndex()
         tracts_index.fill_from_has_traits(datatype)
@@ -281,5 +281,5 @@ class ZipTxtTractsImporter(_TrackImporterBase):
                 vertices_file.close()
 
         datatype.tract_start_idx = tract_start_indices
-        datatype.tract_region = numpy.array(tract_region, dtype=numpy.int16)
+        datatype.tract_region = numpy.array(tract_region)
         return datatype

--- a/framework_tvb/tvb/adapters/uploaders/tract_importer.py
+++ b/framework_tvb/tvb/adapters/uploaders/tract_importer.py
@@ -161,11 +161,7 @@ class _TrackImporterBase(ABCUploader, metaclass=ABCMeta):
 
             region_volume = h5.load_from_index(rvm_index)
 
-            # this is called here and not in _get_tract_region because it goes to disk to get this info
-            # which would massively dominate the runtime of the import
-
         datatype = Tracts()
-        datatype.storage_path = self.storage_path
         datatype.region_volume_map = region_volume
         return datatype
 

--- a/framework_tvb/tvb/adapters/uploaders/tract_importer.py
+++ b/framework_tvb/tvb/adapters/uploaders/tract_importer.py
@@ -230,7 +230,7 @@ class TrackvizTractsImporter(_TrackImporterBase):
             tracts_h5.write_vertices_slice(datatype.vertices)
 
         datatype.tract_start_idx = numpy.array(tract_start_indices)
-        datatype.tract_region = numpy.array(tract_region)
+        datatype.tract_region = numpy.array(tract_region, dtype=numpy.int16)
 
         tracts_index = TractsIndex()
         tracts_index.fill_from_has_traits(datatype)

--- a/framework_tvb/tvb/adapters/uploaders/tract_importer.py
+++ b/framework_tvb/tvb/adapters/uploaders/tract_importer.py
@@ -126,7 +126,7 @@ class _TrackImporterBase(ABCUploader, metaclass=ABCMeta):
         if not (0 <= x_plane < self.region_volume_shape[0] and
                 0 <= y_plane < self.region_volume_shape[1] and
                 0 <= z_plane < self.region_volume_shape[2]):
-            raise IndexError('vertices outside the region volume map cube')
+            raise IndexError('There are vertices outside the region volume map cube!')
 
         # in memory data set
         if self.full_rmap_cache is not None:
@@ -149,7 +149,7 @@ class _TrackImporterBase(ABCUploader, metaclass=ABCMeta):
 
     def _base_before_launch(self, data_file, region_volume):
         if data_file is None:
-            raise LaunchException("Please select a file to import")
+            raise LaunchException("Please select a file to import!")
 
         if region_volume is not None:
             rvm_index = dao.get_datatype_by_gid(region_volume.hex)

--- a/framework_tvb/tvb/adapters/uploaders/tract_importer.py
+++ b/framework_tvb/tvb/adapters/uploaders/tract_importer.py
@@ -31,24 +31,25 @@
 """
 .. moduleauthor:: Mihai Andrei <mihai.andrei@codemart.ro>
 """
-import numpy
 from abc import ABCMeta
+
+import numpy
 from nibabel import trackvis
+from tvb.adapters.datatypes.db.tracts import TractsIndex
 from tvb.adapters.datatypes.h5.region_mapping_h5 import RegionVolumeMappingH5
 from tvb.adapters.datatypes.h5.tracts_h5 import TractsH5
 from tvb.core.adapters.abcuploader import ABCUploader, ABCUploaderForm
 from tvb.core.adapters.exceptions import LaunchException
 from tvb.core.entities.file.files_helper import TvbZip
-from tvb.adapters.datatypes.db.tracts import TractsIndex
 from tvb.core.entities.generic_attributes import GenericAttributes
 from tvb.core.entities.storage import transactional, dao
 from tvb.core.neocom import h5
 from tvb.core.neocom.h5 import path_for
+from tvb.core.neotraits.forms import TraitUploadField, TraitDataTypeSelectField
 from tvb.core.neotraits.uploader_view_model import UploaderViewModel
 from tvb.core.neotraits.view_model import Str, DataTypeGidAttr
 from tvb.datatypes.region_mapping import RegionVolumeMapping
 from tvb.datatypes.tracts import Tracts
-from tvb.core.neotraits.forms import TraitUploadField, TraitDataTypeSelectField
 
 
 def chunk_iter(iterable, n):
@@ -277,5 +278,5 @@ class ZipTxtTractsImporter(_TrackImporterBase):
                 vertices_file.close()
 
         datatype.tract_start_idx = tract_start_indices
-        datatype.tract_region = numpy.array(tract_region)
+        datatype.tract_region = numpy.array(tract_region, dtype=numpy.int16)
         return datatype

--- a/framework_tvb/tvb/adapters/visualizers/brain.py
+++ b/framework_tvb/tvb/adapters/visualizers/brain.py
@@ -267,7 +267,7 @@ class BrainViewer(ABCSurfaceDisplayer):
                            time=json.dumps(time_urls), minActivity=min_val, maxActivity=max_val,
                            legendLabels=legend_labels, labelsStateVar=state_variables,
                            labelsModes=list(range(time_series.data_length_4d)), extended_view=False,
-                           shelfObject=self.prepare_shell_surface_params(shell_surface, SurfaceURLGenerator),
+                           shellObject=self.prepare_shell_surface_params(shell_surface, SurfaceURLGenerator),
                            biHemispheric=self.surface_h5.bi_hemispheric.load(),
                            hemisphereChunkMask=json.dumps(hemisphere_chunk_mask),
                            pageSize=self.PAGE_SIZE, urlRegionBoundaries=boundary_url,
@@ -501,7 +501,7 @@ class DualBrainViewer(BrainViewer):
 
         if isinstance(time_series_index, TimeSeriesSEEGIndex):
             params['brainViewerTemplate'] = "internal_view.html"
-            # Mark as None since we only display shelf face and no point to load these as well
+            # Mark as None since we only display shell face and no point to load these as well
             params['urlVertices'] = None
             params['isSEEG'] = True
 

--- a/framework_tvb/tvb/adapters/visualizers/brain.py
+++ b/framework_tvb/tvb/adapters/visualizers/brain.py
@@ -35,6 +35,7 @@
 """
 
 import numpy
+
 from tvb.adapters.datatypes.h5.surface_h5 import SurfaceH5
 from tvb.adapters.visualizers.eeg_monitor import EegMonitor
 from tvb.adapters.visualizers.surface_view import ensure_shell_surface, SurfaceURLGenerator, ABCSurfaceDisplayer
@@ -42,7 +43,6 @@ from tvb.adapters.visualizers.sensors import prepare_sensors_as_measure_points_p
 from tvb.adapters.visualizers.sensors import prepare_mapped_sensors_as_measure_points_params
 from tvb.adapters.datatypes.h5.time_series_h5 import TimeSeriesH5
 from tvb.core.adapters.abcdisplayer import URLGenerator
-from tvb.core.entities.filters.chain import FilterChain
 from tvb.core.adapters.abcadapter import ABCAdapterForm
 from tvb.adapters.datatypes.db.time_series import *
 from tvb.core.entities.storage import dao
@@ -260,14 +260,6 @@ class BrainViewer(ABCSurfaceDisplayer):
             boundary_url = ''
 
         shell_surface = ensure_shell_surface(self.current_project_id, shell_surface)
-        shelf_object = None
-
-        if shell_surface:
-            with h5.h5_file_for_index(shell_surface) as shell_h5:
-                shell_vertices, shell_normals, _, shell_triangles, _ = SurfaceURLGenerator.get_urls_for_rendering(
-                    shell_h5)
-                shelf_object = json.dumps([shell_vertices, shell_normals, shell_triangles])
-
         params.update(dict(title="Cerebral Activity: " + time_series.title, isOneToOneMapping=self.one_to_one_map,
                            urlVertices=json.dumps(url_vertices), urlTriangles=json.dumps(url_triangles),
                            urlLines=json.dumps(url_lines), urlNormals=json.dumps(url_normals),
@@ -275,7 +267,7 @@ class BrainViewer(ABCSurfaceDisplayer):
                            time=json.dumps(time_urls), minActivity=min_val, maxActivity=max_val,
                            legendLabels=legend_labels, labelsStateVar=state_variables,
                            labelsModes=list(range(time_series.data_length_4d)), extended_view=False,
-                           shelfObject=shelf_object,
+                           shelfObject=self.prepare_shell_surface_params(shell_surface, SurfaceURLGenerator),
                            biHemispheric=self.surface_h5.bi_hemispheric.load(),
                            hemisphereChunkMask=json.dumps(hemisphere_chunk_mask),
                            pageSize=self.PAGE_SIZE, urlRegionBoundaries=boundary_url,

--- a/framework_tvb/tvb/adapters/visualizers/complex_imaginary_coherence.py
+++ b/framework_tvb/tvb/adapters/visualizers/complex_imaginary_coherence.py
@@ -36,6 +36,7 @@
 """
 import json
 import numpy
+
 from tvb.adapters.datatypes.db.spectral import ComplexCoherenceSpectrumIndex
 from tvb.core.adapters.abcadapter import ABCAdapterForm
 from tvb.core.adapters.abcdisplayer import ABCDisplayer, URLGenerator
@@ -93,7 +94,7 @@ class ImaginaryCoherenceDisplay(ABCDisplayer):
         """
         Return the required memory to run this algorithm.
         """
-        input_data_h5_class, input_data_h5_path = self._load_h5_of_gid(view_model.input_data.hex)
+        input_data_h5_class, input_data_h5_path = self.load_h5_of_gid(view_model.input_data.hex)
         with input_data_h5_class(input_data_h5_path) as input_data_h5:
             required_memory = numpy.prod(input_data_h5.read_data_shape()) * 8
         return required_memory
@@ -109,7 +110,7 @@ class ImaginaryCoherenceDisplay(ABCDisplayer):
         """
         self.log.debug("Plot started...")
 
-        input_data_h5_class, input_data_h5_path = self._load_h5_of_gid(view_model.input_data.hex)
+        input_data_h5_class, input_data_h5_path = self.load_h5_of_gid(view_model.input_data.hex)
         with input_data_h5_class(input_data_h5_path) as input_data_h5:
             source_gid = input_data_h5.source.load()
 

--- a/framework_tvb/tvb/adapters/visualizers/local_connectivity_view.py
+++ b/framework_tvb/tvb/adapters/visualizers/local_connectivity_view.py
@@ -33,6 +33,7 @@
 """
 
 import json
+
 from tvb.adapters.visualizers.surface_view import SurfaceURLGenerator
 from tvb.core.adapters.abcadapter import ABCAdapterForm
 from tvb.core.adapters.abcdisplayer import ABCDisplayer
@@ -101,12 +102,12 @@ class LocalConnectivityViewer(ABCDisplayer):
         params = dict(title="Local Connectivity Visualizer", extended_view=False,
                       isOneToOneMapping=False, hasRegionMap=False)
 
-        local_conn_h5_class, local_conn_h5_path = self._load_h5_of_gid(view_model.local_conn.hex)
+        local_conn_h5_class, local_conn_h5_path = self.load_h5_of_gid(view_model.local_conn.hex)
         with local_conn_h5_class(local_conn_h5_path) as local_conn_h5:
             surface_gid = local_conn_h5.surface.load().hex
             min_value, max_value = local_conn_h5.get_min_max_values()
 
-        surface_h5_class, surface_h5_path = self._load_h5_of_gid(surface_gid)
+        surface_h5_class, surface_h5_path = self.load_h5_of_gid(surface_gid)
         with surface_h5_class(surface_h5_path) as surface_h5:
             params.update(self._compute_surface_params(surface_h5))
 

--- a/framework_tvb/tvb/adapters/visualizers/pca.py
+++ b/framework_tvb/tvb/adapters/visualizers/pca.py
@@ -35,6 +35,7 @@ A displayer for the principal components analysis.
 
 """
 import json
+
 from tvb.adapters.visualizers.time_series import ABCSpaceDisplayer
 from tvb.adapters.datatypes.db.mode_decompositions import PrincipalComponentsIndex
 from tvb.core.adapters.abcdisplayer import URLGenerator
@@ -88,11 +89,11 @@ class PCA(ABCSpaceDisplayer):
     def launch(self, view_model):
         # type: (PCAModel) -> dict
         """Construct data for visualization and launch it."""
-        ts_h5_class, ts_h5_path = self._load_h5_of_gid(view_model.pca.hex)
+        ts_h5_class, ts_h5_path = self.load_h5_of_gid(view_model.pca.hex)
         with ts_h5_class(ts_h5_path) as ts_h5:
             source_gid = ts_h5.source.load()
 
-        source_h5_class, source_h5_path = self._load_h5_of_gid(source_gid.hex)
+        source_h5_class, source_h5_path = self.load_h5_of_gid(source_gid.hex)
         with source_h5_class(source_h5_path) as source_h5:
             labels_data = self.get_space_labels(source_h5)
 

--- a/framework_tvb/tvb/adapters/visualizers/pearson_edge_bundle.py
+++ b/framework_tvb/tvb/adapters/visualizers/pearson_edge_bundle.py
@@ -31,6 +31,7 @@
 
 import json
 import numpy
+
 from tvb.adapters.visualizers.pearson_cross_correlation import PearsonCorrelationCoefficientVisualizerForm, \
     PearsonCorrelationCoefficientVisualizerModel
 from tvb.adapters.visualizers.time_series import ABCSpaceDisplayer
@@ -61,7 +62,7 @@ class PearsonEdgeBundle(ABCSpaceDisplayer):
         # type: (PearsonCorrelationCoefficientVisualizerModel) -> dict
         """Construct data for visualization and launch it."""
 
-        datatype_h5_class, datatype_h5_path = self._load_h5_of_gid(view_model.datatype.hex)
+        datatype_h5_class, datatype_h5_path = self.load_h5_of_gid(view_model.datatype.hex)
         with datatype_h5_class(datatype_h5_path) as datatype_h5:
             matrix_shape = datatype_h5.array_data.shape[0:2]
             ts_gid = datatype_h5.source.load()
@@ -69,7 +70,7 @@ class PearsonEdgeBundle(ABCSpaceDisplayer):
         state_list = ts_index.get_labels_for_dimension(1)
         mode_list = list(range(ts_index.data_length_4d))
 
-        ts_h5_class, ts_h5_path = self._load_h5_of_gid(ts_index.gid)
+        ts_h5_class, ts_h5_path = self.load_h5_of_gid(ts_index.gid)
         with ts_h5_class(ts_h5_path) as ts_h5:
             labels = self.get_space_labels(ts_h5)
         if not labels:

--- a/framework_tvb/tvb/adapters/visualizers/region_volume_mapping.py
+++ b/framework_tvb/tvb/adapters/visualizers/region_volume_mapping.py
@@ -125,7 +125,7 @@ class _MappedArrayVolumeBase(ABCDisplayer):
 
     def get_mapped_array_volume_view(self, entity_gid, mapped_array_gid, x_plane, y_plane, z_plane,
                                      mapped_array_slice=None, **kwargs):
-        entity_h5_class, entity_h5_path = self._load_h5_of_gid(entity_gid)
+        entity_h5_class, entity_h5_path = self.load_h5_of_gid(entity_gid)
         with entity_h5_class(entity_h5_path) as entity_h5:
             data_shape = entity_h5.array_data.shape
             x_plane, y_plane, z_plane = preprocess_space_parameters(x_plane, y_plane, z_plane, data_shape[0],
@@ -133,7 +133,7 @@ class _MappedArrayVolumeBase(ABCDisplayer):
             slice_x, slice_y, slice_z = entity_h5.get_volume_slice(x_plane, y_plane, z_plane)
             connectivity_gid = entity_h5.connectivity.load().hex
 
-        mapped_array_h5_class, mapped_array_h5_path = self._load_h5_of_gid(mapped_array_gid)
+        mapped_array_h5_class, mapped_array_h5_path = self.load_h5_of_gid(mapped_array_gid)
         with mapped_array_h5_class(mapped_array_h5_path) as mapped_array_h5:
             if mapped_array_slice:
                 matrix_slice = parse_slice(mapped_array_slice)
@@ -165,7 +165,7 @@ class _MappedArrayVolumeBase(ABCDisplayer):
 
     def get_voxel_region(self, region_mapping_volume_gid, x_plane, y_plane, z_plane):
 
-        entity_h5_class, entity_h5_path = self._load_h5_of_gid(region_mapping_volume_gid)
+        entity_h5_class, entity_h5_path = self.load_h5_of_gid(region_mapping_volume_gid)
         with entity_h5_class(entity_h5_path) as entity_h5:
 
             data_shape = entity_h5.array_data.shape
@@ -216,7 +216,7 @@ class _MappedArrayVolumeBase(ABCDisplayer):
         return params
 
     def get_volume_view(self, entity_gid, **kwargs):
-        h5_class, h5_path = self._load_h5_of_gid(entity_gid)
+        h5_class, h5_path = self.load_h5_of_gid(entity_gid)
         with h5_class(h5_path) as h5_opened:
             if h5_class is TimeSeriesRegionH5:
                 return self._get_volume_view_region(h5_opened, **kwargs)
@@ -240,7 +240,7 @@ class _MappedArrayVolumeBase(ABCDisplayer):
         if region_mapping_volume_gid is None:
             raise Exception("Invalid method called for TS without Volume Mapping!")
 
-        volume_rm_h5_class, volume_rm_h5_path = self._load_h5_of_gid(region_mapping_volume_gid)
+        volume_rm_h5_class, volume_rm_h5_path = self.load_h5_of_gid(region_mapping_volume_gid)
         volume_rm_h5 = volume_rm_h5_class(volume_rm_h5_path)
         volume_rm_shape = volume_rm_h5.array_data.shape
 

--- a/framework_tvb/tvb/adapters/visualizers/sensors.py
+++ b/framework_tvb/tvb/adapters/visualizers/sensors.py
@@ -34,6 +34,7 @@
 """
 
 import json
+
 from tvb.basic.logger.builder import get_logger
 from tvb.adapters.visualizers.surface_view import ensure_shell_surface, SurfaceURLGenerator
 from tvb.core.adapters.abcadapter import ABCAdapterForm
@@ -204,24 +205,13 @@ class SensorsViewer(ABCDisplayer):
 
         raise LaunchException("Unknown sensors type!")
 
-    def _prepare_shell_surface_params(self, shell_surface):
-        if shell_surface:
-            shell_h5_class, shell_h5_path = self._load_h5_of_gid(shell_surface.gid)
-            with shell_h5_class(shell_h5_path) as shell_h5:
-                shell_vertices, shell_normals, _, shell_triangles, _ = SurfaceURLGenerator.get_urls_for_rendering(
-                    shell_h5)
-                shelfObject = json.dumps([shell_vertices, shell_normals, shell_triangles])
-
-            return shelfObject
-        return None
-
     def _params_internal_sensors(self, internal_sensors, shell_surface=None):
 
         params = prepare_sensors_as_measure_points_params(internal_sensors)
 
         shell_surface = ensure_shell_surface(self.current_project_id, shell_surface, CORTICAL)
 
-        params['shelfObject'] = self._prepare_shell_surface_params(shell_surface)
+        params['shelfObject'] = self.prepare_shell_surface_params(shell_surface, SurfaceURLGenerator)
 
         return self.build_display_result('sensors/sensors_internal', params,
                                          pages={"controlPage": "sensors/sensors_controls"})
@@ -236,12 +226,12 @@ class SensorsViewer(ABCDisplayer):
         shell_surface = ensure_shell_surface(self.current_project_id, shell_surface)
 
         params.update({
-            'shelfObject': self._prepare_shell_surface_params(shell_surface),
+            'shelfObject': self.prepare_shell_surface_params(shell_surface, SurfaceURLGenerator),
             'urlVertices': '', 'urlTriangles': '', 'urlLines': '[]', 'urlNormals': ''
         })
 
         if eeg_cap is not None:
-            eeg_cap_h5_class, eeg_cap_h5_path = self._load_h5_of_gid(eeg_cap.gid)
+            eeg_cap_h5_class, eeg_cap_h5_path = self.load_h5_of_gid(eeg_cap.gid)
             with eeg_cap_h5_class(eeg_cap_h5_path) as eeg_cap_h5:
                 params.update(self._compute_surface_params(eeg_cap_h5))
 
@@ -255,12 +245,12 @@ class SensorsViewer(ABCDisplayer):
         shell_surface = ensure_shell_surface(self.current_project_id, shell_surface)
 
         params.update({
-            'shelfObject': self._prepare_shell_surface_params(shell_surface),
+            'shelfObject': self.prepare_shell_surface_params(shell_surface, SurfaceURLGenerator),
             'urlVertices': '', 'urlTriangles': '', 'urlLines': '[]', 'urlNormals': '',
             'boundaryURL': '', 'urlRegionMap': ''})
 
         if projection_surface is not None:
-            projection_surface_h5_class, projection_surface_h5_path = self._load_h5_of_gid(projection_surface.gid)
+            projection_surface_h5_class, projection_surface_h5_path = self.load_h5_of_gid(projection_surface.gid)
             with projection_surface_h5_class(projection_surface_h5_path) as projection_surface_h5:
                 params.update(self._compute_surface_params(projection_surface_h5))
 

--- a/framework_tvb/tvb/adapters/visualizers/sensors.py
+++ b/framework_tvb/tvb/adapters/visualizers/sensors.py
@@ -211,7 +211,7 @@ class SensorsViewer(ABCDisplayer):
 
         shell_surface = ensure_shell_surface(self.current_project_id, shell_surface, CORTICAL)
 
-        params['shelfObject'] = self.prepare_shell_surface_params(shell_surface, SurfaceURLGenerator)
+        params['shellObject'] = self.prepare_shell_surface_params(shell_surface, SurfaceURLGenerator)
 
         return self.build_display_result('sensors/sensors_internal', params,
                                          pages={"controlPage": "sensors/sensors_controls"})
@@ -226,7 +226,7 @@ class SensorsViewer(ABCDisplayer):
         shell_surface = ensure_shell_surface(self.current_project_id, shell_surface)
 
         params.update({
-            'shelfObject': self.prepare_shell_surface_params(shell_surface, SurfaceURLGenerator),
+            'shellObject': self.prepare_shell_surface_params(shell_surface, SurfaceURLGenerator),
             'urlVertices': '', 'urlTriangles': '', 'urlLines': '[]', 'urlNormals': ''
         })
 
@@ -245,7 +245,7 @@ class SensorsViewer(ABCDisplayer):
         shell_surface = ensure_shell_surface(self.current_project_id, shell_surface)
 
         params.update({
-            'shelfObject': self.prepare_shell_surface_params(shell_surface, SurfaceURLGenerator),
+            'shellObject': self.prepare_shell_surface_params(shell_surface, SurfaceURLGenerator),
             'urlVertices': '', 'urlTriangles': '', 'urlLines': '[]', 'urlNormals': '',
             'boundaryURL': '', 'urlRegionMap': ''})
 

--- a/framework_tvb/tvb/adapters/visualizers/surface_view.py
+++ b/framework_tvb/tvb/adapters/visualizers/surface_view.py
@@ -37,6 +37,7 @@ import uuid
 import numpy
 from abc import ABCMeta
 from six import add_metaclass
+
 from tvb.adapters.visualizers.time_series import ABCSpaceDisplayer
 from tvb.adapters.datatypes.db.graph import ConnectivityMeasureIndex
 from tvb.adapters.datatypes.db.region_mapping import RegionMappingIndex
@@ -435,14 +436,7 @@ class SurfaceViewer(ABCSurfaceDisplayer):
             shell_surface_index = self.load_entity_by_gid(view_model.shell_surface)
 
         shell_surface = ensure_shell_surface(self.current_project_id, shell_surface_index)
-
-        if shell_surface:
-            shell_h5 = h5.h5_file_for_index(shell_surface)
-            assert isinstance(shell_h5, SurfaceH5)
-            shell_vertices, shell_normals, _, shell_triangles, _ = SurfaceURLGenerator.get_urls_for_rendering(shell_h5)
-            params['shelfObject'] = json.dumps([shell_vertices, shell_normals, shell_triangles])
-            shell_h5.close()
-
+        params['shelfObject'] = self.prepare_shell_surface_params(shell_surface, SurfaceURLGenerator)
         return self.build_display_result("surface/surface_view", params,
                                          pages={"controlPage": "surface/surface_viewer_controls"})
 

--- a/framework_tvb/tvb/adapters/visualizers/surface_view.py
+++ b/framework_tvb/tvb/adapters/visualizers/surface_view.py
@@ -429,14 +429,14 @@ class SurfaceViewer(ABCSurfaceDisplayer):
 
         surface_h5.close()
 
-        params['shelfObject'] = None
+        params['shellObject'] = None
 
         shell_surface_index = None
         if view_model.shell_surface:
             shell_surface_index = self.load_entity_by_gid(view_model.shell_surface)
 
         shell_surface = ensure_shell_surface(self.current_project_id, shell_surface_index)
-        params['shelfObject'] = self.prepare_shell_surface_params(shell_surface, SurfaceURLGenerator)
+        params['shellObject'] = self.prepare_shell_surface_params(shell_surface, SurfaceURLGenerator)
         return self.build_display_result("surface/surface_view", params,
                                          pages={"controlPage": "surface/surface_viewer_controls"})
 

--- a/framework_tvb/tvb/adapters/visualizers/time_series_volume.py
+++ b/framework_tvb/tvb/adapters/visualizers/time_series_volume.py
@@ -40,6 +40,7 @@ Backend-side for TS Visualizer of TS Volume DataTypes.
 
 import json
 import numpy
+
 from tvb.adapters.visualizers.region_volume_mapping import _MappedArrayVolumeBase
 from tvb.adapters.datatypes.h5.time_series_h5 import TimeSeriesVolumeH5, TimeSeriesRegionH5
 from tvb.adapters.datatypes.db.structural import StructuralMRIIndex
@@ -113,22 +114,22 @@ class TimeSeriesVolumeVisualiser(_MappedArrayVolumeBase):
         url_timeseries_data = URLGenerator.build_url(self.stored_adapter.id, 'get_voxel_time_series',
                                                      view_model.time_series, '')
 
-        ts_h5_class, ts_h5_path = self._load_h5_of_gid(view_model.time_series.hex)
+        ts_h5_class, ts_h5_path = self.load_h5_of_gid(view_model.time_series.hex)
         ts_h5 = ts_h5_class(ts_h5_path)
         min_value, max_value = ts_h5.get_min_max_values()
 
         ts_index = self.load_entity_by_gid(view_model.time_series)
 
         if isinstance(ts_h5, TimeSeriesVolumeH5):
-            volume_h5_class, volume_h5_path = self._load_h5_of_gid(ts_h5.volume.load())
+            volume_h5_class, volume_h5_path = self.load_h5_of_gid(ts_h5.volume.load())
             volume_h5 = volume_h5_class(volume_h5_path)
             volume_shape = ts_h5.data.shape
         else:
             rmv_index = self.load_entity_by_gid(ts_h5.region_mapping_volume.load())
-            rmv_h5_class, rmv_h5_path = self._load_h5_of_gid(rmv_index.gid)
+            rmv_h5_class, rmv_h5_path = self.load_h5_of_gid(rmv_index.gid)
             rmv_h5 = rmv_h5_class(rmv_h5_path)
             volume_index = self.load_entity_by_gid(rmv_h5.volume.load())
-            volume_h5_class, volume_h5_path = self._load_h5_of_gid(volume_index.gid)
+            volume_h5_class, volume_h5_path = self.load_h5_of_gid(volume_index.gid)
             volume_h5 = volume_h5_class(volume_h5_path)
             volume_shape = [ts_h5.data.shape[0]]
             volume_shape.extend(rmv_h5.array_data.shape)
@@ -166,7 +167,7 @@ class TimeSeriesVolumeVisualiser(_MappedArrayVolumeBase):
         if background_index is None:
             return _MappedArrayVolumeBase.compute_background_params()
 
-        background_class, background_path = self._load_h5_of_gid(background_index.gid)
+        background_class, background_path = self.load_h5_of_gid(background_index.gid)
         background_h5 = background_class(background_path)
         min_value, max_value = background_h5.get_min_max_values()
         background_h5.close()
@@ -186,7 +187,7 @@ class TimeSeriesVolumeVisualiser(_MappedArrayVolumeBase):
                 The main part will be a vector with all the values over time from the x,y,z coordinates.
         """
 
-        ts_h5_class, ts_h5_path = self._load_h5_of_gid(entity_gid)
+        ts_h5_class, ts_h5_path = self.load_h5_of_gid(entity_gid)
 
         with ts_h5_class(ts_h5_path) as ts_h5:
             if ts_h5_class is TimeSeriesRegionH5:
@@ -199,7 +200,7 @@ class TimeSeriesVolumeVisualiser(_MappedArrayVolumeBase):
         if region_mapping_volume_gid is None:
             raise Exception("Invalid method called for TS without Volume Mapping!")
 
-        volume_rm_h5_class, volume_rm_h5_path = self._load_h5_of_gid(region_mapping_volume_gid.hex)
+        volume_rm_h5_class, volume_rm_h5_path = self.load_h5_of_gid(region_mapping_volume_gid.hex)
         volume_rm_h5 = volume_rm_h5_class(volume_rm_h5_path)
 
         volume_rm_shape = volume_rm_h5.array_data.shape
@@ -213,7 +214,7 @@ class TimeSeriesVolumeVisualiser(_MappedArrayVolumeBase):
         voxel_slices = prepare_time_slice(time_length), slice(var, var + 1), slice(idx, idx + 1), slice(mode, mode + 1)
 
         connectivity_gid = volume_rm_h5.connectivity.load()
-        connectivity_h5_class, connectivity_h5_path = self._load_h5_of_gid(connectivity_gid.hex)
+        connectivity_h5_class, connectivity_h5_path = self.load_h5_of_gid(connectivity_gid.hex)
         connectivity_h5 = connectivity_h5_class(connectivity_h5_path)
         label = connectivity_h5.region_labels.load()[idx]
 

--- a/framework_tvb/tvb/adapters/visualizers/tract.py
+++ b/framework_tvb/tvb/adapters/visualizers/tract.py
@@ -32,12 +32,18 @@
 A tracts visualizer
 .. moduleauthor:: Mihai Andrei <mihai.andrei@codemart.ro>
 """
+import json
+
+from tvb.adapters.visualizers.surface_view import ensure_shell_surface, SurfaceURLGenerator
 from tvb.adapters.visualizers.time_series import ABCSpaceDisplayer
 from tvb.core.adapters.abcadapter import ABCAdapterForm
 from tvb.adapters.datatypes.db.tracts import TractsIndex
+from tvb.core.adapters.abcdisplayer import URLGenerator
+from tvb.core.entities.storage import dao
+from tvb.core.neocom import h5
 from tvb.core.neotraits.forms import TraitDataTypeSelectField
 from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
-from tvb.datatypes.surfaces import CorticalSurface, Surface
+from tvb.datatypes.surfaces import CorticalSurface, Surface, CORTICAL
 from tvb.datatypes.tracts import Tracts
 
 
@@ -92,26 +98,38 @@ class TractViewer(ABCSpaceDisplayer):
     # TODO: migrate to neotraits
     def launch(self, view_model):
         # type: (TractViewerModel) -> dict
-        from tvb.adapters.visualizers.surface_view import prepare_shell_surface_urls
+        tracts_index = dao.get_datatype_by_gid(view_model.tracts.hex)
+        region_volume_mapping_index = dao.get_datatype_by_gid(tracts_index.fk_region_volume_map_gid)
+        connectivity = dao.get_datatype_by_gid(region_volume_mapping_index.fk_connectivity_gid)
 
-        url_track_starts, url_track_vertices = view_model.tracts.get_urls_for_rendering()
+        shell_surface_index = None
+        if view_model.shell_surface:
+            shell_surface_index = self.load_entity_by_gid(view_model.shell_surface)
 
-        if view_model.tracts.region_volume_map is None:
-            raise Exception('only tracts with an associated region volume map are supported at this moment')
+        shell_surface_index = ensure_shell_surface(self.current_project_id, shell_surface_index, CORTICAL)
 
-        connectivity = view_model.tracts.region_volume_map.connectivity
+        tracts_starts = URLGenerator.build_h5_url(tracts_index.gid, 'get_line_starts')
+        tracts_vertices = URLGenerator.build_binary_datatype_attribute_url(tracts_index.gid, 'get_vertices')
 
         params = dict(title="Tract Visualizer",
-                      shelfObject=prepare_shell_surface_urls(self.current_project_id, view_model.shell_surface,
-                                                             preferred_type=CorticalSurface),
+                      shelfObject=self._prepare_shell_surface_params(shell_surface_index),
+                      urlTrackStarts=tracts_starts, urlTrackVertices=tracts_vertices)
 
-                      urlTrackStarts=url_track_starts,
-                      urlTrackVertices=url_track_vertices)
-
-        params.update(self.build_params_for_selectable_connectivity(connectivity))
+        params.update(self.build_params_for_selectable_connectivity(h5.load_from_index(connectivity)))
 
         return self.build_display_result("tract/tract_view", params,
                                          pages={"controlPage": "tract/tract_viewer_controls"})
+
+    def _prepare_shell_surface_params(self, shell_surface):
+        if shell_surface:
+            shell_h5_class, shell_h5_path = self._load_h5_of_gid(shell_surface.gid)
+            with shell_h5_class(shell_h5_path) as shell_h5:
+                shell_vertices, shell_normals, _, shell_triangles, _ = SurfaceURLGenerator.get_urls_for_rendering(
+                    shell_h5)
+                shelfObject = json.dumps([shell_vertices, shell_normals, shell_triangles])
+
+            return shelfObject
+        return None
 
     def get_required_memory_size(self, view_model):
         # type: (TractViewerModel) -> int

--- a/framework_tvb/tvb/adapters/visualizers/tract.py
+++ b/framework_tvb/tvb/adapters/visualizers/tract.py
@@ -109,7 +109,7 @@ class TractViewer(ABCSpaceDisplayer):
         tracts_vertices = URLGenerator.build_binary_datatype_attribute_url(tracts_index.gid, 'get_vertices')
 
         params = dict(title="Tract Visualizer",
-                      shelfObject=self.prepare_shell_surface_params(shell_surface_index, SurfaceURLGenerator),
+                      shellObject=self.prepare_shell_surface_params(shell_surface_index, SurfaceURLGenerator),
                       urlTrackStarts=tracts_starts, urlTrackVertices=tracts_vertices)
 
         params.update(self.build_params_for_selectable_connectivity(h5.load_from_index(connectivity)))

--- a/framework_tvb/tvb/adapters/visualizers/tract.py
+++ b/framework_tvb/tvb/adapters/visualizers/tract.py
@@ -43,7 +43,7 @@ from tvb.core.entities.storage import dao
 from tvb.core.neocom import h5
 from tvb.core.neotraits.forms import TraitDataTypeSelectField
 from tvb.core.neotraits.view_model import ViewModel, DataTypeGidAttr
-from tvb.datatypes.surfaces import CorticalSurface, Surface, CORTICAL
+from tvb.datatypes.surfaces import CorticalSurface, Surface, FACE
 from tvb.datatypes.tracts import Tracts
 
 
@@ -95,7 +95,6 @@ class TractViewer(ABCSpaceDisplayer):
     def get_form_class(self):
         return TractViewerForm
 
-    # TODO: migrate to neotraits
     def launch(self, view_model):
         # type: (TractViewerModel) -> dict
         tracts_index = dao.get_datatype_by_gid(view_model.tracts.hex)
@@ -106,7 +105,7 @@ class TractViewer(ABCSpaceDisplayer):
         if view_model.shell_surface:
             shell_surface_index = self.load_entity_by_gid(view_model.shell_surface)
 
-        shell_surface_index = ensure_shell_surface(self.current_project_id, shell_surface_index, CORTICAL)
+        shell_surface_index = ensure_shell_surface(self.current_project_id, shell_surface_index, FACE)
 
         tracts_starts = URLGenerator.build_h5_url(tracts_index.gid, 'get_line_starts')
         tracts_vertices = URLGenerator.build_binary_datatype_attribute_url(tracts_index.gid, 'get_vertices')

--- a/framework_tvb/tvb/adapters/visualizers/tract.py
+++ b/framework_tvb/tvb/adapters/visualizers/tract.py
@@ -32,8 +32,6 @@
 A tracts visualizer
 .. moduleauthor:: Mihai Andrei <mihai.andrei@codemart.ro>
 """
-import json
-
 from tvb.adapters.visualizers.surface_view import ensure_shell_surface, SurfaceURLGenerator
 from tvb.adapters.visualizers.time_series import ABCSpaceDisplayer
 from tvb.core.adapters.abcadapter import ABCAdapterForm
@@ -111,24 +109,13 @@ class TractViewer(ABCSpaceDisplayer):
         tracts_vertices = URLGenerator.build_binary_datatype_attribute_url(tracts_index.gid, 'get_vertices')
 
         params = dict(title="Tract Visualizer",
-                      shelfObject=self._prepare_shell_surface_params(shell_surface_index),
+                      shelfObject=self.prepare_shell_surface_params(shell_surface_index, SurfaceURLGenerator),
                       urlTrackStarts=tracts_starts, urlTrackVertices=tracts_vertices)
 
         params.update(self.build_params_for_selectable_connectivity(h5.load_from_index(connectivity)))
 
         return self.build_display_result("tract/tract_view", params,
                                          pages={"controlPage": "tract/tract_viewer_controls"})
-
-    def _prepare_shell_surface_params(self, shell_surface):
-        if shell_surface:
-            shell_h5_class, shell_h5_path = self._load_h5_of_gid(shell_surface.gid)
-            with shell_h5_class(shell_h5_path) as shell_h5:
-                shell_vertices, shell_normals, _, shell_triangles, _ = SurfaceURLGenerator.get_urls_for_rendering(
-                    shell_h5)
-                shelfObject = json.dumps([shell_vertices, shell_normals, shell_triangles])
-
-            return shelfObject
-        return None
 
     def get_required_memory_size(self, view_model):
         # type: (TractViewerModel) -> int

--- a/framework_tvb/tvb/adapters/visualizers/wavelet_spectrogram.py
+++ b/framework_tvb/tvb/adapters/visualizers/wavelet_spectrogram.py
@@ -37,6 +37,7 @@ Plot the power of a WaveletCoefficients object
 """
 
 import json
+
 from tvb.core.adapters.abcadapter import ABCAdapterForm
 from tvb.core.adapters.abcdisplayer import ABCDisplayer
 from tvb.adapters.datatypes.db.spectral import WaveletCoefficientsIndex
@@ -94,7 +95,7 @@ class WaveletSpectrogramVisualizer(ABCDisplayer):
         """
          Return the required memory to run this algorithm.
          """
-        input_h5_class, input_h5_path = self._load_h5_of_gid(view_model.input_data.hex)
+        input_h5_class, input_h5_path = self.load_h5_of_gid(view_model.input_data.hex)
         with input_h5_class(input_h5_path) as input_h5:
             shape = input_h5.data.shape
         return shape[0] * shape[1] * 8

--- a/framework_tvb/tvb/core/adapters/abcdisplayer.py
+++ b/framework_tvb/tvb/core/adapters/abcdisplayer.py
@@ -206,11 +206,9 @@ class ABCDisplayer(ABCAdapter, metaclass=ABCMeta):
         Prepares urls that are necessary for a shell surface.
         """
         if shell_surface:
-            shell_h5_class, shell_h5_path = self.load_h5_of_gid(shell_surface.gid)
-            with shell_h5_class(shell_h5_path) as shell_h5:
-                shell_vertices, shell_normals, _, shell_triangles, _ = surface_url_generator.get_urls_for_rendering(
-                    shell_h5)
-                shellObject = json.dumps([shell_vertices, shell_normals, shell_triangles])
-
+            shell_h5 = h5.h5_file_for_index(shell_surface)
+            shell_vertices, shell_normals, _, shell_triangles, _ = surface_url_generator.get_urls_for_rendering(shell_h5)
+            shellObject = json.dumps([shell_vertices, shell_normals, shell_triangles])
+            shell_h5.close()
             return shellObject
         return None

--- a/framework_tvb/tvb/core/adapters/abcdisplayer.py
+++ b/framework_tvb/tvb/core/adapters/abcdisplayer.py
@@ -210,7 +210,7 @@ class ABCDisplayer(ABCAdapter, metaclass=ABCMeta):
             with shell_h5_class(shell_h5_path) as shell_h5:
                 shell_vertices, shell_normals, _, shell_triangles, _ = surface_url_generator.get_urls_for_rendering(
                     shell_h5)
-                shelfObject = json.dumps([shell_vertices, shell_normals, shell_triangles])
+                shellObject = json.dumps([shell_vertices, shell_normals, shell_triangles])
 
-            return shelfObject
+            return shellObject
         return None

--- a/framework_tvb/tvb/core/adapters/abcdisplayer.py
+++ b/framework_tvb/tvb/core/adapters/abcdisplayer.py
@@ -51,6 +51,7 @@ class URLGenerator(object):
     INVOKE_ADAPTER = 'invoke_adapter'
     H5_FILE = 'read_from_h5_file'
     DATATYPE_ATTRIBUTE = 'read_datatype_attribute'
+    BINARY_DATATYPE_ATTRIBUTE = 'read_binary_datatype_attribute'
 
     @staticmethod
     def build_base_h5_url(entity_gid):
@@ -93,6 +94,17 @@ class URLGenerator(object):
         url_regex = '/{}/{}/{}/{}/{}'
         url = url_regex.format(URLGenerator.FLOW, URLGenerator.DATATYPE_ATTRIBUTE,
                                datatype_gid, attribute_name, flatten)
+        if parameter is not None:
+            url += "?" + str(parameter)
+        return url
+
+    @staticmethod
+    def build_binary_datatype_attribute_url(datatype_gid, attribute_name, parameter=None):
+        if isinstance(datatype_gid, UUID):
+            datatype_gid = datatype_gid.hex
+        url_regex = '/{}/{}/{}/{}'
+        url = url_regex.format(URLGenerator.FLOW, URLGenerator.BINARY_DATATYPE_ATTRIBUTE,
+                               datatype_gid, attribute_name)
         if parameter is not None:
             url += "?" + str(parameter)
         return url

--- a/framework_tvb/tvb/core/adapters/abcdisplayer.py
+++ b/framework_tvb/tvb/core/adapters/abcdisplayer.py
@@ -195,8 +195,22 @@ class ABCDisplayer(ABCAdapter, metaclass=ABCMeta):
         format_str = "%0." + str(precision) + "g"
         return "[" + ",".join(format_str % s for s in xs) + "]"
 
-    def _load_h5_of_gid(self, entity_gid):
+    def load_h5_of_gid(self, entity_gid):
         entity_index = self.load_entity_by_gid(entity_gid)
         entity_h5_class = h5.REGISTRY.get_h5file_for_index(type(entity_index))
         entity_h5_path = h5.path_for_stored_index(entity_index)
         return entity_h5_class, entity_h5_path
+
+    def prepare_shell_surface_params(self, shell_surface, surface_url_generator):
+        """
+        Prepares urls that are necessary for a shell surface.
+        """
+        if shell_surface:
+            shell_h5_class, shell_h5_path = self.load_h5_of_gid(shell_surface.gid)
+            with shell_h5_class(shell_h5_path) as shell_h5:
+                shell_vertices, shell_normals, _, shell_triangles, _ = surface_url_generator.get_urls_for_rendering(
+                    shell_h5)
+                shelfObject = json.dumps([shell_vertices, shell_normals, shell_triangles])
+
+            return shelfObject
+        return None

--- a/framework_tvb/tvb/interfaces/web/controllers/flow_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/flow_controller.py
@@ -416,8 +416,7 @@ class FlowController(BaseController):
             return method(entity_gid, **kwargs)
         return method(entity_gid)
 
-    @expose_json
-    def read_from_h5_file(self, entity_gid, method_name, flatten=False, datatype_kwargs='null', **kwargs):
+    def _read_from_h5(self, entity_gid, method_name, datatype_kwargs='null', **kwargs):
         self.logger.debug("Starting to read HDF5: " + entity_gid + "/" + method_name + "/" + str(kwargs))
         entity = load_entity_by_gid(entity_gid)
         entity_h5 = h5.h5_file_for_index(entity)
@@ -432,8 +431,13 @@ class FlowController(BaseController):
             result = result(**kwargs)
         else:
             result = result()
-
         entity_h5.close()
+
+        return result
+
+    @expose_json
+    def read_from_h5_file(self, entity_gid, method_name, flatten=False, datatype_kwargs='null', **kwargs):
+        result = self._read_from_h5(entity_gid, method_name, datatype_kwargs, **kwargs)
         return self._prepare_result(result, flatten)
 
     @expose_json
@@ -464,8 +468,8 @@ class FlowController(BaseController):
             return result
 
     @expose_numpy_array
-    def read_binary_datatype_attribute(self, entity_gid, dataset_name, datatype_kwargs='null', **kwargs):
-        return self._read_datatype_attribute(entity_gid, dataset_name, datatype_kwargs, **kwargs)
+    def read_binary_datatype_attribute(self, entity_gid, method_name, datatype_kwargs='null', **kwargs):
+        return self._read_from_h5(entity_gid, method_name, datatype_kwargs, **kwargs)
 
     @expose_fragment("flow/genericAdapterFormFields")
     def get_simple_adapter_interface(self, algorithm_id, parent_div='', is_uploader=False):

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/brain/internal_view.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/brain/internal_view.html
@@ -12,7 +12,7 @@
             VSI_StartInternalActivityViewer('{{ base_adapter_url }}', {{ pageSize }}, '{{ time | safe }}', '{{ urlVertices if urlVertices else '' }}',
                     '{{urlLines | safe }}', '{{ urlTriangles | safe }}', '{{ urlNormals | safe }}', '{{ urlMeasurePoints | safe }}', {{ noOfMeasurePoints }},
                     '{{ urlRegionMap | safe }}', '{{ minActivity }}', '{{ maxActivity }}', '{{ isOneToOneMapping }}',
-                     {{ 'true' if extended_view else 'false' }}, {{ ("'" ~ shelfObject ~ "'" if shelfObject else 'null') | safe }},
+                     {{ 'true' if extended_view else 'false' }}, {{ ("'" ~ shellObject ~ "'" if shellObject else 'null') | safe }},
                     '{{ urlMeasurePointsLabels | safe }}', '{{ urlRegionBoundaries }}');
         });
     </script>

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/brain/view.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/brain/view.html
@@ -11,7 +11,7 @@
                 '{{ urlNormals | safe }}', '{{ urlMeasurePoints | safe }}', {{ noOfMeasurePoints }},
                 '{{ urlRegionMap | safe }}', '{{ minActivity }}', '{{ maxActivity }}', '{{ isOneToOneMapping }}',
                 {{ 'true' if extended_view else 'false' }},
-                {{ ("'" + shelfObject + "'" if shelfObject else 'null') | safe }}, {{ hemisphereChunkMask }},
+                {{ ("'" + shellObject + "'" if shellObject else 'null') | safe }}, {{ hemisphereChunkMask }},
                 '{{ urlMeasurePointsLabels  }}', '{{ urlRegionBoundaries | safe }}', '{{ measurePointsSelectionGID }}');
         });
     </script>

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/commons/scripts/internalBrain.js
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/commons/scripts/internalBrain.js
@@ -49,9 +49,9 @@ function _VSI_init_sphericalMeasurePoints(){
 }
 
 function VSI_StartInternalSensorViewer(urlMeasurePoints,  noOfMeasurePoints, urlMeasurePointsLabels,
-                                       shelfObject, minMeasure, maxMeasure, measure){
+                                       shellObject, minMeasure, maxMeasure, measure){
     _VS_static_entrypoint('', '[]', '', '', urlMeasurePoints, noOfMeasurePoints, '', urlMeasurePointsLabels, '',
-                          shelfObject, null, false, true, minMeasure, maxMeasure, measure);
+                          shellObject, null, false, true, minMeasure, maxMeasure, measure);
     isInternalSensorView = true;
     displayMeasureNodes = true;
 
@@ -62,12 +62,12 @@ function VSI_StartInternalSensorViewer(urlMeasurePoints,  noOfMeasurePoints, url
 function VSI_StartInternalActivityViewer(baseAdapterURL, onePageSize, urlTimeList, urlVerticesList, urlLinesList,
                     urlTrianglesList, urlNormalsList, urlMeasurePoints, noOfMeasurePoints,
                     urlRegionMapList, minActivity, maxActivity,
-                    oneToOneMapping, doubleView, shelfObject, urlMeasurePointsLabels, boundaryURL) {
+                    oneToOneMapping, doubleView, shellObject, urlMeasurePointsLabels, boundaryURL) {
 
     _VS_movie_entrypoint(baseAdapterURL, onePageSize, urlTimeList, urlVerticesList, urlLinesList,
                     urlTrianglesList, urlNormalsList, urlMeasurePoints, noOfMeasurePoints,
                     urlRegionMapList, minActivity, maxActivity,
-                    oneToOneMapping, doubleView, shelfObject, null, urlMeasurePointsLabels, boundaryURL);
+                    oneToOneMapping, doubleView, shellObject, null, urlMeasurePointsLabels, boundaryURL);
     isInternalSensorView = true;
     displayMeasureNodes = true;
     isFaceToDisplay = true;

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/commons/scripts/virtualBrain.js
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/commons/scripts/virtualBrain.js
@@ -103,7 +103,7 @@ var isPreview = false;
  */
 var brainBuffers = [];
 var brainLinesBuffers = [];
-var shelfBuffers = [];
+var shellBuffers = [];
 var measurePointsBuffers = [];
 
 var regionBoundariesController = null;
@@ -233,7 +233,7 @@ function VS_StartPortletPreview(urlBaseAdapter, urlVerticesList, urlTrianglesLis
 }
 
 function _VS_static_entrypoint(urlVerticesList, urlLinesList, urlTrianglesList, urlNormalsList, urlMeasurePoints,
-                               noOfMeasurePoints, urlRegionMapList, urlMeasurePointsLabels, boundaryURL, shelfObject,
+                               noOfMeasurePoints, urlRegionMapList, urlMeasurePointsLabels, boundaryURL, shellObject,
                                hemisphereChunkMask, argDisplayMeasureNodes, argIsFaceToDisplay,
                                minMeasure, maxMeasure, urlMeasure) {
     // initialize global configuration
@@ -289,7 +289,7 @@ function _VS_static_entrypoint(urlVerticesList, urlLinesList, urlTrianglesList, 
 
     const canvas = document.getElementById(BRAIN_CANVAS_ID);
     _initViewerGL(canvas, urlVerticesList, urlNormalsList, urlTrianglesList,
-        urlRegionMapList, urlLinesList, boundaryURL, shelfObject, hemisphereChunkMask);
+        urlRegionMapList, urlLinesList, boundaryURL, shellObject, hemisphereChunkMask);
 
     _bindEvents(canvas);
 
@@ -302,7 +302,7 @@ function _VS_static_entrypoint(urlVerticesList, urlLinesList, urlTrianglesList, 
 function _VS_movie_entrypoint(baseAdapterURL, onePageSize, urlTimeList, urlVerticesList, urlLinesList,
                               urlTrianglesList, urlNormalsList, urlMeasurePoints, noOfMeasurePoints,
                               urlRegionMapList, minActivity, maxActivity, oneToOneMapping, doubleView,
-                              shelfObject, hemisphereChunkMask, urlMeasurePointsLabels, boundaryURL) {
+                              shellObject, hemisphereChunkMask, urlMeasurePointsLabels, boundaryURL) {
     // initialize global configuration
     isDoubleView = doubleView;
     if (oneToOneMapping === 'True') {
@@ -328,7 +328,7 @@ function _VS_movie_entrypoint(baseAdapterURL, onePageSize, urlTimeList, urlVerti
     const canvas = document.getElementById(BRAIN_CANVAS_ID);
 
     _initViewerGL(canvas, urlVerticesList, urlNormalsList, urlTrianglesList,
-        urlRegionMapList, urlLinesList, boundaryURL, shelfObject, hemisphereChunkMask);
+        urlRegionMapList, urlLinesList, boundaryURL, shellObject, hemisphereChunkMask);
 
     _bindEvents(canvas);
 
@@ -363,10 +363,10 @@ function VS_StartSurfaceViewer(urlVerticesList, urlLinesList, urlTrianglesList, 
 
 function VS_StartEEGSensorViewer(urlVerticesList, urlLinesList, urlTrianglesList, urlNormalsList, urlMeasurePoints,
                                  noOfMeasurePoints, urlMeasurePointsLabels,
-                                 shelfObject, minMeasure, maxMeasure, urlMeasure) {
+                                 shellObject, minMeasure, maxMeasure, urlMeasure) {
     isEEGView = true;
     _VS_static_entrypoint(urlVerticesList, urlLinesList, urlTrianglesList, urlNormalsList, urlMeasurePoints,
-        noOfMeasurePoints, '', urlMeasurePointsLabels, '', shelfObject, null, true, true,
+        noOfMeasurePoints, '', urlMeasurePointsLabels, '', shellObject, null, true, true,
         minMeasure, maxMeasure, urlMeasure);
     _VS_init_cubicalMeasurePoints();
 }
@@ -374,12 +374,12 @@ function VS_StartEEGSensorViewer(urlVerticesList, urlLinesList, urlTrianglesList
 function VS_StartBrainActivityViewer(baseAdapterURL, onePageSize, urlTimeList, urlVerticesList, urlLinesList,
                                      urlTrianglesList, urlNormalsList, urlMeasurePoints, noOfMeasurePoints,
                                      urlRegionMapList, minActivity, maxActivity,
-                                     oneToOneMapping, doubleView, shelfObject, hemisphereChunkMask,
+                                     oneToOneMapping, doubleView, shellObject, hemisphereChunkMask,
                                      urlMeasurePointsLabels, boundaryURL, measurePointsSelectionGID) {
     _VS_movie_entrypoint(baseAdapterURL, onePageSize, urlTimeList, urlVerticesList, urlLinesList,
         urlTrianglesList, urlNormalsList, urlMeasurePoints, noOfMeasurePoints,
         urlRegionMapList, minActivity, maxActivity,
-        oneToOneMapping, doubleView, shelfObject, hemisphereChunkMask,
+        oneToOneMapping, doubleView, shellObject, hemisphereChunkMask,
         urlMeasurePointsLabels, boundaryURL);
     _VS_init_cubicalMeasurePoints();
 
@@ -413,7 +413,7 @@ function _isValidActivityData() {
  * Scene setup common to all webgl brain viewers
  */
 function _initViewerGL(canvas, urlVerticesList, urlNormalsList, urlTrianglesList,
-                       urlRegionMapList, urlLinesList, boundaryURL, shelfObject, hemisphere_chunk_mask) {
+                       urlRegionMapList, urlLinesList, boundaryURL, shellObject, hemisphere_chunk_mask) {
     customInitGL(canvas);
     GL_initColorPickFrameBuffer();
     initShaders();
@@ -440,9 +440,9 @@ function _initViewerGL(canvas, urlVerticesList, urlNormalsList, urlTrianglesList
     brainLinesBuffers = HLPR_getDataBuffers(gl, $.parseJSON(urlLinesList), isDoubleView, true);
     regionBoundariesController = new RB_RegionBoundariesController(boundaryURL);
 
-    if (shelfObject) {
-        shelfObject = $.parseJSON(shelfObject);
-        shelfBuffers = initBuffers(shelfObject[0], shelfObject[1], shelfObject[2], false, true);
+    if (shellObject) {
+        shellObject = $.parseJSON(shellObject);
+        shellBuffers = initBuffers(shellObject[0], shellObject[1], shellObject[2], false, true);
     }
 
     VB_BrainNavigator = new NAV_BrainNavigator(isOneToOneMapping, brainBuffers, measurePoints, measurePointsLabels);
@@ -1117,7 +1117,7 @@ function drawScene() {
             const faceDrawMode = isInternalSensorView ? drawingMode : gl.TRIANGLES;
             mvPushMatrix();
             mvTranslate(VB_BrainNavigator.getPosition());
-            drawBuffers(faceDrawMode, shelfBuffers, null, true, gl.FRONT);
+            drawBuffers(faceDrawMode, shellBuffers, null, true, gl.FRONT);
             mvPopMatrix();
         }
 

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/sensors/sensors_eeg.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/sensors/sensors_eeg.html
@@ -11,7 +11,7 @@
         $(document).ready(function() {
             VS_StartEEGSensorViewer('{{ urlVertices | safe }}', '{{ urlLines | safe }}', '{{ urlTriangles | safe }}', '{{ urlNormals | safe }}',
                     '{{ urlMeasurePoints | safe }}', '{{ noOfMeasurePoints }}', '{{ urlMeasurePointsLabels }}',
-                    '{{ shelfObject | safe if shelfObject else null }}', {{ minMeasure }}, {{ maxMeasure }}, '{{ urlMeasure }}');
+                    '{{ shellObject | safe if shellObject else null }}', {{ minMeasure }}, {{ maxMeasure }}, '{{ urlMeasure }}');
         });
     </script>
 

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/sensors/sensors_internal.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/sensors/sensors_internal.html
@@ -13,7 +13,7 @@
     <script type="text/javascript">
         $(document).ready(function() {
             VSI_StartInternalSensorViewer('{{ urlMeasurePoints | safe }}', '{{ noOfMeasurePoints }}',
-                    '{{ urlMeasurePointsLabels }}', '{{ shelfObject | safe if shelfObject else null }}',
+                    '{{ urlMeasurePointsLabels }}', '{{ shellObject | safe if shellObject else null }}',
                     '{{ minMeasure }}', '{{ maxMeasure }}', '{{ urlMeasure }}');
         });
     </script>

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/surface/surface_view.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/surface/surface_view.html
@@ -8,7 +8,7 @@
             VS_StartSurfaceViewer('{{ urlVertices | safe}}', '{{ urlLines | safe }}', '{{ urlTriangles | safe }}',
                     '{{ urlNormals | safe }}', '{{ urlMeasurePoints | safe }}', {{ noOfMeasurePoints }},
                     '{{ urlRegionMap | safe }}', '{{ urlMeasurePointsLabels | safe }}',
-                    '{{ boundaryURL | safe }}', '{{ shelfObject | safe if shelfObject else null }}', {{ minMeasure }}, {{ maxMeasure }},
+                    '{{ boundaryURL | safe }}', '{{ shellObject | safe if shellObject else null }}', {{ minMeasure }}, {{ maxMeasure }},
                     '{{ clientMeasureUrl | safe }}', {{ hemisphereChunkMask }});
         });
     </script>

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/tract/track.js
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/tract/track.js
@@ -34,7 +34,7 @@ var chunks_tract_offsets;
 
 var tracts_loaded = false;
 
-var TRACK_shelfDisplayBuffers = [];
+var TRACK_shellDisplayBuffers = [];
 
 var drawingMode;
 
@@ -215,20 +215,20 @@ function _bindEvents(canvas){
     });
 }
 
-function TRACK_webGLStart(urlTrackStarts, urlTrackVertices, shelfObject) {
+function TRACK_webGLStart(urlTrackStarts, urlTrackVertices, shellObject) {
     var canvas = document.getElementById(BRAIN_CANVAS_ID);
-    shelfObject = $.parseJSON(shelfObject);
+    shellObject = $.parseJSON(shellObject);
 
     _customInitGL(canvas);
     _initShaders();
 
     displayMessage("Start loading surface data!", "infoMessage");
-    downloadBrainGeometry($.toJSON(shelfObject[0]), $.toJSON(shelfObject[2]), $.toJSON(shelfObject[1]),
+    downloadBrainGeometry($.toJSON(shellObject[0]), $.toJSON(shellObject[2]), $.toJSON(shellObject[1]),
         function(drawingBrain){
             displayMessage("Finished loading surface data!", "infoMessage");
-            // Finished downloading buffer data. Initialize TRACK_shelfDisplayBuffers
-            TRACK_shelfDisplayBuffers = drawingBrainUploadGeometryBuffers(drawingBrain);
-            drawingBrainUploadDefaultColorBuffer(drawingBrain.vertices, TRACK_shelfDisplayBuffers);
+            // Finished downloading buffer data. Initialize TRACK_shellDisplayBuffers
+            TRACK_shellDisplayBuffers = drawingBrainUploadGeometryBuffers(drawingBrain);
+            drawingBrainUploadDefaultColorBuffer(drawingBrain.vertices, TRACK_shellDisplayBuffers);
             drawScene();
         }
     );
@@ -257,7 +257,7 @@ function TRACK_webGLStart(urlTrackStarts, urlTrackVertices, shelfObject) {
  * Redraw from buffers.
  */
 function drawScene() {
-    if (TRACK_shelfDisplayBuffers.length === 0) {
+    if (TRACK_shellDisplayBuffers.length === 0) {
         displayMessage("The load operation for the surface data is not completed yet!", "infoMessage");
         return;
     }
@@ -284,7 +284,7 @@ function drawScene() {
 
     if (isFaceToDisplay) {
         gl.uniform1i(GL_shaderProgram.useActivity, true);
-        drawBuffers(drawingMode, TRACK_shelfDisplayBuffers, true, gl.FRONT);
+        drawBuffers(drawingMode, TRACK_shellDisplayBuffers, true, gl.FRONT);
     }
 
     mvPopMatrix();

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/tract/tract_view.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/visualizers/tract/tract_view.html
@@ -6,7 +6,7 @@
 
     <script type="text/javascript">
         $(document).ready(function() {
-            TRACK_webGLStart('{{ urlTrackStarts | safe }}', '{{ urlTrackVertices | safe }}', '{{ shelfObject | safe if shelfObject else null }}');
+            TRACK_webGLStart('{{ urlTrackStarts | safe }}', '{{ urlTrackVertices | safe }}', '{{ shellObject | safe if shellObject else null }}');
         });
     </script>
 

--- a/framework_tvb/tvb/tests/framework/adapters/visualizers/brainviewer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/visualizers/brainviewer_test.py
@@ -51,7 +51,7 @@ class TestBrainViewer(TransactionalTestCase):
     EXPECTED_KEYS = ['urlVertices', 'urlNormals', 'urlTriangles', 'urlLines', 'urlRegionMap',
                      'base_adapter_url', 'isOneToOneMapping', 'minActivity', 'maxActivity',
                      'noOfMeasurePoints', 'isAdapter']
-    EXPECTED_EXTRA_KEYS = ['urlMeasurePointsLabels', 'urlMeasurePoints', 'pageSize', 'shelfObject',
+    EXPECTED_EXTRA_KEYS = ['urlMeasurePointsLabels', 'urlMeasurePoints', 'pageSize', 'shellObject',
                            'extended_view', 'legendLabels', 'labelsStateVar', 'labelsModes', 'title']
 
     face = os.path.join(os.path.dirname(tvb_data.surfaceData.__file__), 'cortex_16384.zip')

--- a/framework_tvb/tvb/tests/framework/adapters/visualizers/sensorsviewer_test.py
+++ b/framework_tvb/tvb/tests/framework/adapters/visualizers/sensorsviewer_test.py
@@ -53,7 +53,7 @@ class TestSensorViewers(TransactionalTestCase):
     """
 
     EXPECTED_KEYS_INTERNAL = {'urlMeasurePoints': None, 'urlMeasurePointsLabels': None, 'noOfMeasurePoints': 103,
-                              'minMeasure': 0, 'maxMeasure': 103, 'urlMeasure': None, 'shelfObject': None}
+                              'minMeasure': 0, 'maxMeasure': 103, 'urlMeasure': None, 'shellObject': None}
 
     EXPECTED_KEYS_EEG = EXPECTED_KEYS_INTERNAL.copy()
     EXPECTED_KEYS_EEG.update({'urlVertices': None, 'urlTriangles': None, 'urlLines': None, 'urlNormals': None,

--- a/scientific_library/tvb/datatypes/tracts.py
+++ b/scientific_library/tvb/datatypes/tracts.py
@@ -42,8 +42,6 @@ TRACTS_CHUNK_SIZE = 100
 class Tracts(HasTraits):
     """Datatype for results of diffusion imaging tractography."""
 
-    MAX_N_VERTICES = 2 ** 16
-
     vertices = NArray(
         label="Vertex positions",
         doc="""An array specifying coordinates for the tracts vertices."""
@@ -68,7 +66,6 @@ class Tracts(HasTraits):
     region_volume_map = Attr(
         field_type=RegionVolumeMapping,
         label="Region volume Mapping used to create the tract_region index",
-        required=False
     )
 
     @property


### PR DESCRIPTION
I seemingly managed to fix the importers and the visualizer partially. One of the first problems I encountered is that judging by how the code is written I am pretty sure that the Region Volume Mapping when importing a Tracts should be a required, not an optional field. Paula sent me a RVM and a connectivity which I was able to import with the 5M.trk file and I also changed the code until I was able to see some tracts in the viewer. The problem is that it strongly seems that not only are the vertices not read in slices, but there are actually more vertices read than they are said to be in the H5 which clearly means that the reading of vertices in slices is what still needs to be fixed.