### PR TITLE
TVB-2870: Move everything related to monitors handling in a new class

### DIFF
--- a/framework_tvb/tvb/adapters/simulator/monitor_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/monitor_forms.py
@@ -84,10 +84,6 @@ def get_form_for_monitor(monitor_class):
     return get_monitor_to_form_dict().get(monitor_class)
 
 
-def prepare_monitor_legend(is_surface_simulation, monitor):
-    return get_monitor_to_ui_name_dict(is_surface_simulation)[type(monitor)] + ' monitor'
-
-
 class MonitorForm(Form):
 
     def __init__(self, session_stored_simulator=None):

--- a/framework_tvb/tvb/adapters/simulator/monitor_forms.py
+++ b/framework_tvb/tvb/adapters/simulator/monitor_forms.py
@@ -84,21 +84,6 @@ def get_form_for_monitor(monitor_class):
     return get_monitor_to_form_dict().get(monitor_class)
 
 
-def build_list_of_monitors_from_view_models(monitor_view_models):
-    next_monitors_dict = dict()
-    count = 0
-    for monitor_model in monitor_view_models:
-        next_monitors_dict[monitor_model.__class__.__name__] = (monitor_model, count + 1)
-        count = count + 1
-    return next_monitors_dict
-
-
-def build_list_of_monitors_from_names(monitor_names, is_surface_simulation):
-    monitor_dict = get_ui_name_to_monitor_dict(is_surface_simulation)
-    monitor_view_models = [monitor_dict[monitor_name]() for monitor_name in monitor_names]
-    return build_list_of_monitors_from_view_models(monitor_view_models)
-
-
 def prepare_monitor_legend(is_surface_simulation, monitor):
     return get_monitor_to_ui_name_dict(is_surface_simulation)[type(monitor)] + ' monitor'
 

--- a/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
@@ -29,14 +29,13 @@
 #
 
 import uuid
-
 import formencode
 from formencode import validators
+
 from tvb.adapters.datatypes.db.patterns import StimuliRegionIndex, SpatioTemporalPatternIndex
 from tvb.adapters.simulator.integrator_forms import get_form_for_integrator
 from tvb.adapters.simulator.model_forms import get_ui_name_to_model
-from tvb.adapters.simulator.monitor_forms import get_ui_name_to_monitor_dict, get_monitor_to_ui_name_dict, \
-    get_form_for_monitor, prepare_monitor_legend
+from tvb.adapters.simulator.monitor_forms import get_ui_name_to_monitor_dict, get_monitor_to_ui_name_dict
 from tvb.adapters.simulator.subforms_mapping import get_ui_name_to_integrator_dict
 from tvb.basic.neotraits.api import Attr, Range, List, Float
 from tvb.core.adapters.abcadapter import ABCAdapterForm
@@ -191,32 +190,6 @@ class SimulatorMonitorFragment(ABCAdapterForm):
         self.monitors.data = [
             get_monitor_to_ui_name_dict(self.is_surface_simulation)[type(monitor)]
             for monitor in trait]
-
-    @staticmethod
-    def prepare_monitor_fragment(simulator, rendering_rules, form_action_url):
-        monitor_fragment = SimulatorMonitorFragment(simulator.is_surface_simulation)
-        monitor_fragment.fill_from_trait(simulator.monitors)
-
-        rendering_rules.form = monitor_fragment
-        rendering_rules.form_action_url = form_action_url
-        return rendering_rules.to_dict()
-
-    @staticmethod
-    def get_fragment_after_monitors(simulator, burst_config, project_id, is_branch, rendering_rules, setup_pse_url):
-        first_monitor = simulator.first_monitor
-        if first_monitor is None:
-            rendering_rules.is_branch = is_branch
-            return SimulatorFinalFragment.prepare_final_fragment(simulator, burst_config, project_id, rendering_rules,
-                                                                 setup_pse_url)
-
-        form = get_form_for_monitor(type(first_monitor))(simulator)
-        form = AlgorithmService().prepare_adapter_form(form_instance=form)
-        form.fill_from_trait(first_monitor)
-
-        monitor_name = prepare_monitor_legend(simulator.is_surface_simulation, first_monitor)
-        rendering_rules.monitor_name = monitor_name
-        rendering_rules.form = form
-        return rendering_rules.to_dict()
 
 
 class SimulatorFinalFragment(ABCAdapterForm):

--- a/framework_tvb/tvb/core/services/simulator_service.py
+++ b/framework_tvb/tvb/core/services/simulator_service.py
@@ -246,14 +246,6 @@ class SimulatorService(object):
                                    operations=["=="], values=[conn.number_of_regions])
         return None
 
-    @staticmethod
-    def get_current_and_next_monitor_form(current_monitor_name, simulator, next_monitors_dict):
-        current_monitor, next_monitor_index = next_monitors_dict[current_monitor_name]
-
-        if next_monitor_index < len(next_monitors_dict):
-            return current_monitor, simulator.monitors[next_monitor_index]
-        return current_monitor, None
-
     def get_simulation_state_index(self, burst_config, simulation_history_class):
         parent_burst = burst_config.parent_burst_object
         simulation_state_index = dao.get_generic_entity(simulation_history_class, parent_burst.gid, "fk_parent_burst")

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator/monitors_wizard_handler.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator/monitors_wizard_handler.py
@@ -45,9 +45,9 @@ class MonitorsWizardHandler:
         self.next_monitors_dict = None
 
     def set_monitors_list_on_simulator(self, session_stored_simulator, monitor_names):
-        self.build_list_of_monitors_from_names(monitor_names)
+        self.build_list_of_monitors_from_names(monitor_names, session_stored_simulator.is_surface_simulation)
         monitor_dict = get_ui_name_to_monitor_dict(session_stored_simulator.is_surface_simulation)
-        session_stored_simulator.monitors = list(monitor_dict[monitor]() for monitor in self.next_monitors_dict.keys())
+        session_stored_simulator.monitors = list(monitor_dict[monitor]() for monitor in monitor_names)
 
     def clear_next_monitors_dict(self):
         if self.next_monitors_dict:
@@ -57,15 +57,17 @@ class MonitorsWizardHandler:
         monitor_names = []
         monitor_dict = get_monitor_to_ui_name_dict(simulator.is_surface_simulation)
         for monitor in simulator.monitors:
-            monitor_names.append(monitor_dict[monitor.__class__])
+            monitor_names.append(monitor_dict[type(monitor)])
 
-        self.build_list_of_monitors_from_names(monitor_names)
+        self.build_list_of_monitors_from_names(monitor_names, simulator.is_surface_simulation)
 
-    def build_list_of_monitors_from_names(self, monitor_names):
+    def build_list_of_monitors_from_names(self, monitor_names, is_surface):
         self.next_monitors_dict = dict()
+        monitors_dict = get_ui_name_to_monitor_dict(is_surface)
         count = 0
         for monitor_name in monitor_names:
-            self.next_monitors_dict[monitor_name] = count
+            monitor_vm = monitors_dict[monitor_name].__name__
+            self.next_monitors_dict[monitor_vm] = count
             count = count + 1
 
     def get_current_and_next_monitor_form(self, current_monitor_name, simulator):

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator/monitors_wizard_handler.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator/monitors_wizard_handler.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+#
+#
+# TheVirtualBrain-Framework Package. This package holds all Data Management, and
+# Web-UI helpful to run brain-simulations. To use it, you also need do download
+# TheVirtualBrain-Scientific Package (for simulators). See content of the
+# documentation-folder for more details. See also http://www.thevirtualbrain.org
+#
+# (c) 2012-2020, Baycrest Centre for Geriatric Care ("Baycrest") and others
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this
+# program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+#   CITATION:
+# When using The Virtual Brain for scientific publications, please cite it as follows:
+#
+#   Paula Sanz Leon, Stuart A. Knock, M. Marmaduke Woodman, Lia Domide,
+#   Jochen Mersmann, Anthony R. McIntosh, Viktor Jirsa (2013)
+#       The Virtual Brain: a simulator of primate brain network dynamics.
+#   Frontiers in Neuroinformatics (7:10. doi: 10.3389/fninf.2013.00010)
+#
+#
+
+"""
+.. moduleauthor:: Robert Vincze <robert.vincze@codemart.ro>
+"""
+
+from tvb.adapters.simulator.equation_forms import get_form_for_equation
+from tvb.adapters.simulator.monitor_forms import AdditiveNoiseViewModel, get_ui_name_to_monitor_dict, \
+    get_form_for_monitor, prepare_monitor_legend, BoldViewModel
+from tvb.adapters.simulator.simulator_fragments import SimulatorMonitorFragment, SimulatorFinalFragment
+from tvb.core.services.algorithm_service import AlgorithmService
+from tvb.interfaces.web.controllers.simulator.simulator_wizzard_urls import SimulatorWizzardURLs
+
+
+class MonitorsWizardHandler:
+    def __init__(self):
+        self.next_monitors_dict = None
+
+    def set_monitors_list_on_simulator(self, session_stored_simulator, monitor_names):
+        self.build_list_of_monitors_from_names(monitor_names, session_stored_simulator.is_surface_simulation)
+        session_stored_simulator.monitors = list(monitor for monitor, _ in self.next_monitors_dict.values())
+
+    def clear_next_monitors_dict(self):
+        if self.next_monitors_dict:
+            self.next_monitors_dict.clear()
+
+    def build_list_of_monitors_from_view_models(self, monitor_view_models):
+        self.next_monitors_dict = dict()
+        count = 0
+        for monitor_model in monitor_view_models:
+            self.next_monitors_dict[monitor_model.__class__.__name__] = (monitor_model, count + 1)
+            count = count + 1
+
+    def build_list_of_monitors_from_names(self, monitor_names, is_surface_simulation):
+        monitor_dict = get_ui_name_to_monitor_dict(is_surface_simulation)
+        monitor_view_models = [monitor_dict[monitor_name]() for monitor_name in monitor_names]
+        return self.build_list_of_monitors_from_view_models(monitor_view_models)
+
+    def get_current_and_next_monitor_form(self, current_monitor_name, simulator):
+        current_monitor, next_monitor_index = self.next_monitors_dict[current_monitor_name]
+
+        if next_monitor_index < len(self.next_monitors_dict):
+            return current_monitor, simulator.monitors[next_monitor_index]
+        return current_monitor, None
+
+    @staticmethod
+    def prepare_monitor_fragment(simulator, rendering_rules, form_action_url):
+        monitor_fragment = SimulatorMonitorFragment(simulator.is_surface_simulation)
+        monitor_fragment.fill_from_trait(simulator.monitors)
+
+        rendering_rules.form = monitor_fragment
+        rendering_rules.form_action_url = form_action_url
+        return rendering_rules.to_dict()
+
+    @staticmethod
+    def prepare_next_fragment_if_bold(monitor, rendering_rules, form_action_url):
+        next_form = get_form_for_equation(type(monitor.hrf_kernel))()
+        next_form.fill_from_trait(monitor.hrf_kernel)
+        rendering_rules.form = next_form
+        rendering_rules.form_action_url = form_action_url
+        return rendering_rules.to_dict()
+
+    def handle_next_fragment_for_monitors(self, context, rendering_rules, current_monitor, next_monitor, is_noise_form,
+                                          form_action_url, if_bold_url):
+        simulator, _, _, is_branch = context.get_common_params()
+        if isinstance(current_monitor, BoldViewModel) and is_noise_form is False:
+            return self.prepare_next_fragment_if_bold(current_monitor, rendering_rules, if_bold_url)
+        if not next_monitor:
+            rendering_rules.is_branch = is_branch
+            return SimulatorFinalFragment.prepare_final_fragment(simulator, context.burst_config, context.project.id,
+                                                                 rendering_rules, SimulatorWizzardURLs.SETUP_PSE_URL)
+
+        next_form = get_form_for_monitor(type(next_monitor))(simulator)
+        next_form = AlgorithmService().prepare_adapter_form(form_instance=next_form, project_id=context.project.id)
+        next_form.fill_from_trait(next_monitor)
+        monitor_name = prepare_monitor_legend(simulator.is_surface_simulation, next_monitor)
+        rendering_rules.form = next_form
+        rendering_rules.form_action_url = form_action_url
+        rendering_rules.monitor_name = monitor_name
+        return rendering_rules.to_dict()
+
+    def prepare_next_fragment_after_noise(self, simulator, is_branch, rendering_rules, monitors_url,
+                                          noise_equation_params_url):
+        if isinstance(simulator.integrator.noise, AdditiveNoiseViewModel):
+            rendering_rules.is_branch = is_branch
+            return self.prepare_monitor_fragment(simulator, rendering_rules, monitors_url)
+
+        equation_form = get_form_for_equation(type(simulator.integrator.noise.b))()
+        equation_form.equation.data = simulator.integrator.noise.b.equation
+        equation_form.fill_from_trait(simulator.integrator.noise.b)
+
+        rendering_rules.form = equation_form
+        rendering_rules.form_action_url = noise_equation_params_url
+        return rendering_rules.to_dict()
+
+    @staticmethod
+    def get_fragment_after_monitors(simulator, burst_config, project_id, is_branch, rendering_rules, setup_pse_url):
+        first_monitor = simulator.first_monitor
+        if first_monitor is None:
+            rendering_rules.is_branch = is_branch
+            return SimulatorFinalFragment.prepare_final_fragment(simulator, burst_config, project_id, rendering_rules,
+                                                                 setup_pse_url)
+
+        form = get_form_for_monitor(type(first_monitor))(simulator)
+        form = AlgorithmService().prepare_adapter_form(form_instance=form)
+        form.fill_from_trait(first_monitor)
+
+        monitor_name = prepare_monitor_legend(simulator.is_surface_simulation, first_monitor)
+        rendering_rules.monitor_name = monitor_name
+        rendering_rules.form = form
+        return rendering_rules.to_dict()

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator/simulator_controller.py
@@ -399,7 +399,8 @@ class SimulatorController(BurstBaseController):
     def get_first_monitor_fragment_url(self, simulator, monitors_url):
         first_monitor = simulator.first_monitor
         if first_monitor is not None:
-            return self.build_monitor_url(monitors_url, type(first_monitor).__name__)
+            monitor_name = get_monitor_to_ui_name_dict(simulator)[first_monitor.__class__]
+            return self.build_monitor_url(monitors_url, monitor_name)
         return SimulatorWizzardURLs.SETUP_PSE_URL
 
     @expose_fragment('simulator_fragment')
@@ -428,7 +429,8 @@ class SimulatorController(BurstBaseController):
         if isinstance(current_monitor, BoldViewModel):
             return self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_EQUATION_URL, monitor_name)
         if next_monitor is not None:
-            return self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_PARAMS_URL, type(next_monitor).__name__)
+            next_monitor_name = get_monitor_to_ui_name_dict(False)[next_monitor.__class__]
+            return self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_PARAMS_URL, next_monitor_name)
         return SimulatorWizzardURLs.SETUP_PSE_URL
 
     @staticmethod
@@ -437,11 +439,12 @@ class SimulatorController(BurstBaseController):
             return SimulatorWizzardURLs.LAUNCH_PSE_URL
         return SimulatorWizzardURLs.SETUP_PSE_URL
 
-    def get_urls_for_next_monitor_fragment(self, next_monitor, current_monitor):
-        form_action_url = self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_PARAMS_URL,
-                                                 type(next_monitor).__name__)
-        if_bold_url = self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_EQUATION_URL,
-                                             type(current_monitor).__name__)
+    def get_urls_for_next_monitor_fragment(self, next_monitor, current_monitor, is_surface_simulation):
+        monitors_dict = get_monitor_to_ui_name_dict(is_surface_simulation)
+        next_monitor_name = monitors_dict[next_monitor.__class__] if next_monitor else 'None'
+        form_action_url = self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_PARAMS_URL, next_monitor_name)
+        current_monitor_name = monitors_dict[current_monitor.__class__]
+        if_bold_url = self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_EQUATION_URL, current_monitor_name)
         return form_action_url, if_bold_url
 
     @expose_fragment('simulator_fragment')
@@ -467,7 +470,8 @@ class SimulatorController(BurstBaseController):
             last_request_type=cherrypy.request.method, last_form_url=self.context.last_loaded_fragment_url,
             previous_form_action_url=previous_form_action_url)
 
-        form_action_url, if_bold_url = self.get_urls_for_next_monitor_fragment(next_monitor, current_monitor)
+        form_action_url, if_bold_url = self.get_urls_for_next_monitor_fragment(
+            next_monitor, current_monitor, session_stored_simulator.is_surface_simulation)
         return self.monitors_handler.handle_next_fragment_for_monitors(self.context, rendering_rules, current_monitor,
                                                                        next_monitor, False, form_action_url,
                                                                        if_bold_url)
@@ -655,7 +659,7 @@ class SimulatorController(BurstBaseController):
             self.context.init_session_at_burst_loading(burst_config, simulator, last_loaded_form_url)
 
             form = self.prepare_first_fragment()
-            self.monitors_handler.build_list_of_monitors_from_view_models(self.context.simulator.monitors)
+            self.monitors_handler.build_list_of_monitors_from_view_models(self.context.simulator)
             rendering_rules = SimulatorFragmentRenderingRules(form, SimulatorWizzardURLs.SET_CONNECTIVITY_URL,
                                                               is_simulation_readonly_load=True, is_first_fragment=True)
             return rendering_rules.to_dict()
@@ -669,7 +673,7 @@ class SimulatorController(BurstBaseController):
     def _prepare_first_fragment_for_burst_copy(self, burst_config_id, burst_name_format):
         simulator, burst_config_copy = self.burst_service.prepare_data_for_burst_copy(
             burst_config_id, burst_name_format, self.context.project)
-        self.monitors_handler.build_list_of_monitors_from_view_models(simulator.monitors)
+        self.monitors_handler.build_list_of_monitors_from_view_models(simulator)
 
         last_loaded_form_url = self.get_url_for_final_fragment(burst_config_copy)
         self.context.init_session_at_copy_preparation(burst_config_copy, simulator, last_loaded_form_url)
@@ -757,7 +761,7 @@ class SimulatorController(BurstBaseController):
             if upload_param in data and data[upload_param]:
                 simulator, burst_config = self.burst_service.load_simulation_from_zip(data[upload_param],
                                                                                       self.context.project)
-                self.monitors_handler.build_list_of_monitors_from_view_models(simulator.monitors)
+                self.monitors_handler.build_list_of_monitors_from_view_models(simulator)
                 if burst_config.is_pse_burst():
                     last_loaded_form_url = SimulatorWizzardURLs.LAUNCH_PSE_URL
                 self.context.init_session_at_sim_config_from_zip(burst_config, simulator, last_loaded_form_url)

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator/simulator_controller.py
@@ -37,6 +37,7 @@ from tvb.adapters.exporters.export_manager import ExportManager
 from tvb.adapters.simulator.coupling_forms import get_form_for_coupling
 from tvb.adapters.simulator.equation_forms import get_form_for_equation
 from tvb.adapters.simulator.model_forms import get_form_for_model
+from tvb.adapters.simulator.monitor_forms import get_form_for_monitor
 from tvb.adapters.simulator.noise_forms import get_form_for_noise
 from tvb.adapters.simulator.range_parameters import SimulatorRangeParameters
 from tvb.adapters.simulator.simulator_adapter import SimulatorAdapterForm

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator/simulator_controller.py
@@ -37,8 +37,6 @@ from tvb.adapters.exporters.export_manager import ExportManager
 from tvb.adapters.simulator.coupling_forms import get_form_for_coupling
 from tvb.adapters.simulator.equation_forms import get_form_for_equation
 from tvb.adapters.simulator.model_forms import get_form_for_model
-from tvb.adapters.simulator.monitor_forms import build_list_of_monitors_from_names, \
-    build_list_of_monitors_from_view_models
 from tvb.adapters.simulator.noise_forms import get_form_for_noise
 from tvb.adapters.simulator.range_parameters import SimulatorRangeParameters
 from tvb.adapters.simulator.simulator_adapter import SimulatorAdapterForm
@@ -56,6 +54,7 @@ from tvb.core.services.simulator_service import SimulatorService
 from tvb.interfaces.web.controllers.autologging import traced
 from tvb.interfaces.web.controllers.burst.base_controller import BurstBaseController
 from tvb.interfaces.web.controllers.decorators import *
+from tvb.interfaces.web.controllers.simulator.monitors_wizard_handler import MonitorsWizardHandler
 from tvb.interfaces.web.controllers.simulator.simulator_fragment_rendering_rules import \
     SimulatorFragmentRenderingRules, POST_REQUEST
 from tvb.interfaces.web.controllers.simulator.simulator_wizzard_urls import SimulatorWizzardURLs
@@ -77,7 +76,7 @@ class SimulatorController(BurstBaseController):
         self.cached_simulator_algorithm = self.algorithm_service.get_algorithm_by_module_and_class(
             IntrospectionRegistry.SIMULATOR_MODULE, IntrospectionRegistry.SIMULATOR_CLASS)
         self.context = SimulatorContext()
-        self.next_monitors_dict = None
+        self.monitors_handler = MonitorsWizardHandler()
 
     @expose_json
     def cancel_or_remove_burst(self, burst_id):
@@ -337,8 +336,8 @@ class SimulatorController(BurstBaseController):
             is_noise_fragment=False)
 
         if not isinstance(session_stored_simulator.integrator, IntegratorStochasticViewModel):
-            return SimulatorMonitorFragment.prepare_monitor_fragment(session_stored_simulator, rendering_rules,
-                                                                     SimulatorWizzardURLs.SET_MONITORS_URL)
+            return self.monitors_handler.prepare_monitor_fragment(session_stored_simulator, rendering_rules,
+                                                                  SimulatorWizzardURLs.SET_MONITORS_URL)
 
         integrator_noise_fragment = get_form_for_noise(type(session_stored_simulator.integrator.noise))()
         if hasattr(integrator_noise_fragment, 'equation'):
@@ -350,21 +349,6 @@ class SimulatorController(BurstBaseController):
         rendering_rules.form = integrator_noise_fragment
         rendering_rules.form_action_url = SimulatorWizzardURLs.SET_NOISE_PARAMS_URL
         rendering_rules.is_noise_fragment = True
-        return rendering_rules.to_dict()
-
-    @staticmethod
-    def prepare_next_fragment_after_noise(simulator, is_branch, rendering_rules, monitors_url,
-                                          noise_equation_params_url):
-        if isinstance(simulator.integrator.noise, AdditiveNoiseViewModel):
-            rendering_rules.is_branch = is_branch
-            return SimulatorMonitorFragment.prepare_monitor_fragment(simulator, rendering_rules, monitors_url)
-
-        equation_form = get_form_for_equation(type(simulator.integrator.noise.b))()
-        equation_form.equation.data = simulator.integrator.noise.b.equation
-        equation_form.fill_from_trait(simulator.integrator.noise.b)
-
-        rendering_rules.form = equation_form
-        rendering_rules.form_action_url = noise_equation_params_url
         return rendering_rules.to_dict()
 
     @expose_fragment('simulator_fragment')
@@ -384,9 +368,9 @@ class SimulatorController(BurstBaseController):
             None, None, SimulatorWizzardURLs.SET_NOISE_PARAMS_URL, is_simulation_copy, is_simulation_load,
             self.context.last_loaded_fragment_url, cherrypy.request.method)
 
-        return self.prepare_next_fragment_after_noise(session_stored_simulator, is_branch,
-                                                      rendering_rules, SimulatorWizzardURLs.SET_MONITORS_URL,
-                                                      SimulatorWizzardURLs.SET_NOISE_EQUATION_PARAMS_URL)
+        return self.monitors_handler.prepare_next_fragment_after_noise(
+            session_stored_simulator, is_branch, rendering_rules, SimulatorWizzardURLs.SET_MONITORS_URL,
+            SimulatorWizzardURLs.SET_NOISE_EQUATION_PARAMS_URL)
 
     @expose_fragment('simulator_fragment')
     def set_noise_equation_params(self, **data):
@@ -402,8 +386,8 @@ class SimulatorController(BurstBaseController):
             None, None, SimulatorWizzardURLs.SET_NOISE_EQUATION_PARAMS_URL, is_simulation_copy, is_simulation_load,
             self.context.last_loaded_fragment_url, cherrypy.request.method)
 
-        return SimulatorMonitorFragment.prepare_monitor_fragment(session_stored_simulator, rendering_rules,
-                                                                 SimulatorWizzardURLs.SET_MONITORS_URL)
+        return self.monitors_handler.prepare_monitor_fragment(session_stored_simulator, rendering_rules,
+                                                              SimulatorWizzardURLs.SET_MONITORS_URL)
 
     @staticmethod
     def build_monitor_url(fragment_url, monitor):
@@ -423,10 +407,7 @@ class SimulatorController(BurstBaseController):
         if cherrypy.request.method == POST_REQUEST:
             fragment = SimulatorMonitorFragment(is_surface_simulation=session_stored_simulator.is_surface_simulation)
             fragment.fill_from_post(data)
-
-            self.next_monitors_dict = build_list_of_monitors_from_names(fragment.monitors.value,
-                                                                        session_stored_simulator.is_surface_simulation)
-            session_stored_simulator.monitors = list(monitor for monitor, _ in self.next_monitors_dict.values())
+            self.monitors_handler.set_monitors_list_on_simulator(session_stored_simulator, fragment.monitors.value)
 
         last_loaded_fragment_url = self.get_first_monitor_fragment_url(
             session_stored_simulator, SimulatorWizzardURLs.SET_MONITOR_PARAMS_URL)
@@ -438,7 +419,7 @@ class SimulatorController(BurstBaseController):
             is_simulation_copy=is_simulation_copy, is_simulation_readonly_load=is_simulation_load,
             last_request_type=cherrypy.request.method, form_action_url=last_loaded_fragment_url,
             previous_form_action_url=SimulatorWizzardURLs.SET_MONITORS_URL)
-        return SimulatorMonitorFragment.get_fragment_after_monitors(
+        return self.monitors_handler.get_fragment_after_monitors(
             session_stored_simulator, self.context.burst_config, self.context.project.id,
             is_branch, rendering_rules, SimulatorWizzardURLs.SETUP_PSE_URL)
 
@@ -455,40 +436,19 @@ class SimulatorController(BurstBaseController):
             return SimulatorWizzardURLs.LAUNCH_PSE_URL
         return SimulatorWizzardURLs.SETUP_PSE_URL
 
-    def prepare_next_fragment_if_bold(self, monitor, rendering_rules):
-        next_form = get_form_for_equation(type(monitor.hrf_kernel))()
-        next_form.fill_from_trait(monitor.hrf_kernel)
-        rendering_rules.form = next_form
-        rendering_rules.form_action_url = self.build_monitor_url(
-            SimulatorWizzardURLs.SET_MONITOR_EQUATION_URL, type(monitor).__name__)
-        return rendering_rules.to_dict()
-
-    def handle_next_fragment_for_monitors(self, simulator, burst_config, project_id, is_branch, rendering_rules,
-                                          current_monitor, next_monitor, is_noise_form):
-        if isinstance(current_monitor, BoldViewModel) and is_noise_form is False:
-            return self.prepare_next_fragment_if_bold(current_monitor, rendering_rules)
-        if not next_monitor:
-            rendering_rules.is_branch = is_branch
-            return SimulatorFinalFragment.prepare_final_fragment(simulator, burst_config, project_id, rendering_rules,
-                                                                 SimulatorWizzardURLs.SETUP_PSE_URL)
-
-        next_form = get_form_for_monitor(type(next_monitor))(simulator)
-        next_form = self.algorithm_service.prepare_adapter_form(form_instance=next_form, project_id=project_id)
-        next_form.fill_from_trait(next_monitor)
+    def get_urls_for_next_monitor_fragment(self, next_monitor, current_monitor):
         form_action_url = self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_PARAMS_URL,
                                                  type(next_monitor).__name__)
-        monitor_name = prepare_monitor_legend(simulator.is_surface_simulation, next_monitor)
-        rendering_rules.form = next_form
-        rendering_rules.form_action_url = form_action_url
-        rendering_rules.monitor_name = monitor_name
-        return rendering_rules.to_dict()
+        if_bold_url = self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_EQUATION_URL,
+                                             type(current_monitor).__name__)
+        return form_action_url, if_bold_url
 
     @expose_fragment('simulator_fragment')
     def set_monitor_params(self, current_monitor_name, **data):
         session_stored_simulator, is_simulation_copy, is_simulator_load, is_branch = self.context.get_common_params()
 
-        current_monitor, next_monitor = self.simulator_service.get_current_and_next_monitor_form(
-            current_monitor_name, session_stored_simulator, self.next_monitors_dict)
+        current_monitor, next_monitor = self.monitors_handler.get_current_and_next_monitor_form(
+            current_monitor_name, session_stored_simulator)
 
         if cherrypy.request.method == POST_REQUEST:
             form = get_form_for_monitor(type(current_monitor))(session_stored_simulator)
@@ -496,7 +456,7 @@ class SimulatorController(BurstBaseController):
             form.fill_trait(current_monitor)
 
             last_loaded_form_url = self.get_url_after_monitors(
-                current_monitor, current_monitor, next_monitor)
+                current_monitor, current_monitor_name, next_monitor)
             self.context.add_last_loaded_form_url_to_session(last_loaded_form_url)
 
         previous_form_action_url = self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_PARAMS_URL,
@@ -506,9 +466,10 @@ class SimulatorController(BurstBaseController):
             last_request_type=cherrypy.request.method, last_form_url=self.context.last_loaded_fragment_url,
             previous_form_action_url=previous_form_action_url)
 
-        return self.handle_next_fragment_for_monitors(session_stored_simulator, self.context.burst_config,
-                                                      self.context.project.id, is_branch, rendering_rules,
-                                                      current_monitor, next_monitor, False)
+        form_action_url, if_bold_url = self.get_urls_for_next_monitor_fragment(next_monitor, current_monitor)
+        return self.monitors_handler.handle_next_fragment_for_monitors(self.context, rendering_rules, current_monitor,
+                                                                       next_monitor, False, form_action_url,
+                                                                       if_bold_url)
 
     def get_url_after_monitor_equation(self, next_monitor):
         if next_monitor is None:
@@ -521,8 +482,8 @@ class SimulatorController(BurstBaseController):
     @expose_fragment('simulator_fragment')
     def set_monitor_equation(self, current_monitor_name, **data):
         session_stored_simulator, is_simulation_copy, is_simulator_load, is_branch = self.context.get_common_params()
-        current_monitor, next_monitor = self.simulator_service.get_current_and_next_monitor_form(
-            current_monitor_name, session_stored_simulator, self.next_monitors_dict)
+        current_monitor, next_monitor = self.monitors_handler.get_current_and_next_monitor_form(
+            current_monitor_name, session_stored_simulator)
 
         if cherrypy.request.method == POST_REQUEST:
             form = get_form_for_equation(type(current_monitor.hrf_kernel))()
@@ -538,9 +499,9 @@ class SimulatorController(BurstBaseController):
             None, None, previous_form_action_url, is_simulation_copy, is_simulator_load,
             self.context.last_loaded_fragment_url, cherrypy.request)
 
-        return self.handle_next_fragment_for_monitors(session_stored_simulator, self.context.burst_config,
-                                                      self.context.project.id, is_branch, rendering_rules,
-                                                      current_monitor, next_monitor, True)
+        form_action_url, if_bold_url = self.get_urls_for_next_monitor_fragment(next_monitor, current_monitor)
+        return self.monitors_handler.handle_next_fragment_for_monitors(self.context, rendering_rules, current_monitor,
+                                                                       next_monitor, True, form_action_url, if_bold_url)
 
     @expose_fragment('simulator_fragment')
     def setup_pse(self, **data):
@@ -693,8 +654,7 @@ class SimulatorController(BurstBaseController):
             self.context.init_session_at_burst_loading(burst_config, simulator, last_loaded_form_url)
 
             form = self.prepare_first_fragment()
-            session_stored_simulator = self.context.simulator
-            self.next_monitors_dict = build_list_of_monitors_from_view_models(session_stored_simulator.monitors)
+            self.monitors_handler.build_list_of_monitors_from_view_models(self.context.simulator.monitors)
             rendering_rules = SimulatorFragmentRenderingRules(form, SimulatorWizzardURLs.SET_CONNECTIVITY_URL,
                                                               is_simulation_readonly_load=True, is_first_fragment=True)
             return rendering_rules.to_dict()
@@ -708,7 +668,7 @@ class SimulatorController(BurstBaseController):
     def _prepare_first_fragment_for_burst_copy(self, burst_config_id, burst_name_format):
         simulator, burst_config_copy = self.burst_service.prepare_data_for_burst_copy(
             burst_config_id, burst_name_format, self.context.project)
-        self.next_monitors_dict = build_list_of_monitors_from_view_models(simulator.monitors)
+        self.monitors_handler.build_list_of_monitors_from_view_models(simulator.monitors)
 
         last_loaded_form_url = self.get_url_for_final_fragment(burst_config_copy)
         self.context.init_session_at_copy_preparation(burst_config_copy, simulator, last_loaded_form_url)
@@ -737,8 +697,7 @@ class SimulatorController(BurstBaseController):
     def reset_simulator_configuration(self):
         burst_config = BurstConfiguration(self.context.project.id)
         self.context.init_session_at_sim_reset(burst_config, SimulatorWizzardURLs.SET_CONNECTIVITY_URL)
-        if self.next_monitors_dict:
-            self.next_monitors_dict.clear()
+        self.monitors_handler.clear_next_monitors_dict()
 
         form = self.prepare_first_fragment()
         rendering_rules = SimulatorFragmentRenderingRules(form, SimulatorWizzardURLs.SET_CONNECTIVITY_URL,
@@ -797,7 +756,7 @@ class SimulatorController(BurstBaseController):
             if upload_param in data and data[upload_param]:
                 simulator, burst_config = self.burst_service.load_simulation_from_zip(data[upload_param],
                                                                                       self.context.project)
-                self.next_monitors_dict = build_list_of_monitors_from_view_models(simulator.monitors)
+                self.monitors_handler.build_list_of_monitors_from_view_models(simulator.monitors)
                 if burst_config.is_pse_burst():
                     last_loaded_form_url = SimulatorWizzardURLs.LAUNCH_PSE_URL
                 self.context.init_session_at_sim_config_from_zip(burst_config, simulator, last_loaded_form_url)

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator/simulator_controller.py
@@ -399,8 +399,8 @@ class SimulatorController(BurstBaseController):
     def get_first_monitor_fragment_url(self, simulator, monitors_url):
         first_monitor = simulator.first_monitor
         if first_monitor is not None:
-            monitor_name = get_monitor_to_ui_name_dict(simulator)[first_monitor.__class__]
-            return self.build_monitor_url(monitors_url, monitor_name)
+            monitor_vm_name = type(first_monitor).__name__
+            return self.build_monitor_url(monitors_url, monitor_vm_name)
         return SimulatorWizzardURLs.SETUP_PSE_URL
 
     @expose_fragment('simulator_fragment')
@@ -429,8 +429,7 @@ class SimulatorController(BurstBaseController):
         if isinstance(current_monitor, BoldViewModel):
             return self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_EQUATION_URL, monitor_name)
         if next_monitor is not None:
-            next_monitor_name = get_monitor_to_ui_name_dict(False)[next_monitor.__class__]
-            return self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_PARAMS_URL, next_monitor_name)
+            return self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_PARAMS_URL, type(next_monitor).__name__)
         return SimulatorWizzardURLs.SETUP_PSE_URL
 
     @staticmethod
@@ -439,12 +438,11 @@ class SimulatorController(BurstBaseController):
             return SimulatorWizzardURLs.LAUNCH_PSE_URL
         return SimulatorWizzardURLs.SETUP_PSE_URL
 
-    def get_urls_for_next_monitor_fragment(self, next_monitor, current_monitor, is_surface_simulation):
-        monitors_dict = get_monitor_to_ui_name_dict(is_surface_simulation)
-        next_monitor_name = monitors_dict[next_monitor.__class__] if next_monitor else 'None'
-        form_action_url = self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_PARAMS_URL, next_monitor_name)
-        current_monitor_name = monitors_dict[current_monitor.__class__]
-        if_bold_url = self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_EQUATION_URL, current_monitor_name)
+    def get_urls_for_next_monitor_fragment(self, next_monitor, current_monitor):
+        form_action_url = self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_PARAMS_URL,
+                                                 type(next_monitor).__name__)
+        if_bold_url = self.build_monitor_url(SimulatorWizzardURLs.SET_MONITOR_EQUATION_URL,
+                                             type(current_monitor).__name__)
         return form_action_url, if_bold_url
 
     @expose_fragment('simulator_fragment')
@@ -470,8 +468,7 @@ class SimulatorController(BurstBaseController):
             last_request_type=cherrypy.request.method, last_form_url=self.context.last_loaded_fragment_url,
             previous_form_action_url=previous_form_action_url)
 
-        form_action_url, if_bold_url = self.get_urls_for_next_monitor_fragment(
-            next_monitor, current_monitor, session_stored_simulator.is_surface_simulation)
+        form_action_url, if_bold_url = self.get_urls_for_next_monitor_fragment(next_monitor, current_monitor)
         return self.monitors_handler.handle_next_fragment_for_monitors(self.context, rendering_rules, current_monitor,
                                                                        next_monitor, False, form_action_url,
                                                                        if_bold_url)

--- a/framework_tvb/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
@@ -57,7 +57,7 @@ from tvb.core.services.operation_service import OperationService
 from tvb.datatypes.equations import FirstOrderVolterra, GeneralizedSigmoid, TemporalApplicableEquation, Linear
 from tvb.datatypes.surfaces import CORTICAL
 from tvb.interfaces.web.controllers.common import *
-from tvb.interfaces.web.controllers.simulator.simulator_controller import SimulatorController, common
+from tvb.interfaces.web.controllers.simulator.simulator_controller import SimulatorController
 from tvb.simulator.coupling import Sigmoidal
 from tvb.simulator.models import ModelsEnum
 from tvb.tests.framework.core.factory import TestFactory

--- a/framework_tvb/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
@@ -38,8 +38,8 @@ from os import path
 from uuid import UUID
 from mock import patch
 from datetime import datetime
-
 from cherrypy.lib.sessions import RamSession
+
 from tvb.adapters.creators.stimulus_creator import RegionStimulusCreator
 from tvb.adapters.datatypes.db.patterns import StimuliRegionIndex
 from tvb.adapters.datatypes.db.simulation_history import SimulationHistoryIndex
@@ -432,7 +432,7 @@ class TestSimulationController(BaseTransactionalControllerTest):
             self.simulator_controller.context.add_session_stored_simulator(self.session_stored_simulator)
             self.simulator_controller.context.add_burst_config_to_session(BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitors(**self.sess_mock._data)
-            rendering_rules = self.simulator_controller.set_monitor_params('SubSampleViewModel', **self.sess_mock._data)
+            rendering_rules = self.simulator_controller.set_monitor_params('Temporally sub-sample', **self.sess_mock._data)
 
         assert self.session_stored_simulator.monitors[0].period == 0.8, "Period was not set correctly."
         assert list(self.session_stored_simulator.monitors[0].variables_of_interest) == \
@@ -486,7 +486,7 @@ class TestSimulationController(BaseTransactionalControllerTest):
             self.simulator_controller.context.add_session_stored_simulator(self.session_stored_simulator)
             self.simulator_controller.context.add_burst_config_to_session(BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitors(**self.sess_mock._data)
-            self.simulator_controller.set_monitor_params('EEGViewModel', **self.sess_mock._data)
+            self.simulator_controller.set_monitor_params('EEG', **self.sess_mock._data)
 
         assert self.session_stored_simulator.monitors[0].period == 0.75, "Period was not set correctly."
         assert list(self.session_stored_simulator.monitors[0].variables_of_interest) == \
@@ -532,7 +532,7 @@ class TestSimulationController(BaseTransactionalControllerTest):
             self.simulator_controller.context.add_session_stored_simulator(self.session_stored_simulator)
             self.simulator_controller.context.add_burst_config_to_session(BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitors(**self.sess_mock._data)
-            self.simulator_controller.set_monitor_params('MEGViewModel', **self.sess_mock._data)
+            self.simulator_controller.set_monitor_params('MEG', **self.sess_mock._data)
 
         assert self.session_stored_simulator.monitors[0].period == 0.75, "Period was not set correctly."
         assert list(self.session_stored_simulator.monitors[0].variables_of_interest) == \
@@ -578,7 +578,7 @@ class TestSimulationController(BaseTransactionalControllerTest):
             self.simulator_controller.context.add_session_stored_simulator(self.session_stored_simulator)
             self.simulator_controller.context.add_burst_config_to_session(BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitors(**self.sess_mock._data)
-            self.simulator_controller.set_monitor_params('iEEGViewModel', **self.sess_mock._data)
+            self.simulator_controller.set_monitor_params('Intracerebral / Stereo EEG', **self.sess_mock._data)
 
         assert self.session_stored_simulator.monitors[0].period == 0.75, "Period was not set correctly."
         assert list(self.session_stored_simulator.monitors[0].variables_of_interest) == \
@@ -604,7 +604,7 @@ class TestSimulationController(BaseTransactionalControllerTest):
         with patch('cherrypy.session', self.sess_mock, create=True):
             self.simulator_controller.context.add_session_stored_simulator(self.session_stored_simulator)
             self.simulator_controller.set_monitors(**self.sess_mock._data)
-            self.simulator_controller.set_monitor_params('BoldViewModel', **self.sess_mock._data)
+            self.simulator_controller.set_monitor_params('BOLD', **self.sess_mock._data)
 
         assert self.session_stored_simulator.monitors[0].period == 2000.0, "Period was not set correctly."
         assert list(self.session_stored_simulator.monitors[0].variables_of_interest) == \
@@ -633,9 +633,10 @@ class TestSimulationController(BaseTransactionalControllerTest):
             self.simulator_controller.context.add_session_stored_simulator(self.session_stored_simulator)
             self.simulator_controller.context.add_burst_config_to_session(BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitors(**self.sess_mock._data)
-            self.simulator_controller.set_monitor_params('SpatialAverageViewModel', **self.sess_mock._data)
-            self.simulator_controller.set_monitor_params('TemporalAverageViewModel', **self.sess_mock._data)
-            self.simulator_controller.set_monitor_params('EEGViewModel', **self.sess_mock._data)
+            self.simulator_controller.set_monitor_params('Spatial average with temporal sub-sample',
+                                                         **self.sess_mock._data)
+            self.simulator_controller.set_monitor_params('Temporal average', **self.sess_mock._data)
+            self.simulator_controller.set_monitor_params('EEG', **self.sess_mock._data)
 
         assert list(self.session_stored_simulator.monitors[0].variables_of_interest) == \
                list(variable_of_interest_indexes.values()), "Variables of interest were not set correctly."
@@ -664,7 +665,7 @@ class TestSimulationController(BaseTransactionalControllerTest):
             self.simulator_controller.context.add_session_stored_simulator(self.session_stored_simulator)
             self.simulator_controller.context.add_burst_config_to_session(BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitors(**self.sess_mock._data)
-            self.simulator_controller.set_monitor_equation('BoldViewModel', **self.sess_mock._data)
+            self.simulator_controller.set_monitor_equation('BOLD', **self.sess_mock._data)
 
         assert self.session_stored_simulator.monitors[0].hrf_kernel.parameters[
                    'tau_s'] == 0.8, "tau_s value was not set correctly."

--- a/framework_tvb/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
@@ -432,7 +432,7 @@ class TestSimulationController(BaseTransactionalControllerTest):
             self.simulator_controller.context.add_session_stored_simulator(self.session_stored_simulator)
             self.simulator_controller.context.add_burst_config_to_session(BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitors(**self.sess_mock._data)
-            rendering_rules = self.simulator_controller.set_monitor_params('Temporally sub-sample', **self.sess_mock._data)
+            rendering_rules = self.simulator_controller.set_monitor_params('SubSampleViewModel', **self.sess_mock._data)
 
         assert self.session_stored_simulator.monitors[0].period == 0.8, "Period was not set correctly."
         assert list(self.session_stored_simulator.monitors[0].variables_of_interest) == \
@@ -486,7 +486,7 @@ class TestSimulationController(BaseTransactionalControllerTest):
             self.simulator_controller.context.add_session_stored_simulator(self.session_stored_simulator)
             self.simulator_controller.context.add_burst_config_to_session(BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitors(**self.sess_mock._data)
-            self.simulator_controller.set_monitor_params('EEG', **self.sess_mock._data)
+            self.simulator_controller.set_monitor_params('EEGViewModel', **self.sess_mock._data)
 
         assert self.session_stored_simulator.monitors[0].period == 0.75, "Period was not set correctly."
         assert list(self.session_stored_simulator.monitors[0].variables_of_interest) == \
@@ -532,7 +532,7 @@ class TestSimulationController(BaseTransactionalControllerTest):
             self.simulator_controller.context.add_session_stored_simulator(self.session_stored_simulator)
             self.simulator_controller.context.add_burst_config_to_session(BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitors(**self.sess_mock._data)
-            self.simulator_controller.set_monitor_params('MEG', **self.sess_mock._data)
+            self.simulator_controller.set_monitor_params('MEGViewModel', **self.sess_mock._data)
 
         assert self.session_stored_simulator.monitors[0].period == 0.75, "Period was not set correctly."
         assert list(self.session_stored_simulator.monitors[0].variables_of_interest) == \
@@ -578,7 +578,7 @@ class TestSimulationController(BaseTransactionalControllerTest):
             self.simulator_controller.context.add_session_stored_simulator(self.session_stored_simulator)
             self.simulator_controller.context.add_burst_config_to_session(BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitors(**self.sess_mock._data)
-            self.simulator_controller.set_monitor_params('Intracerebral / Stereo EEG', **self.sess_mock._data)
+            self.simulator_controller.set_monitor_params('iEEGViewModel', **self.sess_mock._data)
 
         assert self.session_stored_simulator.monitors[0].period == 0.75, "Period was not set correctly."
         assert list(self.session_stored_simulator.monitors[0].variables_of_interest) == \
@@ -604,7 +604,7 @@ class TestSimulationController(BaseTransactionalControllerTest):
         with patch('cherrypy.session', self.sess_mock, create=True):
             self.simulator_controller.context.add_session_stored_simulator(self.session_stored_simulator)
             self.simulator_controller.set_monitors(**self.sess_mock._data)
-            self.simulator_controller.set_monitor_params('BOLD', **self.sess_mock._data)
+            self.simulator_controller.set_monitor_params('BoldViewModel', **self.sess_mock._data)
 
         assert self.session_stored_simulator.monitors[0].period == 2000.0, "Period was not set correctly."
         assert list(self.session_stored_simulator.monitors[0].variables_of_interest) == \
@@ -633,10 +633,10 @@ class TestSimulationController(BaseTransactionalControllerTest):
             self.simulator_controller.context.add_session_stored_simulator(self.session_stored_simulator)
             self.simulator_controller.context.add_burst_config_to_session(BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitors(**self.sess_mock._data)
-            self.simulator_controller.set_monitor_params('Spatial average with temporal sub-sample',
+            self.simulator_controller.set_monitor_params('SpatialAverageViewModel',
                                                          **self.sess_mock._data)
-            self.simulator_controller.set_monitor_params('Temporal average', **self.sess_mock._data)
-            self.simulator_controller.set_monitor_params('EEG', **self.sess_mock._data)
+            self.simulator_controller.set_monitor_params('TemporalAverageViewModel', **self.sess_mock._data)
+            self.simulator_controller.set_monitor_params('EEGViewModel', **self.sess_mock._data)
 
         assert list(self.session_stored_simulator.monitors[0].variables_of_interest) == \
                list(variable_of_interest_indexes.values()), "Variables of interest were not set correctly."
@@ -665,7 +665,7 @@ class TestSimulationController(BaseTransactionalControllerTest):
             self.simulator_controller.context.add_session_stored_simulator(self.session_stored_simulator)
             self.simulator_controller.context.add_burst_config_to_session(BurstConfiguration(self.test_project.id))
             self.simulator_controller.set_monitors(**self.sess_mock._data)
-            self.simulator_controller.set_monitor_equation('BOLD', **self.sess_mock._data)
+            self.simulator_controller.set_monitor_equation('BoldViewModel', **self.sess_mock._data)
 
         assert self.session_stored_simulator.monitors[0].hrf_kernel.parameters[
                    'tau_s'] == 0.8, "tau_s value was not set correctly."


### PR DESCRIPTION
Except the url handling (which I think it must stay in the controller) I moved everything else related to monitors (preparing the fragments and the monitor dict) in this one new class. I chose to send context instead of 4 params to handle_next_fragment_for_monitors, otherwise we woul end up with 10 parameters for that method and I wanted to avoid that many sent params.