### PR TITLE
TVB-2869: Convert string booleans to booleans when applying filters 

### DIFF
--- a/framework_tvb/tvb/interfaces/web/controllers/flow_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/flow_controller.py
@@ -261,16 +261,12 @@ class FlowController(BaseController):
         index_class = getattr(sys.modules[dt_module], dt_class)()
         filters_dict = json.loads(filters)
 
-        fields = []
-        operations = []
-        values = []
-
         for idx in range(len(filters_dict['fields'])):
-            fields.append(filters_dict['fields'][idx])
-            operations.append(filters_dict['operations'][idx])
-            values.append(filters_dict['values'][idx])
+            if filters_dict['values'][idx] in ['True', 'False']:
+                filters_dict['values'][idx] = string2bool(filters_dict['values'][idx])
 
-        filter = FilterChain(fields=fields, operations=operations, values=values)
+        filter = FilterChain(fields=filters_dict['fields'], operations=filters_dict['operations'],
+                             values=filters_dict['values'])
         project = common.get_current_project()
 
         data_type_gid_attr = DataTypeGidAttr(linked_datatype=REGISTRY.get_datatype_for_index(index_class))


### PR DESCRIPTION
The problem appears only with SQLite when applying a filter. When loading a page everything is good, but when the filters are applied on a field and the sql query string is built, instead of 'True' you have '"True"' and that is what messed things up.