### PR TITLE
TVB-2876: Fix integrator choice in PhasePlane

### DIFF
--- a/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
@@ -35,8 +35,7 @@ from formencode import validators
 from tvb.adapters.datatypes.db.patterns import StimuliRegionIndex, SpatioTemporalPatternIndex
 from tvb.adapters.simulator.integrator_forms import get_form_for_integrator
 from tvb.adapters.simulator.model_forms import get_ui_name_to_model
-from tvb.adapters.simulator.monitor_forms import get_ui_name_to_monitor_dict, get_monitor_to_ui_name_dict, \
-    get_form_for_monitor, prepare_monitor_legend
+from tvb.adapters.simulator.monitor_forms import get_ui_name_to_monitor_dict, get_monitor_to_ui_name_dict
 from tvb.adapters.simulator.subforms_mapping import get_ui_name_to_integrator_dict, get_integrator_name_list
 from tvb.basic.neotraits.api import Attr, Range, List, Float
 from tvb.core.adapters.abcadapter import ABCAdapterForm

--- a/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
@@ -35,8 +35,9 @@ from formencode import validators
 from tvb.adapters.datatypes.db.patterns import StimuliRegionIndex, SpatioTemporalPatternIndex
 from tvb.adapters.simulator.integrator_forms import get_form_for_integrator
 from tvb.adapters.simulator.model_forms import get_ui_name_to_model
-from tvb.adapters.simulator.monitor_forms import get_ui_name_to_monitor_dict, get_monitor_to_ui_name_dict
-from tvb.adapters.simulator.subforms_mapping import get_ui_name_to_integrator_dict
+from tvb.adapters.simulator.monitor_forms import get_ui_name_to_monitor_dict, get_monitor_to_ui_name_dict, \
+    get_form_for_monitor, prepare_monitor_legend
+from tvb.adapters.simulator.subforms_mapping import get_ui_name_to_integrator_dict, get_integrator_name_list
 from tvb.basic.neotraits.api import Attr, Range, List, Float
 from tvb.core.adapters.abcadapter import ABCAdapterForm
 from tvb.core.entities.file.simulator.view_model import CortexViewModel, SimulatorAdapterModel, IntegratorViewModel
@@ -164,7 +165,7 @@ class SimulatorIntegratorFragment(ABCAdapterForm):
         self.integrator = SelectField(
             Attr(IntegratorViewModel, default=default_integrator, label=SimulatorAdapterModel.integrator.label,
                  doc=SimulatorAdapterModel.integrator.doc), name='integrator', choices=self.integrator_choices,
-            subform=get_form_for_integrator(default_integrator))
+            subform=get_form_for_integrator(default_integrator), ui_values=get_integrator_name_list())
 
     def fill_from_trait(self, trait):
         # type: (SimulatorAdapterModel) -> None

--- a/framework_tvb/tvb/adapters/simulator/subforms_mapping.py
+++ b/framework_tvb/tvb/adapters/simulator/subforms_mapping.py
@@ -70,6 +70,13 @@ def get_ui_name_to_noise_dict():
     return ui_name_to_noise
 
 
+def get_integrator_name_list():
+    return ['Heun', 'Stochastic Heun', 'Euler', 'Euler-Maruyama', 'Runge-Kutta 4th order', 'Difference equation',
+            'Variable-order Adams / BDF', 'Stochastic variable-order Adams / BDF', 'Dormand-Prince, order (4, 5)',
+            'Stochastic Dormand-Prince, order (4, 5)', 'Stochastic Dormand-Prince, order (4, 5)',
+            'Stochastic Dormand-Prince, order 8 (5, 3)']
+
+
 def get_ui_name_to_integrator_dict():
     ui_name_to_integrator = {
         'Heun': HeunDeterministicViewModel,
@@ -78,8 +85,8 @@ def get_ui_name_to_integrator_dict():
         'Euler-Maruyama': EulerStochasticViewModel,
         'Runge-Kutta 4th order': RungeKutta4thOrderDeterministicViewModel,
         'Difference equation': IdentityViewModel,
-        'Variable-order Adams / BDF': VODEViewModel,
-        'Stochastic variable-order Adams / BDF': VODEStochasticViewModel,
+        'Variable-order Adams (BDF)': VODEViewModel,
+        'Stochastic variable-order Adams (BDF)': VODEStochasticViewModel,
         'Dormand-Prince, order (4, 5)': Dopri5ViewModel,
         'Stochastic Dormand-Prince, order (4, 5)': Dopri5StochasticViewModel,
         'Dormand-Prince, order 8 (5, 3)': Dop853ViewModel,

--- a/framework_tvb/tvb/core/neotraits/forms.py
+++ b/framework_tvb/tvb/core/neotraits/forms.py
@@ -294,7 +294,7 @@ class SelectField(TraitField):
             self.template = 'form_fields/select_field.html'
 
     def __init__(self, trait_attribute, name=None, disabled=False, choices=None, display_none_choice=True,
-                 subform=None, display_subform=True):
+                 subform=None, display_subform=True, ui_values=None):
         super(SelectField, self).__init__(trait_attribute, name, disabled)
         if choices:
             self.choices = choices
@@ -308,6 +308,7 @@ class SelectField(TraitField):
             self.subform_field = FormField(subform, self.subform_prefix + self.name)
             self.display_subform = display_subform
         self._prepare_template(self.choices)
+        self.ui_values = ui_values
 
     @property
     def value(self):
@@ -327,11 +328,13 @@ class SelectField(TraitField):
                     checked=self.data is None
                 )
 
+        choices = self.ui_values if self.ui_values is not None else list(self.choices.keys())
+
         for i, choice in enumerate(self.choices):
             yield Option(
                 id='{}_{}'.format(self.name, i),
                 value=choice,
-                label=str(choice).title(),
+                label=str(choices[i]).title(),
                 checked=self.value == self.choices.get(choice)
             )
 


### PR DESCRIPTION
I propose this solution which would work for any select fields that could have '/' in their name. When ui_values is provided, the integrator names that appear in the UI are NOT used to get the VMs from choices, instead we use another dict which does not have names containing '/'. 