### PR TITLE
TVB-2881: Solved issue which appears when removing a PSE simulation.

### DIFF
--- a/framework_tvb/tvb/core/entities/model/model_burst.py
+++ b/framework_tvb/tvb/core/entities/model/model_burst.py
@@ -34,16 +34,17 @@
 
 from sqlalchemy import Column, Integer, ForeignKey, String, DateTime
 from sqlalchemy.orm import relationship, backref
-from tvb.core.utils import format_timedelta
 from tvb.core.entities.model.model_operation import OperationGroup
 from tvb.core.entities.model.model_project import Project
 from tvb.core.neotraits.db import Base, HasTraitsIndex
+from tvb.core.utils import format_timedelta
 
 NUMBER_OF_PORTLETS_PER_TAB = 4
 
 PARAM_RANGE_PREFIX = 'range_'
 RANGE_PARAMETER_1 = "range_1"
 RANGE_PARAMETER_2 = "range_2"
+
 
 ## TabConfiguration entity is not moved in the "transient" module, although it's not stored in DB,
 ## because it was directly referenced from the BurstConfiguration old class.
@@ -195,3 +196,16 @@ class BurstConfiguration(HasTraitsIndex):
         if self.range1:
             return [self.range1]
         return None
+
+    @property
+    def is_finished(self):
+        return self.status != self.BURST_RUNNING
+
+    @property
+    def operation_info_for_burst_removal(self):
+        """
+        Return operation id for whole burst removal and a flag specifying whether the current burst is a group.
+        """
+        if self.fk_operation_group is None:
+            return self.fk_simulation, False
+        return self.fk_operation_group, True

--- a/framework_tvb/tvb/core/services/burst_service.py
+++ b/framework_tvb/tvb/core/services/burst_service.py
@@ -334,19 +334,6 @@ class BurstService(object):
         op_dir = FilesHelper().get_project_folder(operation.project, str(metric_operation.id))
         return op_dir, metric_operation
 
-    def cancel_or_remove_burst(self, burst_id):
-        burst_configuration = self.load_burst_configuration(burst_id)
-        remove_after_stop = burst_configuration.status != burst_configuration.BURST_RUNNING
-
-        if burst_configuration.fk_operation_group is None:
-            op_id = burst_configuration.fk_simulation
-            is_group = 0
-        else:
-            op_id = burst_configuration.fk_operation_group
-            is_group = 1
-
-        return op_id, is_group, remove_after_stop
-
     @staticmethod
     def handle_range_params_at_loading(burst_config, all_range_parameters):
         param1, param2 = None, None

--- a/framework_tvb/tvb/core/services/operation_service.py
+++ b/framework_tvb/tvb/core/services/operation_service.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 #
-# TheVirtualBrain-Framework Package. This package holds all Data Management, and 
+# TheVirtualBrain-Framework Package. This package holds all Data Management, and
 # Web-UI helpful to run brain-simulations. To use it, you also need do download
 # TheVirtualBrain-Scientific Package (for simulators). See content of the
 # documentation-folder for more details. See also http://www.thevirtualbrain.org
@@ -77,7 +77,7 @@ RANGE_PARAMETER_2 = RANGE_PARAMETER_2
 
 class OperationService:
     """
-    Class responsible for preparing an operation launch. 
+    Class responsible for preparing an operation launch.
     It will prepare parameters, and decide if the operation is to be executed
     immediately, or to be sent on the cluster.
     """
@@ -95,7 +95,7 @@ class OperationService:
         """
         Gets the parameters of the computation from the previous inputs form,
         and launches a computation (on the cluster or locally).
-        
+
         Invoke custom method on an Adapter Instance. Make sure when the
         operation has finished that the correct results are stored into DB.
         """
@@ -384,7 +384,7 @@ class OperationService:
 
     def _remove_files(self, file_list):
         """
-        Remove any files that exist in the file_dictionary. 
+        Remove any files that exist in the file_dictionary.
         Currently used to delete temporary files created during an operation.
         """
         for pth in file_list:
@@ -480,7 +480,7 @@ class OperationService:
     @staticmethod
     def __expand_arguments(arguments_list, range_values, range_title):
         """
-        Parse the arguments submitted from UI (flatten form) 
+        Parse the arguments submitted from UI (flatten form)
         If any ranger is found, return a list of arguments for all possible operations.
         """
         if range_values is None:
@@ -543,16 +543,14 @@ class OperationService:
         result = False
         if is_group:
             op_group = ProjectService.get_operation_group_by_id(operation_id)
-            operations = ProjectService.get_operations_in_group(op_group)
-            for op in operations:
-                result = BackendClientFactory.stop_operation(op.id)
-            operation_id = operations[0].id
-        else:
+            operations_in_group = ProjectService.get_operations_in_group(op_group)
+            for operation in operations_in_group:
+                result = OperationService.stop_operation(operation.id, False, remove_after_stop) or result
+        elif dao.try_get_operation_by_id(operation_id) is not None:
             result = BackendClientFactory.stop_operation(operation_id)
-
-        if remove_after_stop:
-            burst_config = dao.get_burst_for_direct_operation_id(operation_id)
-            ProjectService().remove_operation(operation_id)
-            if burst_config is not None:
-                result = dao.remove_entity(BurstConfiguration, burst_config.id) or result
+            if remove_after_stop:
+                burst_config = dao.get_burst_for_direct_operation_id(operation_id)
+                ProjectService().remove_operation(operation_id)
+                if burst_config is not None:
+                    result = dao.remove_entity(BurstConfiguration, burst_config.id) or result
         return result

--- a/framework_tvb/tvb/core/services/operation_service.py
+++ b/framework_tvb/tvb/core/services/operation_service.py
@@ -542,8 +542,7 @@ class OperationService:
         """
         if is_group:
             op_group = ProjectService.get_operation_group_by_id(operation_id)
-            operations_in_group = ProjectService.get_operations_in_group(op_group)
-            operation_id = operations_in_group[0].id
+            operation_id = ProjectService().get_first_operation_in_group(op_group).id
 
         result = BackendClientFactory.stop_operation(operation_id)
         if remove_after_stop:

--- a/framework_tvb/tvb/core/services/operation_service.py
+++ b/framework_tvb/tvb/core/services/operation_service.py
@@ -540,17 +540,15 @@ class OperationService:
         :param remove_after_stop: if True, also remove the operation(s) after stopping
         :returns True if the stop step was successfully
         """
-        result = False
         if is_group:
             op_group = ProjectService.get_operation_group_by_id(operation_id)
             operations_in_group = ProjectService.get_operations_in_group(op_group)
-            for operation in operations_in_group:
-                result = OperationService.stop_operation(operation.id, False, remove_after_stop) or result
-        else:
-            result = BackendClientFactory.stop_operation(operation_id)
-            if remove_after_stop:
-                burst_config = dao.get_burst_for_direct_operation_id(operation_id)
-                ProjectService().remove_operation(operation_id)
-                if burst_config is not None:
-                    result = dao.remove_entity(BurstConfiguration, burst_config.id) or result
+            operation_id = operations_in_group[0].id
+
+        result = BackendClientFactory.stop_operation(operation_id)
+        if remove_after_stop:
+            burst_config = dao.get_burst_for_direct_operation_id(operation_id)
+            ProjectService().remove_operation(operation_id)
+            if burst_config is not None:
+                result = dao.remove_entity(BurstConfiguration, burst_config.id) or result
         return result

--- a/framework_tvb/tvb/core/services/operation_service.py
+++ b/framework_tvb/tvb/core/services/operation_service.py
@@ -540,11 +540,16 @@ class OperationService:
         :param remove_after_stop: if True, also remove the operation(s) after stopping
         :returns True if the stop step was successfully
         """
+        result = False
         if is_group:
             op_group = ProjectService.get_operation_group_by_id(operation_id)
-            operation_id = ProjectService().get_first_operation_in_group(op_group).id
+            operations = ProjectService.get_operations_in_group(op_group)
+            for op in operations:
+                result = BackendClientFactory.stop_operation(op.id)
+            operation_id = operations[0].id
+        else:
+            result = BackendClientFactory.stop_operation(operation_id)
 
-        result = BackendClientFactory.stop_operation(operation_id)
         if remove_after_stop:
             burst_config = dao.get_burst_for_direct_operation_id(operation_id)
             ProjectService().remove_operation(operation_id)

--- a/framework_tvb/tvb/core/services/project_service.py
+++ b/framework_tvb/tvb/core/services/project_service.py
@@ -842,8 +842,8 @@ class ProjectService:
         return dao.get_results_for_operation(operation_id, selected_filter)
 
     @staticmethod
-    def get_first_operation_in_group(op_group):
-        return dao.get_operations_in_group(op_group.id, only_first_operation=True)
+    def get_operations_in_group(op_group):
+        return dao.get_operations_in_group(op_group.id)
 
     @staticmethod
     def get_datatype_by_id(datatype_id):

--- a/framework_tvb/tvb/core/services/project_service.py
+++ b/framework_tvb/tvb/core/services/project_service.py
@@ -842,10 +842,6 @@ class ProjectService:
         return dao.get_results_for_operation(operation_id, selected_filter)
 
     @staticmethod
-    def get_operations_in_group(op_group):
-        return dao.get_operations_in_group(op_group.id)
-
-    @staticmethod
     def get_datatype_by_id(datatype_id):
         """Retrieve a DataType DB reference by its id."""
         return dao.get_datatype_by_id(datatype_id)

--- a/framework_tvb/tvb/core/services/project_service.py
+++ b/framework_tvb/tvb/core/services/project_service.py
@@ -842,6 +842,10 @@ class ProjectService:
         return dao.get_results_for_operation(operation_id, selected_filter)
 
     @staticmethod
+    def get_first_operation_in_group(op_group):
+        return dao.get_operations_in_group(op_group.id, only_first_operation=True)
+
+    @staticmethod
     def get_datatype_by_id(datatype_id):
         """Retrieve a DataType DB reference by its id."""
         return dao.get_datatype_by_id(datatype_id)

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator/simulator_controller.py
@@ -85,9 +85,10 @@ class SimulatorController(BurstBaseController):
         Cancel or Remove the burst entity given by burst_id (and all linked entities: op, DTs)
         :returns True: if the op was successfully.
         """
-        burst_id = int(burst_id)
-        op_id, is_group, remove_after_stop = self.burst_service.cancel_or_remove_burst(burst_id)
-        return self.cancel_or_remove_operation(op_id, is_group, remove_after_stop)
+        burst_config = BurstService.load_burst_configuration(int(burst_id))
+        op_id, is_group = burst_config.operation_info_for_burst_removal
+
+        return self.cancel_or_remove_operation(op_id, is_group, burst_config.is_finished)
 
     def cancel_or_remove_operation(self, operation_id, is_group, remove_after_stop=False):
         """


### PR DESCRIPTION
I removed that recursive call because there is no need for it. The way our code is built, one operation which is part of a group is enough to delete all datatypes and operations from the respective datatype groups and operation groups.