### PR TITLE
TVB-2886: Fix Surface Visualizer for large surfaces

### DIFF
--- a/framework_tvb/tvb/adapters/datatypes/h5/surface_h5.py
+++ b/framework_tvb/tvb/adapters/datatypes/h5/surface_h5.py
@@ -276,7 +276,7 @@ class SurfaceH5(H5File):
             return self.triangles.load()
         slice_number = int(slice_number)
         start_idx, end_idx = self._get_slice_triangle_boundaries(slice_number)
-        return self.triangles[start_idx: end_idx: 1]
+        return self._split_triangles[start_idx: end_idx: 1]
 
     def get_lines_slice(self, slice_number=0):
         """


### PR DESCRIPTION
This little change solves the issues. I comapred the result of three large surfaces with the ones given by version 1.5.8 and they all match. For the surface that Paula was talking about in the task if you turn the brain around you will see some small areas that don't seem to belong there (this happens in both versions). My estimated guess would be that this is because some of the triangles are ignored (1444 of them to be exact). I also tried with cortex_80k and cortex_2x120k (in order to upload this one the zero_based_triangles needs to be unchecked) and the results match for these as well.