### PR TITLE
Use build isolation to fix tvb-gdist install

### DIFF
--- a/scientific_library/Dockerfile
+++ b/scientific_library/Dockerfile
@@ -15,4 +15,9 @@ RUN cd /opt \
  && cd tvb_data \
  && python3 setup.py develop
 
-RUN pip install h5py==2.10 tvb-gdist pytest-xdist sqlalchemy mako
+RUN pip install h5py==2.10 pytest-xdist sqlalchemy mako
+
+RUN pip install --no-build-isolation tvb-gdist
+
+# docker run --rm -it -v $PWD:/tvb -w /tvb tvb/lib 
+CMD ["/bin/bash", "-c", "cd tvb_bin; python3 setup.py develop --no-deps; cd ../scientific_library; python3 setup.py develop --no-deps; python3 -m pytest -n12"]


### PR DESCRIPTION
This updates the lib Dockerfile to fix gdist installation along lines of the GitHub workflow tests.yml.

It also adds a default action for testing.