### PR TITLE
TVB-2917. Fix issues with postgres when going from 2.1 to 2.2

### DIFF
--- a/framework_tvb/tvb/config/init/model_manager.py
+++ b/framework_tvb/tvb/config/init/model_manager.py
@@ -36,7 +36,6 @@ import os
 import shutil
 from sqlalchemy.sql import text
 from sqlalchemy.engine import reflection
-from sqlalchemy.exc import SQLAlchemyError
 from alembic.config import Config
 from alembic import command
 
@@ -81,17 +80,15 @@ def initialize_startup():
     else:
         _update_sql_scripts()
 
-        try:
+        if 'migrate_version' in table_names:
             db_version = session.execute(text("""SELECT version from migrate_version""")).fetchone()[0]
 
             if db_version == 18:
                 command.stamp(alembic_cfg, 'head')
                 session.execute(text("""DROP TABLE "migrate_version";"""))
+                session.commit()
 
                 return is_db_empty
-
-        except SQLAlchemyError:
-            pass
 
         if 'alembic_version' in table_names:
             db_version = session.execute(text("""SELECT version_num from alembic_version""")).fetchone()


### PR DESCRIPTION
I fixed the error that Bogdan talked about.
Even though the error thrown by postgres is catched when there is no migrate_version table, looks like it does something else which gives an error inside of the upgrade error, an error with a bizzare message, but doing it this way avoids that.

I put the WIP because I would like to also fix the migrate_version table not being deleted with postgres. I don't know why, I tried several ways but it just stays there .If I just try to delete the entry, that stays there too. 

Maybe we could just call the migration script even if we go from 2.1 to 2.2 but have some kind of logic that would just delete the table and then exit the script. I suspect that postgres does not let us delete tables outside of a migration script.