### PR TITLE
add some benchmarking of rng methods

### DIFF
--- a/scientific_library/tvb/tests/library/simulator/rngperf_test.py
+++ b/scientific_library/tvb/tests/library/simulator/rngperf_test.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+
+BitGens = [
+    np.random.PCG64,
+    np.random.Philox,
+    np.random.MT19937,
+    np.random.SFC64,
+]
+
+@pytest.mark.parametrize('BitGen', BitGens)
+def test_raw(benchmark, BitGen):
+    bg = BitGen(42)
+    benchmark(lambda: bg.random_raw(size=1024, output=False))
+
+@pytest.mark.parametrize('BitGen', BitGens)
+def test_uniform(benchmark, BitGen):
+    bg = BitGen(42)
+    rng = np.random.Generator(bg)
+    out = np.empty((1024,), 'f')
+    benchmark(lambda: rng.random(out.shape, np.float32, out))
+
+@pytest.mark.parametrize('BitGen', BitGens)
+def test_normal(benchmark, BitGen):
+    bg = BitGen(42)
+    rng = np.random.Generator(bg)
+    benchmark(lambda: rng.normal(0.0, 1.0, 1024))
+


### PR DESCRIPTION
Just wanted to start benchmarking some of the noise related processes, starting with RNG methods in NumPy, 
```
------------------------------------------------------------------------------ benchmark 'test_normal': 4 tests ------------------------------------------------------------------------------
Name (time in us)            Min                 Max               Mean            StdDev             Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_normal[SFC64]       12.3680 (1.0)      367.2670 (8.29)     13.2001 (1.0)      5.3826 (10.40)    13.0750 (1.0)      0.2400 (1.0)        56;690       75.7571 (1.0)       48488           1
test_normal[PCG64]       14.0950 (1.14)      57.7290 (1.30)     14.9464 (1.13)     0.8019 (1.55)     14.8960 (1.14)     0.2860 (1.19)      223;415       66.9057 (0.88)      24362           1
test_normal[Philox]      16.2600 (1.31)     384.4820 (8.67)     17.2405 (1.31)     5.8486 (11.30)    17.0840 (1.31)     0.3060 (1.28)       59;599       58.0029 (0.77)      36313           1
test_normal[MT19937]     17.6870 (1.43)      44.3250 (1.0)      18.7132 (1.42)     0.5176 (1.0)      18.6310 (1.42)     0.6060 (2.53)     6575;214       53.4382 (0.71)      36388           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```
any comments @i-Zaak ?