### PR TITLE
Faster history updater

### DIFF
--- a/scientific_library/tvb/simulator/backend/ref.py
+++ b/scientific_library/tvb/simulator/backend/ref.py
@@ -39,18 +39,10 @@ class RefBase:
             dest[i] += src[i == map].sum(axis=0)
         return dest
 
-    @njit(parallel=True, boundscheck=False)
-    def _nb_add_at(dest, map, src):
-        for i in prange(map.size):
-            dest[map[i]] += src[i]
-        return dest
-
     try:
         add_at = staticmethod(numpy.add.at)
     except AttributeError:
         add_at = staticmethod(_add_at)
-
-    add_at = staticmethod(_nb_add_at)
 
     @staticmethod
     def linear_interp1d(start_time, end_time, start_value, end_value, interp_point):

--- a/scientific_library/tvb/simulator/backend/ref.py
+++ b/scientific_library/tvb/simulator/backend/ref.py
@@ -4,6 +4,7 @@ This module provides a reference backend implemented with NumPy.
 """
 import numpy
 import numpy as np
+from numba import njit, prange
 from .base import BaseBackend
 
 
@@ -38,10 +39,18 @@ class RefBase:
             dest[i] += src[i == map].sum(axis=0)
         return dest
 
+    @njit(parallel=True, boundscheck=False)
+    def _nb_add_at(dest, map, src):
+        for i in prange(map.size):
+            dest[map[i]] += src[i]
+        return dest
+
     try:
         add_at = staticmethod(numpy.add.at)
     except AttributeError:
         add_at = staticmethod(_add_at)
+
+    add_at = staticmethod(_nb_add_at)
 
     @staticmethod
     def linear_interp1d(start_time, end_time, start_value, end_value, interp_point):

--- a/scientific_library/tvb/simulator/history.py
+++ b/scientific_library/tvb/simulator/history.py
@@ -197,6 +197,11 @@ class DenseHistory(BaseHistory):
     def update(self, step, new_state):
         self.buffer[step % self.n_time] = new_state[self.cvars]
 
+    def update_buffer(self, step):
+        target = self.buffer[step % self.n_time]
+        assert target.base is self.buffer
+        return target, self.cvars
+
 
 class SparseHistory(DenseHistory):
     "History implementation which stores data only for non-zero weights."

--- a/scientific_library/tvb/simulator/simulator.py
+++ b/scientific_library/tvb/simulator/simulator.py
@@ -327,14 +327,14 @@ class Simulator(HasTraits):
     def _history_updater(target, cvar, state, limits, bincount):
         assert target.shape[0] == cvar.size
         assert target.shape[1] == limits.shape[0]
-        for i in range(target.shape[0]):
-            ci = cvar[i]
-            for j in nb.prange(target.shape[1]):
-                acc = nb.float32(0.0)
-                for k in range(limits[j,0], limits[j,1]):
-                    acc += state[ci, k, 0]
-                acc /= bincount[j]
-                target[ci,j,0]
+        for i in nb.prange(target.shape[0] * target.shape[1]):
+            ci = cvar[i//target.shape[1]]
+            j = i % target.shape[1]
+            acc = nb.float64(0.0)
+            for k in range(limits[j,0], limits[j,1]):
+                acc += state[ci, k, 0]
+            acc /= bincount[j]
+            target[ci,j,0] = acc
 
     def _compute_regmap_limits(self):
         limits = []

--- a/scientific_library/tvb/simulator/simulator.py
+++ b/scientific_library/tvb/simulator/simulator.py
@@ -344,13 +344,16 @@ class Simulator(HasTraits):
         return numpy.array(limits)
 
     def _loop_update_history(self, step, state):
-        if not self._regmap_info_cached:
-            # cache regmap limits & bincounts
-            self._regmap_bincount = numpy.bincount(self._regmap)
-            self._regmap_limits = self._compute_regmap_limits()
-            self._regmap_info_cached = True
-        target, cvars = self.history.update_buffer(step) # cvar, node, mode
-        self._history_updater(target, cvars, state, self._regmap_limits, self._regmap_bincount)
+        if self.surface is not None and state.shape[1] > self.connectivity.number_of_regions:
+            if not self._regmap_info_cached:
+                # cache regmap limits & bincounts
+                self._regmap_bincount = numpy.bincount(self._regmap)
+                self._regmap_limits = self._compute_regmap_limits()
+                self._regmap_info_cached = True
+            target, cvars = self.history.update_buffer(step) # cvar, node, mode
+            self._history_updater(target, cvars, state, self._regmap_limits, self._regmap_bincount)
+        else:
+            self.history.update(step, state)
 
     def _loop_monitor_output(self, step, state, node_coupling):
         observed = self.model.observe(state)


### PR DESCRIPTION
This reduces by 4x the time spent in `Simulator._loop_history_update` during a surface simulation, by caching useful data and applying an in-place parallelized update algorithm.

This is currently a draft since the code changes are not entirely well placed, the new algorithm assumes 1 mode and it also assumes region indices are contiguous in the regmap. 