### PR TITLE
TVB-2921. Suggestion for Sqlite fix

### DIFF
--- a/framework_tvb/tvb/config/init/model_manager.py
+++ b/framework_tvb/tvb/config/init/model_manager.py
@@ -93,6 +93,11 @@ def initialize_startup():
         except SQLAlchemyError:
             pass
 
+        if 'alembic_version' in table_names:
+            db_version = session.execute(text("""SELECT version_num from alembic_version""")).fetchone()
+            if not db_version:
+                command.stamp(alembic_cfg, 'head')
+
         with session.connection() as connection:
             alembic_cfg.attributes['connection'] = connection
             command.upgrade(alembic_cfg, TvbProfile.current.version.DB_STRUCTURE_VERSION)


### PR DESCRIPTION
After alembic migration from 1.5.8 to 2.2 is finished, the alembic version number is not added to the alembic_version table.
This is happening only with Sqlite, and only if you run the migration.
When starting clean, it works correctly.

The fix should work for all cases: migration from 1.5.8, migration from 2.1 (switching sql-migrate to alembic), opening 2.2 the second time.