### PR TITLE
TVB-2937. Speed-up the data structure page

### DIFF
--- a/framework_tvb/tvb/core/services/project_service.py
+++ b/framework_tvb/tvb/core/services/project_service.py
@@ -465,10 +465,6 @@ class ProjectService:
             data = {}
             is_group = False
             group_op = None
-            dt_entity = dao.get_datatype_by_gid(dt.gid)
-            if dt_entity is None:
-                self.logger.warning("Ignored entity (possibly removed DT class)" + str(dt))
-                continue
             #  Filter by dt.type, otherwise Links to individual DT inside a group will be mistaken
             if dt.type == "DataTypeGroup" and dt.parent_operation.operation_group is not None:
                 is_group = True
@@ -480,7 +476,7 @@ class ProjectService:
             data[DataTypeMetaData.KEY_NODE_TYPE] = dt.display_type
             data[DataTypeMetaData.KEY_STATE] = dt.state
             data[DataTypeMetaData.KEY_SUBJECT] = str(dt.subject)
-            data[DataTypeMetaData.KEY_TITLE] = dt_entity.display_name
+            data[DataTypeMetaData.KEY_TITLE] = dt.display_name
             data[DataTypeMetaData.KEY_RELEVANCY] = dt.visible
             data[DataTypeMetaData.KEY_LINK] = dt.parent_operation.fk_launched_in != project.id
 

--- a/framework_tvb/tvb/core/services/project_service.py
+++ b/framework_tvb/tvb/core/services/project_service.py
@@ -240,14 +240,7 @@ class ProjectService:
                 result['operation_tag'] = one_op[12]
                 if not result['group']:
                     datatype_results = dao.get_results_for_operation(result['id'])
-                    result['results'] = []
-                    for dt in datatype_results:
-                        dt_loaded = load_entity_by_gid(dt.gid)
-                        if dt_loaded:
-                            result['results'].append(dt_loaded)
-                        else:
-                            self.logger.warning("Could not retrieve datatype %s" % str(dt))
-
+                    result['results'] = [dt for dt in datatype_results]
                 else:
                     result['results'] = None
                 operations.append(result)


### PR DESCRIPTION
The method `get_project_structure` is called when loading the **Data Structure** page, and a short profiling session shows that for around 200 datatypes, this method takes around 6.8 seconds to compute, out of which, around 5.2 seconds is spent calling the `dt_entity = dao.get_datatype_by_gid(dt.gid) ` inside the loop.
By avoiding that DAO call and the following check, the execution time goes under 1 second (0.8 seconds).

I am not sure what problem does this check for `dt_entity is None` solve, but from the commit message it seems to be rarely happening, so I am wondering whether we could find another solution that prevents the `get_project_structure` slow-down.
@liadomide do you remember more about this check?