### PR TITLE
NFS-18. Review Cortex and full_region_map usage

### DIFF
--- a/scientific_library/tvb/datatypes/connectivity.py
+++ b/scientific_library/tvb/datatypes/connectivity.py
@@ -36,12 +36,12 @@ The Connectivity datatype.
 
 """
 
+from copy import copy
+
 import numpy
 import scipy.stats
-from copy import copy
-from tvb.basic.readers import ZipReader, H5Reader, try_get_absolute_path
 from tvb.basic.neotraits.api import Attr, NArray, List, HasTraits, Int, narray_summary_info
-
+from tvb.basic.readers import ZipReader, H5Reader, try_get_absolute_path
 
 
 class Connectivity(HasTraits):
@@ -125,6 +125,11 @@ class Connectivity(HasTraits):
     # In case of edited Connectivity, this are the nodes left in interest area,
     # the rest were part of a lesion, so they were removed.
     saved_selection = List(of=int)
+
+    @property
+    def subcortical_indices(self):
+        subcortical_indices = numpy.flatnonzero(self.cortical == 0)
+        return subcortical_indices
 
     @property
     def saved_selection_labels(self):

--- a/scientific_library/tvb/datatypes/cortex.py
+++ b/scientific_library/tvb/datatypes/cortex.py
@@ -81,7 +81,7 @@ class Cortex(HasTraits):
         "Generate a full region mapping vector."
         if self._regmap is not None:
             return self._regmap
-        rm = self.region_mapping
+        rm = self.region_mapping_data.array_data
         unmapped = self.region_mapping_data.connectivity.unmapped_indices(rm)
         self._regmap = numpy.r_[rm, unmapped]
         return self._regmap

--- a/scientific_library/tvb/datatypes/cortex.py
+++ b/scientific_library/tvb/datatypes/cortex.py
@@ -69,15 +69,6 @@ class Cortex(HasTraits):
 
     @property
     def region_mapping(self):
-        """
-        Define shortcut for retrieving RegionMapping map array.
-        """
-        if self.region_mapping_data is None:
-            return None
-        return self.region_mapping_data.array_data
-
-    @property
-    def full_region_map(self):
         "Generate a full region mapping vector."
         if self._regmap is not None:
             return self._regmap
@@ -85,14 +76,6 @@ class Cortex(HasTraits):
         unmapped = self.region_mapping_data.connectivity.unmapped_indices(rm)
         self._regmap = numpy.r_[rm, unmapped]
         return self._regmap
-
-    @property
-    def full_cortical_region_map(self):
-        return self.full_region_map
-
-    @property
-    def cortical_surface(self):
-        return self.surface
 
     @property
     def surface(self):
@@ -151,13 +134,13 @@ class Cortex(HasTraits):
 
         # Pad the local connectivity matrix with zeros when non-cortical regions
         # are included in the long range connectivity...
-        if self.local_connectivity.matrix.shape[0] < self.full_region_map.shape[0]:
+        if self.local_connectivity.matrix.shape[0] < self.region_mapping.shape[0]:
             self.log.info("There are non-cortical regions, will pad local connectivity")
             padding = scipy.sparse.csc_matrix((self.local_connectivity.matrix.shape[0],
-                                               self.full_region_map.shape[0] - self.local_connectivity.matrix.shape[0]))
+                                               self.region_mapping.shape[0] - self.local_connectivity.matrix.shape[0]))
             self.local_connectivity.matrix = scipy.sparse.hstack([self.local_connectivity.matrix, padding])
 
-            padding = scipy.sparse.csc_matrix((self.full_region_map.shape[0] - self.local_connectivity.matrix.shape[0],
+            padding = scipy.sparse.csc_matrix((self.region_mapping.shape[0] - self.local_connectivity.matrix.shape[0],
                                                self.local_connectivity.matrix.shape[1]))
             self.local_connectivity.matrix = scipy.sparse.vstack([self.local_connectivity.matrix, padding])
 
@@ -207,7 +190,6 @@ class Cortex(HasTraits):
         else:
             raise RuntimeError("cortex.coupling_strength must be size 1 or number_of_vertices")
         return local_coupling
-
 
     @classmethod
     def from_file(cls, source_file='cortex_16384.zip', region_mapping_file=os.path.join("regionMapping_16k_76.txt"),

--- a/scientific_library/tvb/simulator/backend/ref.py
+++ b/scientific_library/tvb/simulator/backend/ref.py
@@ -138,14 +138,6 @@ class RefSurface(RefBase):
         state = region_state.transpose((1, 0, 2))  # (cvar, node, mode)
         return state
 
-    @staticmethod
-    def full_region_map(surf, conn):
-        "Generate a full region mapping vector."
-        rm = surf.region_mapping
-        unmapped = conn.unmapped_indices(rm)
-        regmap = numpy.r_[rm, unmapped]
-        return regmap, rm.size, unmapped.size
-
 
 class ReferenceBackend(BaseBackend, RefSurface):
     "Base reference backend, implemented in readable NumPy."

--- a/scientific_library/tvb/simulator/history.py
+++ b/scientific_library/tvb/simulator/history.py
@@ -104,7 +104,7 @@ class BaseHistory(StaticAttr):
             n_time, n_svar, n_node, n_mode = ic_shape = initial_conditions.shape
             nr = sim.connectivity.number_of_regions
             if sim.surface is not None and n_node == nr:
-                initial_conditions = initial_conditions[:, :, sim.surface.full_region_map]
+                initial_conditions = initial_conditions[:, :, sim.surface.region_mapping]
                 return sim._configure_history(initial_conditions)
             elif sim.surface is None and ic_shape[1:] != sim.good_history_shape[1:]:
                 raise ValueError("Incorrect history sample shape %s, expected %s"
@@ -114,15 +114,6 @@ class BaseHistory(StaticAttr):
                     sim.log.debug("Using last %d time-steps for history.", sim.connectivity.horizon)
                     history = initial_conditions[-sim.connectivity.horizon:, :, :, :].copy()
                 else:
-                    # maybe a better broadcast test than this?
-                    if ic_shape[2] != sim._regmap.shape[0] or ic_shape[1] != len(sim.model.state_variables):
-                        raise ValueError(
-                            'Incorrect initial condition shape for a surface sim. '
-                            'Expected broadcastable to (time, n_state_vars, n_nodes, n_modes) = (1, %s, %s, %s). '
-                            'Found %s' %
-                            (len(sim.model.state_variables), sim._regmap.shape[0], sim.model.number_of_modes,
-                             ic_shape)
-                        )
                     sim.log.debug('Padding initial conditions with model.initial')
                     history = sim.model.initial_for_simulator(sim.integrator, sim.good_history_shape)
                     shift = sim.current_step % sim.connectivity.horizon
@@ -131,8 +122,8 @@ class BaseHistory(StaticAttr):
                         n_reg = sim.connectivity.number_of_regions
                         (nt, ns, _, nm), ax = history.shape, (2, 0, 1, 3)
                         region_initial_conditions = numpy.zeros((nt, ns, n_reg, nm))
-                        backend.add_at(region_initial_conditions.transpose(ax), sim.surface.full_region_map, initial_conditions.transpose(ax))
-                        region_initial_conditions /= numpy.bincount(sim.surface.full_region_map).reshape((-1, 1))
+                        backend.add_at(region_initial_conditions.transpose(ax), sim.surface.region_mapping, initial_conditions.transpose(ax))
+                        region_initial_conditions /= numpy.bincount(sim.surface.region_mapping).reshape((-1, 1))
                         history[:region_initial_conditions.shape[0], :, :, :] = region_initial_conditions
                     else:
                         history[:ic_shape[0], :, :, :] = initial_conditions
@@ -151,8 +142,8 @@ class BaseHistory(StaticAttr):
             n_reg = sim.connectivity.number_of_regions
             (nt, ns, _, nm), ax = history.shape, (2, 0, 1, 3)
             region_history = numpy.zeros((nt, ns, n_reg, nm))
-            backend.add_at(region_history.transpose(ax), sim.surface.full_region_map, history.transpose(ax))
-            region_history /= numpy.bincount(sim.surface.full_region_map).reshape((-1, 1))
+            backend.add_at(region_history.transpose(ax), sim.surface.region_mapping, history.transpose(ax))
+            region_history /= numpy.bincount(sim.surface.region_mapping).reshape((-1, 1))
             history = region_history
 
         inst = cls(sim.connectivity.weights, sim.connectivity.idelays,

--- a/scientific_library/tvb/simulator/history.py
+++ b/scientific_library/tvb/simulator/history.py
@@ -104,7 +104,7 @@ class BaseHistory(StaticAttr):
             n_time, n_svar, n_node, n_mode = ic_shape = initial_conditions.shape
             nr = sim.connectivity.number_of_regions
             if sim.surface is not None and n_node == nr:
-                initial_conditions = initial_conditions[:, :, sim._regmap]
+                initial_conditions = initial_conditions[:, :, sim.surface.full_region_map]
                 return sim._configure_history(initial_conditions)
             elif sim.surface is None and ic_shape[1:] != sim.good_history_shape[1:]:
                 raise ValueError("Incorrect history sample shape %s, expected %s"
@@ -114,6 +114,15 @@ class BaseHistory(StaticAttr):
                     sim.log.debug("Using last %d time-steps for history.", sim.connectivity.horizon)
                     history = initial_conditions[-sim.connectivity.horizon:, :, :, :].copy()
                 else:
+                    # maybe a better broadcast test than this?
+                    if ic_shape[2] != sim._regmap.shape[0] or ic_shape[1] != len(sim.model.state_variables):
+                        raise ValueError(
+                            'Incorrect initial condition shape for a surface sim. '
+                            'Expected broadcastable to (time, n_state_vars, n_nodes, n_modes) = (1, %s, %s, %s). '
+                            'Found %s' %
+                            (len(sim.model.state_variables), sim._regmap.shape[0], sim.model.number_of_modes,
+                             ic_shape)
+                        )
                     sim.log.debug('Padding initial conditions with model.initial')
                     history = sim.model.initial_for_simulator(sim.integrator, sim.good_history_shape)
                     shift = sim.current_step % sim.connectivity.horizon
@@ -122,8 +131,8 @@ class BaseHistory(StaticAttr):
                         n_reg = sim.connectivity.number_of_regions
                         (nt, ns, _, nm), ax = history.shape, (2, 0, 1, 3)
                         region_initial_conditions = numpy.zeros((nt, ns, n_reg, nm))
-                        backend.add_at(region_initial_conditions.transpose(ax), sim._regmap, initial_conditions.transpose(ax))
-                        region_initial_conditions /= numpy.bincount(sim._regmap).reshape((-1, 1))
+                        backend.add_at(region_initial_conditions.transpose(ax), sim.surface.full_region_map, initial_conditions.transpose(ax))
+                        region_initial_conditions /= numpy.bincount(sim.surface.full_region_map).reshape((-1, 1))
                         history[:region_initial_conditions.shape[0], :, :, :] = region_initial_conditions
                     else:
                         history[:ic_shape[0], :, :, :] = initial_conditions
@@ -142,8 +151,8 @@ class BaseHistory(StaticAttr):
             n_reg = sim.connectivity.number_of_regions
             (nt, ns, _, nm), ax = history.shape, (2, 0, 1, 3)
             region_history = numpy.zeros((nt, ns, n_reg, nm))
-            backend.add_at(region_history.transpose(ax), sim._regmap, history.transpose(ax))
-            region_history /= numpy.bincount(sim._regmap).reshape((-1, 1))
+            backend.add_at(region_history.transpose(ax), sim.surface.full_region_map, history.transpose(ax))
+            region_history /= numpy.bincount(sim.surface.full_region_map).reshape((-1, 1))
             history = region_history
 
         inst = cls(sim.connectivity.weights, sim.connectivity.idelays,

--- a/scientific_library/tvb/simulator/models/base.py
+++ b/scientific_library/tvb/simulator/models/base.py
@@ -239,7 +239,7 @@ class Model(HasTraits):
     def _map_roi_param_to_surface(self, sim, param, region_parameters, spatial_reshape):
         if sim.surface is not None:
             if region_parameters.size == sim.connectivity.number_of_regions:
-                new_parameters = region_parameters[sim.surface.full_region_map].reshape(spatial_reshape)
+                new_parameters = region_parameters[sim.surface.region_mapping].reshape(spatial_reshape)
                 setattr(self, param, new_parameters)
 
     def update_state_variables_before_integration(self, state_variables, coupling, local_coupling=0.0, stimulus=0.0):

--- a/scientific_library/tvb/simulator/models/base.py
+++ b/scientific_library/tvb/simulator/models/base.py
@@ -239,6 +239,7 @@ class Model(HasTraits):
     def _map_roi_param_to_surface(self, sim, param, region_parameters, spatial_reshape):
         if sim.surface is not None:
             if region_parameters.size == sim.connectivity.number_of_regions:
+                # TODO: cortex.region_mapping
                 new_parameters = region_parameters[sim.surface.region_mapping].reshape(spatial_reshape)
                 setattr(self, param, new_parameters)
 

--- a/scientific_library/tvb/simulator/models/base.py
+++ b/scientific_library/tvb/simulator/models/base.py
@@ -239,8 +239,7 @@ class Model(HasTraits):
     def _map_roi_param_to_surface(self, sim, param, region_parameters, spatial_reshape):
         if sim.surface is not None:
             if region_parameters.size == sim.connectivity.number_of_regions:
-                # TODO: cortex.region_mapping
-                new_parameters = region_parameters[sim.surface.region_mapping].reshape(spatial_reshape)
+                new_parameters = region_parameters[sim.surface.full_region_map].reshape(spatial_reshape)
                 setattr(self, param, new_parameters)
 
     def update_state_variables_before_integration(self, state_variables, coupling, local_coupling=0.0, stimulus=0.0):

--- a/scientific_library/tvb/simulator/monitors.py
+++ b/scientific_library/tvb/simulator/monitors.py
@@ -55,18 +55,19 @@ Conversion of power of 2 sample-rates(Hz) to Monitor periods(ms)
 """
 
 import abc
+
 import numpy
+import tvb.datatypes.equations as equations
+import tvb.datatypes.projections as projections_module
+import tvb.datatypes.sensors as sensors_module
+from tvb.basic.neotraits.api import HasTraits, Attr, NArray, Float, narray_describe
+from tvb.datatypes.region_mapping import RegionMapping
 from tvb.datatypes.time_series import (TimeSeries, TimeSeriesRegion, TimeSeriesEEG, TimeSeriesMEG, TimeSeriesSEEG,
                                        TimeSeriesSurface)
 from tvb.simulator import noise
-import tvb.datatypes.sensors as sensors_module
-import tvb.datatypes.projections as projections_module
-from tvb.datatypes.region_mapping import RegionMapping
-import tvb.datatypes.equations as equations
-from tvb.simulator.common import numpy_add_at
 from tvb.simulator.backend.ref import ReferenceBackend
-from tvb.basic.neotraits.api import HasTraits, Attr, NArray, Float, narray_describe
-from .backend import ReferenceBackend
+from tvb.simulator.common import numpy_add_at
+
 
 class Monitor(HasTraits):
     """
@@ -74,7 +75,7 @@ class Monitor(HasTraits):
     """
 
     period = Float(
-        label="Sampling period (ms)",  # order = 10
+        label="Sampling period (ms)",
         default=0.9765625,  # ms. 0.9765625 => 1024Hz #ms, 0.5 => 2000Hz
         doc="""Sampling period in milliseconds, must be an integral multiple
         of integration-step size. As a guide: 2048 Hz => 0.48828125 ms ;  
@@ -82,7 +83,7 @@ class Monitor(HasTraits):
 
     variables_of_interest = NArray(
         dtype=int,
-        label="Model variables to watch",  # order=11,
+        label="Model variables to watch",
         doc=("Indices of model's variables of interest (VOI) that this monitor should record. "
              "Note that the indices should start at zero, so that if a model offers VOIs V, W and "
              "V+W, and W is selected, and this monitor should record W, then the correct index is 0."),
@@ -176,13 +177,11 @@ class Raw(Monitor):
     _ui_name = "Raw recording"
 
     period = Float(default=0.0, label="Sampling period is ignored for Raw Monitor")
-    # order = -1
 
     variables_of_interest = NArray(
         dtype=int,
         label="Raw Monitor sees all!!! Resistance is futile...",
         required=False)
-    # order = -1
 
     def _config_vois(self, simulator):
         self.voi = numpy.arange(len(simulator.model.variables_of_interest))
@@ -254,7 +253,7 @@ class SpatialAverage(Monitor):
     HEMISPHERES = "hemispheres"
     REGION_MAPPING = "region mapping"
 
-    spatial_mask = NArray(  #TODO: Check it's a vector of length Nodes (like region mapping for surface)
+    spatial_mask = NArray(  # TODO: Check it's a vector of length Nodes (like region mapping for surface)
         dtype=int,
         label="Spatial Mask",
         required=False,
@@ -269,12 +268,9 @@ class SpatialAverage(Monitor):
         default=HEMISPHERES,
         label="Default Mask",
         required=False,
-        doc=("Fallback in case spatial mask is none and no surface provided" 
+        doc=("Fallback in case spatial mask is none and no surface provided"
              "to use either connectivity hemispheres or cortical attributes."))
-        # order = -1)
-    
-    backend = ReferenceBackend()
-    
+
     def _support_bool_mask(self, mask):
         """
         Ensure we support also the case of a boolean mask (eg: connectivity.cortical) with all values being 1,
@@ -298,7 +294,7 @@ class SpatialAverage(Monitor):
         if self.spatial_mask is None:
             self.is_default_special_mask = True
             if simulator.surface is not None:
-                self.spatial_mask, _, _ = self.backend.full_region_map(simulator.surface, simulator.connectivity)
+                self.spatial_mask = simulator.surface.full_cortical_region_map
             else:
                 conn = simulator.connectivity
                 if self.default_mask == self.CORTICAL:
@@ -319,7 +315,7 @@ class SpatialAverage(Monitor):
         number_of_areas = len(areas)
         if not numpy.all(areas == numpy.arange(number_of_areas)):
             msg = ("Areas in the spatial_mask must be specified as a "
-                    "contiguous set of indices starting from zero.")
+                   "contiguous set of indices starting from zero.")
             raise Exception(msg)
 
         self.log.debug("spatial_mask")
@@ -487,7 +483,7 @@ class Projection(Monitor):
 
     @classmethod
     def from_file(cls, sensors_fname, projection_fname, rm_f_name="regionMapping_16k_76.txt",
-                  period=1e3/1024.0, **kwds):
+                  period=1e3 / 1024.0, **kwds):
         """
         Build Projection-based monitor from sensors and projection files, and
         any extra keyword arguments are passed to the monitor class constructor.
@@ -521,7 +517,7 @@ class Projection(Monitor):
         if self.obsnoise is not None:
             # configure the noise level
             if self.obsnoise.ntau > 0.0:
-                noiseshape = self.sensors.labels[:,numpy.newaxis].shape
+                noiseshape = self.sensors.labels[:, numpy.newaxis].shape
                 self.obsnoise.configure_coloured(dt=self.dt, shape=noiseshape)
             else:
                 self.obsnoise.configure_white(dt=self.dt)
@@ -532,6 +528,8 @@ class Projection(Monitor):
         conn = simulator.connectivity
         using_cortical_surface = surf is not None
         if using_cortical_surface:
+            # TODO: Shouldn't the full_reg_map be used here?
+            # This code assumes that subcortical regions are mapped to a single vertex
             non_cortical_indices, = numpy.where(numpy.bincount(surf.region_mapping) == 1)
             self.rmap = surf.region_mapping
         else:
@@ -606,7 +604,7 @@ class Projection(Monitor):
                 sample += self.obsnoise.generate(shape=sample.shape)
 
             self._state[:] = 0.0
-            return time, sample.T[..., numpy.newaxis] # for compatibility
+            return time, sample.T[..., numpy.newaxis]  # for compatibility
 
     _gain = None
 
@@ -676,12 +674,13 @@ class EEG(Projection):
             'sphere approximation of the head (Sarvas 1987).')
 
     @classmethod
-    def from_file(cls, sensors_fname='eeg_brainstorm_65.txt', projection_fname='projection_eeg_65_surface_16k.npy', **kwargs):
+    def from_file(cls, sensors_fname='eeg_brainstorm_65.txt', projection_fname='projection_eeg_65_surface_16k.npy',
+                  **kwargs):
         return Projection.from_file.__func__(cls, sensors_fname, projection_fname, **kwargs)
 
     def config_for_sim(self, simulator):
         super(EEG, self).config_for_sim(simulator)
-        self._ref_vec = numpy.zeros((self.sensors.number_of_sensors, ))
+        self._ref_vec = numpy.zeros((self.sensors.number_of_sensors,))
         if self.reference:
             if self.reference.lower() != 'average':
                 sensor_names = self.sensors.labels.tolist()
@@ -698,16 +697,16 @@ class EEG(Projection):
         # a => vector from sources_to_sensor
         # Q => source unit vectors
         r_0, Q = loc, ori
-        center = numpy.mean(r_0, axis=0)[numpy.newaxis, ]
-        radius = 1.05125 * max(numpy.sqrt(numpy.sum((r_0 - center)**2, axis=1)))
+        center = numpy.mean(r_0, axis=0)[numpy.newaxis,]
+        radius = 1.05125 * max(numpy.sqrt(numpy.sum((r_0 - center) ** 2, axis=1)))
         loc = self.sensors.locations.copy()
-        sen_dis = numpy.sqrt(numpy.sum((loc)**2, axis=1))
+        sen_dis = numpy.sqrt(numpy.sum((loc) ** 2, axis=1))
         loc = loc / sen_dis[:, numpy.newaxis] * radius + center
         V_r = numpy.zeros((loc.shape[0], r_0.shape[0]))
         for sensor_k in numpy.arange(loc.shape[0]):
             a = loc[sensor_k, :] - r_0
-            na = numpy.sqrt(numpy.sum(a**2, axis=1))[:, numpy.newaxis]
-            V_r[sensor_k, :] = numpy.sum(Q * (a / na**3), axis=1 ) / (4.0 * numpy.pi * self.sigma)
+            na = numpy.sqrt(numpy.sum(a ** 2, axis=1))[:, numpy.newaxis]
+            V_r[sensor_k, :] = numpy.sum(Q * (a / na ** 3), axis=1) / (4.0 * numpy.pi * self.sigma)
         return V_r
 
     def sample(self, step, state):
@@ -730,55 +729,54 @@ class MEG(Projection):
 
     projection = Attr(
         projections_module.ProjectionSurfaceMEG,
-        default=None, label='Projection matrix', # order=2,
+        default=None, label='Projection matrix',
         doc='Projection matrix to apply to sources.')
 
     sensors = Attr(
         sensors_module.SensorsMEG,
-        label = "MEG Sensors",
-        default = None,
-        required = True,
+        label="MEG Sensors",
+        default=None,
+        required=True,
         doc="The set of MEG sensors for which the forward solution will be calculated.")
-
 
     @classmethod
     def from_file(cls, sensors_fname='meg_brainstorm_276.txt',
-                   projection_fname='projection_meg_276_surface_16k.npy', **kwargs):
+                  projection_fname='projection_meg_276_surface_16k.npy', **kwargs):
         return Projection.from_file.__func__(cls, sensors_fname, projection_fname, **kwargs)
 
     def analytic(self, loc, ori):
         """Compute single sphere analytic form of MEG lead field.
         Equation 25 of [Sarvas_1987]_."""
         # the magnetic constant = 1.25663706 × 10-6 m kg s-2 A-2  (H/m)
-        mu_0 = 1.25663706e-6 #mH/mm
+        mu_0 = 1.25663706e-6  # mH/mm
         # r => sensor positions
         # r_0 => source positions
         # a => vector from sources_to_sensor
         # Q => source unit vectors
         r_0, Q = loc, ori
         centre = numpy.mean(r_0, axis=0)[numpy.newaxis, :]
-        radius = 1.01 * max(numpy.sqrt(numpy.sum((r_0 - centre)**2, axis=1)))
+        radius = 1.01 * max(numpy.sqrt(numpy.sum((r_0 - centre) ** 2, axis=1)))
         sensor_locations = self.sensors.locations.copy()
-        sen_dis = numpy.sqrt(numpy.sum((sensor_locations)**2, axis=1))
+        sen_dis = numpy.sqrt(numpy.sum((sensor_locations) ** 2, axis=1))
         sensor_locations = sensor_locations / sen_dis[:, numpy.newaxis]
         sensor_locations = sensor_locations * radius
         sensor_locations = sensor_locations + centre
         B_r = numpy.zeros((sensor_locations.shape[0], r_0.shape[0], 3))
         for sensor_k in numpy.arange(sensor_locations.shape[0]):
-            a = sensor_locations[sensor_k,:] - r_0
-            na = numpy.sqrt(numpy.sum(a**2, axis=1))[:, numpy.newaxis]
-            rsk = sensor_locations[sensor_k,:][numpy.newaxis, :]
-            nr = numpy.sqrt(numpy.sum(rsk**2, axis=1))[:, numpy.newaxis]
+            a = sensor_locations[sensor_k, :] - r_0
+            na = numpy.sqrt(numpy.sum(a ** 2, axis=1))[:, numpy.newaxis]
+            rsk = sensor_locations[sensor_k, :][numpy.newaxis, :]
+            nr = numpy.sqrt(numpy.sum(rsk ** 2, axis=1))[:, numpy.newaxis]
 
-            F = a * (nr * a + nr**2 - numpy.sum(r_0 * rsk, axis=1)[:, numpy.newaxis])
+            F = a * (nr * a + nr ** 2 - numpy.sum(r_0 * rsk, axis=1)[:, numpy.newaxis])
             adotr = numpy.sum((a / na) * rsk, axis=1)[:, numpy.newaxis]
-            delF = ((na**2 / nr + adotr + 2.0 * na + 2.0 * nr) * rsk -
+            delF = ((na ** 2 / nr + adotr + 2.0 * na + 2.0 * nr) * rsk -
                     (a + 2.0 * nr + adotr * r_0))
 
-            B_r[sensor_k, :] = ((mu_0 / (4.0 * numpy.pi * F**2)) *
+            B_r[sensor_k, :] = ((mu_0 / (4.0 * numpy.pi * F ** 2)) *
                                 (numpy.cross(F * Q, r_0) - numpy.sum(numpy.cross(Q, r_0) *
                                                                      (rsk * delF), axis=1)[:, numpy.newaxis]))
-        return numpy.sqrt(numpy.sum(B_r**2, axis=2))
+        return numpy.sqrt(numpy.sum(B_r ** 2, axis=2))
 
     def create_time_series(self, connectivity=None, surface=None,
                            region_map=None, region_volume_map=None):
@@ -797,17 +795,16 @@ class iEEG(Projection):
         default=None, label='Projection matrix',
         doc='Projection matrix to apply to sources.')
 
-    sigma = Float(label="conductivity", default=1.0)  #, order=4)
+    sigma = Float(label="conductivity", default=1.0)
 
     sensors = Attr(
         sensors_module.SensorsInternal,
         label="Internal brain sensors", default=None, required=True,
         doc="The set of SEEG sensors for which the forward solution will be calculated.")
 
-
     @classmethod
     def from_file(cls, sensors_fname='seeg_588.txt',
-                   projection_fname='projection_seeg_588_surface_16k.npy', **kwargs):
+                  projection_fname='projection_seeg_588_surface_16k.npy', **kwargs):
         return Projection.from_file.__func__(cls, sensors_fname, projection_fname, **kwargs)
 
     def analytic(self, loc, ori):
@@ -891,8 +888,7 @@ class Bold(Monitor):
     hrf_length = Float(
         label="Duration (ms)",
         default=20000.,
-        doc= """Duration of the hrf kernel""",)
-
+        doc="""Duration of the hrf kernel""", )
 
     _interim_period = None
     _interim_istep = None
@@ -907,25 +903,25 @@ class Bold(Monitor):
         Compute the hemodynamic response function.
 
         """
-        self._stock_sample_rate = 2.0**-2 #/ms    # NOTE: An integral multiple of dt
-        magic_number = self.hrf_length #* 0.8      # truncates G, volterra kernel, once ~zero
-        #Length of history needed for convolution in steps @ _stock_sample_rate
-        required_history_length = self._stock_sample_rate * magic_number # 3840 for tau_s=0.8
+        self._stock_sample_rate = 2.0 ** -2  # /ms    # NOTE: An integral multiple of dt
+        magic_number = self.hrf_length  # * 0.8      # truncates G, volterra kernel, once ~zero
+        # Length of history needed for convolution in steps @ _stock_sample_rate
+        required_history_length = self._stock_sample_rate * magic_number  # 3840 for tau_s=0.8
         self._stock_steps = numpy.ceil(required_history_length).astype(int)
-        stock_time_max    = magic_number/1000.0                                # [s]
-        stock_time_step   = stock_time_max / self._stock_steps                 # [s]
-        self._stock_time  = numpy.arange(0.0, stock_time_max, stock_time_step) # [s]
+        stock_time_max = magic_number / 1000.0  # [s]
+        stock_time_step = stock_time_max / self._stock_steps  # [s]
+        self._stock_time = numpy.arange(0.0, stock_time_max, stock_time_step)  # [s]
         self.log.debug("Bold requires %d steps for HRF kernel convolution", self._stock_steps)
-        #Compute the HRF kernel
+        # Compute the HRF kernel
         G = self.hrf_kernel.evaluate(self._stock_time)
-        #Reverse it, need it into the past for matrix-multiply of stock
+        # Reverse it, need it into the past for matrix-multiply of stock
         G = G[::-1]
         self.hemodynamic_response_function = G[numpy.newaxis, :]
-        #Interim stock configuration
-        self._interim_period = 1.0 / self._stock_sample_rate #period in ms
-        self._interim_istep = int(round(self._interim_period / self.dt)) # interim period in integration time steps
+        # Interim stock configuration
+        self._interim_period = 1.0 / self._stock_sample_rate  # period in ms
+        self._interim_istep = int(round(self._interim_period / self.dt))  # interim period in integration time steps
         self.log.debug('Bold HRF shape %s, interim period & istep %d & %d',
-                  self.hemodynamic_response_function.shape, self._interim_period, self._interim_istep)
+                       self.hemodynamic_response_function.shape, self._interim_period, self._interim_istep)
 
     def _config_time(self, simulator):
         super(Bold, self)._config_time(simulator)
@@ -947,13 +943,13 @@ class Bold(Monitor):
         # At stock's period update it with the temporal average of interim-stock
         if step % self._interim_istep == 0:
             avg_interim_stock = numpy.mean(self._interim_stock, axis=0)
-            self._stock[((step//self._interim_istep % self._stock_steps) - 1), :] = avg_interim_stock
+            self._stock[((step // self._interim_istep % self._stock_steps) - 1), :] = avg_interim_stock
         # At the monitor's period, apply the heamodynamic response function to
         # the stock and return the resulting BOLD signal.
         if step % self.istep == 0:
             time = step * self.dt
             hrf = numpy.roll(self.hemodynamic_response_function,
-                             ((step//self._interim_istep % self._stock_steps) - 1),
+                             ((step // self._interim_istep % self._stock_steps) - 1),
                              axis=1)
             if isinstance(self.hrf_kernel, equations.FirstOrderVolterra):
                 k1_V0 = self.hrf_kernel.parameters["k_1"] * self.hrf_kernel.parameters["V_0"]
@@ -979,7 +975,7 @@ class BoldRegionROI(Bold):
 
     def config_for_sim(self, simulator):
         super(BoldRegionROI, self).config_for_sim(simulator)
-        self.region_mapping = simulator.surface.region_mapping
+        self.region_mapping = simulator.surface.full_region_map
         self.no_regions = simulator.surface.region_mapping_data.connectivity.number_of_regions
 
     def sample(self, step, state):

--- a/scientific_library/tvb/simulator/monitors.py
+++ b/scientific_library/tvb/simulator/monitors.py
@@ -528,10 +528,9 @@ class Projection(Monitor):
         conn = simulator.connectivity
         using_cortical_surface = surf is not None
         if using_cortical_surface:
-            # TODO: Shouldn't the full_reg_map be used here?
             # This code assumes that subcortical regions are mapped to a single vertex
-            non_cortical_indices, = numpy.where(numpy.bincount(surf.region_mapping) == 1)
-            self.rmap = surf.region_mapping
+            non_cortical_indices, = numpy.where(numpy.bincount(surf.full_region_map) == 1)
+            self.rmap = surf.full_region_map
         else:
             # assume all cortical if no info
             if conn.cortical.size == 0:

--- a/scientific_library/tvb/simulator/monitors.py
+++ b/scientific_library/tvb/simulator/monitors.py
@@ -294,7 +294,7 @@ class SpatialAverage(Monitor):
         if self.spatial_mask is None:
             self.is_default_special_mask = True
             if simulator.surface is not None:
-                self.spatial_mask = simulator.surface.full_cortical_region_map
+                self.spatial_mask = simulator.surface.region_mapping
             else:
                 conn = simulator.connectivity
                 if self.default_mask == self.CORTICAL:
@@ -529,8 +529,8 @@ class Projection(Monitor):
         using_cortical_surface = surf is not None
         if using_cortical_surface:
             # This code assumes that subcortical regions are mapped to a single vertex
-            non_cortical_indices, = numpy.where(numpy.bincount(surf.full_region_map) == 1)
-            self.rmap = surf.full_region_map
+            non_cortical_indices, = numpy.where(numpy.bincount(surf.region_mapping) == 1)
+            self.rmap = surf.region_mapping
         else:
             # assume all cortical if no info
             if conn.cortical.size == 0:
@@ -974,7 +974,7 @@ class BoldRegionROI(Bold):
 
     def config_for_sim(self, simulator):
         super(BoldRegionROI, self).config_for_sim(simulator)
-        self.region_mapping = simulator.surface.full_region_map
+        self.region_mapping = simulator.surface.region_mapping
         self.no_regions = simulator.surface.region_mapping_data.connectivity.number_of_regions
 
     def sample(self, step, state):

--- a/scientific_library/tvb/simulator/simulator.py
+++ b/scientific_library/tvb/simulator/simulator.py
@@ -45,7 +45,7 @@ import time
 import numpy
 from tvb.basic.neotraits.api import HasTraits, Attr, NArray, List, Float
 from tvb.basic.profile import TvbProfile
-from tvb.datatypes import cortex, connectivity, patterns, region_mapping
+from tvb.datatypes import cortex, connectivity, patterns
 from tvb.simulator import models, integrators, monitors, coupling
 from tvb.simulator.models.base import Model
 
@@ -237,10 +237,8 @@ class Simulator(HasTraits):
             self.number_of_nodes = self.connectivity.number_of_regions
             self.log.info('Region simulation with %d ROI nodes', self.number_of_nodes)
         else:
-            self._regmap, nc, nsc = self.backend.full_region_map(self.surface, self.connectivity)
-            self.number_of_nodes = nc + nsc
-            self.log.info('Surface simulation with %d vertices + %d non-cortical, %d total nodes',
-                          nc, nsc, self.number_of_nodes)
+            self.number_of_nodes = len(self.surface.full_region_map)
+            self.log.info('Surface simulation with %d total nodes (vertices + non-cortical)', self.number_of_nodes)
 
     def configure(self, full_configure=True):
         """Configure simulator and its components.
@@ -291,7 +289,7 @@ class Simulator(HasTraits):
         """Compute delayed node coupling values."""
         coupling = self.coupling(step, self.history)
         if self.surface is not None:
-            coupling = coupling[:, self._regmap]
+            coupling = coupling[:, self.surface.full_region_map]
         return coupling
 
     def _prepare_stimulus(self):
@@ -315,7 +313,7 @@ class Simulator(HasTraits):
     def _loop_update_history(self, step, state):
         """Update history."""
         if self.surface is not None and state.shape[1] > self.connectivity.number_of_regions:
-            state = self.backend.surface_state_to_rois(self._regmap, self.connectivity.number_of_regions, state)
+            state = self.backend.surface_state_to_rois(self.surface.full_region_map, self.connectivity.number_of_regions, state)
         self.history.update(step, state)
 
     def _loop_monitor_output(self, step, state, node_coupling):
@@ -400,12 +398,12 @@ class Simulator(HasTraits):
 
         if self.surface is not None:
             if self.integrator.noise.nsig.size == self.connectivity.number_of_regions:
-                self.integrator.noise.nsig = self.integrator.noise.nsig[self.surface.region_mapping]
+                self.integrator.noise.nsig = self.integrator.noise.nsig[self.surface.full_region_map]
             elif self.integrator.noise.nsig.size == self.model.nvar * self.connectivity.number_of_regions:
                 self.integrator.noise.nsig = \
-                    self.integrator.noise.nsig[self.model.state_variable_mask][:, self.surface.region_mapping]
+                    self.integrator.noise.nsig[self.model.state_variable_mask][:, self.surface.full_region_map]
             elif self.integrator.noise.nsig.size == self.model.nintvar * self.connectivity.number_of_regions:
-                self.integrator.noise.nsig = self.integrator.noise.nsig[:, self.surface.region_mapping]
+                self.integrator.noise.nsig = self.integrator.noise.nsig[:, self.surface.full_region_map]
 
         good_nsig_shape = (self.model.nintvar, self.number_of_nodes, self.model.number_of_modes)
         nsig = self.integrator.noise.nsig
@@ -443,7 +441,7 @@ class Simulator(HasTraits):
         if self.stimulus is not None:
             if self.surface:
                 # NOTE the region mapping of the stimuli should also include the subcortical areas
-                self.stimulus.configure_space(region_mapping=self._regmap)
+                self.stimulus.configure_space(region_mapping=self.surface.full_region_map)
             else:
                 self.stimulus.configure_space()
 

--- a/scientific_library/tvb/simulator/simulator.py
+++ b/scientific_library/tvb/simulator/simulator.py
@@ -568,7 +568,7 @@ class Simulator(HasTraits):
         try:
             memreq += self.surface.triangles.nbytes * 2
             memreq += self.surface.vertices.nbytes * 2
-            memreq += self.surface.region_mapping.nbytes * self.number_of_nodes * 8. * 4  # region_average, region_sum
+            memreq += self.surface.full_region_map.nbytes * self.number_of_nodes * 8. * 4  # region_average, region_sum
             memreq += self.surface.local_connectivity.matrix.nnz * 8
         except AttributeError:
             pass

--- a/scientific_library/tvb/tests/library/base_testcase.py
+++ b/scientific_library/tvb/tests/library/base_testcase.py
@@ -32,6 +32,7 @@
 .. moduleauthor:: Bogdan Neacsa <bogdan.neacsa@codemart.ro>
 """
 
+import numpy
 from tvb.tests.library import setup_test_console_env
 
 if "TEST_INITIALIZATION_DONE_LIBRARY" not in globals():
@@ -68,3 +69,19 @@ class BaseTestCase(object):
     @staticmethod
     def assert_equal(expected, actual, message=""):
         assert expected == actual, message + " Expected %s but got %s." % (expected, actual)
+
+    @staticmethod
+    def add_subcorticals_to_conn(conn):
+        # Add 2 rows and columns to the weights matrix as if it had 2 subcortical regions
+        nr_regs = conn.weights.shape[0]
+        nr_regs_with_subcorticals = nr_regs + 2
+        rows_to_add = numpy.zeros((2, nr_regs))
+        conn.weights = numpy.vstack((conn.weights, rows_to_add))
+        conn.tract_lengths = numpy.vstack((conn.tract_lengths, rows_to_add))
+        columns_to_add = numpy.zeros((nr_regs_with_subcorticals, 2))
+        conn.weights = numpy.column_stack((conn.weights, columns_to_add))
+        conn.tract_lengths = numpy.column_stack((conn.tract_lengths, columns_to_add))
+        conn.orientations = numpy.vstack((conn.orientations, numpy.zeros((2, 3))))
+        conn.centres = numpy.vstack((conn.centres, numpy.zeros((2, 3))))
+        conn.cortical = numpy.r_[conn.cortical, [False, False]]
+        conn.areas = numpy.r_[conn.areas, [0., 0.]]

--- a/scientific_library/tvb/tests/library/datatypes/surfaces_test.py
+++ b/scientific_library/tvb/tests/library/datatypes/surfaces_test.py
@@ -206,7 +206,7 @@ class TestSurfaces(BaseTestCase):
         dt.region_mapping_data.connectivity = Connectivity.from_file()
         dt.__setattr__('valid_for_simulations', True)
         assert isinstance(dt, Cortex)
-        assert dt.full_region_map is not None
+        assert dt.region_mapping is not None
         ## Initialize Local Connectivity, to avoid long computation time.
         dt.local_connectivity = LocalConnectivity.from_file()
 

--- a/scientific_library/tvb/tests/library/datatypes/surfaces_test.py
+++ b/scientific_library/tvb/tests/library/datatypes/surfaces_test.py
@@ -34,6 +34,7 @@
 import sys
 import numpy
 import pytest
+from tvb.datatypes.connectivity import Connectivity
 from tvb.datatypes.surfaces import CorticalSurface
 from tvb.tests.library.base_testcase import BaseTestCase
 from tvb.datatypes.cortex import Cortex
@@ -202,6 +203,7 @@ class TestSurfaces(BaseTestCase):
     @pytest.mark.skipif(sys.maxsize <= 2147483647, reason="Cannot deal with local connectivity on a 32-bit machine.")
     def test_cortexdata(self):
         dt = Cortex.from_file()
+        dt.region_mapping_data.connectivity = Connectivity.from_file()
         dt.__setattr__('valid_for_simulations', True)
         assert isinstance(dt, Cortex)
         assert dt.region_mapping is not None

--- a/scientific_library/tvb/tests/library/datatypes/surfaces_test.py
+++ b/scientific_library/tvb/tests/library/datatypes/surfaces_test.py
@@ -206,7 +206,7 @@ class TestSurfaces(BaseTestCase):
         dt.region_mapping_data.connectivity = Connectivity.from_file()
         dt.__setattr__('valid_for_simulations', True)
         assert isinstance(dt, Cortex)
-        assert dt.region_mapping is not None
+        assert dt.full_region_map is not None
         ## Initialize Local Connectivity, to avoid long computation time.
         dt.local_connectivity = LocalConnectivity.from_file()
 

--- a/scientific_library/tvb/tests/library/datatypes/surfaces_test.py
+++ b/scientific_library/tvb/tests/library/datatypes/surfaces_test.py
@@ -32,15 +32,16 @@
 .. moduleauthor:: Bogdan Neacsa <bogdan.neacsa@codemart.ro>
 """
 import sys
+
 import numpy
 import pytest
+from tvb.datatypes import surfaces
 from tvb.datatypes.connectivity import Connectivity
-from tvb.datatypes.surfaces import CorticalSurface
-from tvb.tests.library.base_testcase import BaseTestCase
 from tvb.datatypes.cortex import Cortex
 from tvb.datatypes.local_connectivity import LocalConnectivity
 from tvb.datatypes.region_mapping import RegionMapping
-from tvb.datatypes import surfaces
+from tvb.datatypes.surfaces import CorticalSurface
+from tvb.tests.library.base_testcase import BaseTestCase
 
 
 class TestSurfaces(BaseTestCase):
@@ -204,7 +205,6 @@ class TestSurfaces(BaseTestCase):
     def test_cortexdata(self):
         dt = Cortex.from_file()
         dt.region_mapping_data.connectivity = Connectivity.from_file()
-        dt.__setattr__('valid_for_simulations', True)
         assert isinstance(dt, Cortex)
         assert dt.region_mapping is not None
         ## Initialize Local Connectivity, to avoid long computation time.
@@ -214,3 +214,13 @@ class TestSurfaces(BaseTestCase):
         assert dt.vertices.shape == (16384, 3)
         assert dt.vertex_normals.shape == (16384, 3)
         assert dt.triangles.shape == (32760, 3)
+
+    def test_cortex_reg_map_without_subcorticals(self):
+        dt = Cortex.from_file()
+        dt.region_mapping_data.connectivity = Connectivity.from_file()
+        self.add_subcorticals_to_conn(dt.region_mapping_data.connectivity)
+        dt.region_mapping_data.connectivity.configure()
+
+        assert isinstance(dt, Cortex)
+        assert dt.region_mapping is not None
+        assert numpy.unique(dt.region_mapping).size == dt.region_mapping_data.connectivity.number_of_regions

--- a/scientific_library/tvb/tests/library/simulator/coupling_test.py
+++ b/scientific_library/tvb/tests/library/simulator/coupling_test.py
@@ -163,10 +163,12 @@ class TestCouplingShape(BaseTestCase):
                     )
                     return state
 
+        conn = connectivity.Connectivity.from_file()
         surf = cortex.Cortex.from_file()
+        surf.region_mapping_data.connectivity = conn
         sim = simulator.Simulator(
             model=CouplingShapeTestModel(self, surf.vertices.shape[0]),
-            connectivity=connectivity.Connectivity.from_file(),
+            connectivity=conn,
             surface=surf)
 
         sim.configure()

--- a/scientific_library/tvb/tests/library/simulator/monitors_test.py
+++ b/scientific_library/tvb/tests/library/simulator/monitors_test.py
@@ -161,6 +161,7 @@ class TestProjectionMonitorsWithSubcorticalRegions(BaseTestCase):
         default_cortex = Cortex.from_file()
         default_cortex.region_mapping_data = region_mapping
         default_cortex.coupling_strength = local_coupling_strength
+        default_cortex.region_mapping_data.connectivity = white_matter
 
         sim = simulator.Simulator(model=oscillator, connectivity=white_matter, coupling=white_matter_coupling,
                                   integrator=heunint, monitors=mons, surface=default_cortex)

--- a/scientific_library/tvb/tests/library/simulator/regionmapping_test.py
+++ b/scientific_library/tvb/tests/library/simulator/regionmapping_test.py
@@ -54,6 +54,7 @@ class TestRegionMapping(BaseTestCase):
         # Surface and local connectivity kernel
         surf = cortex.Cortex.from_file() #Initialise a surface
         surf.local_connectivity = local_connectivity.LocalConnectivity.from_file()
+        surf.region_mapping_data.connectivity = con
         surf.configure()
 
         # Model

--- a/scientific_library/tvb/tests/library/simulator/simulator_test.py
+++ b/scientific_library/tvb/tests/library/simulator/simulator_test.py
@@ -128,6 +128,7 @@ class Simulator(object):
             white_matter = Connectivity.from_file(source_file="connectivity_192.zip")
             region_mapping = RegionMapping.from_file(source_file="regionMapping_16k_192.txt")
         region_mapping.surface = CorticalSurface.from_file()
+        region_mapping.connectivity = white_matter
 
         white_matter_coupling = coupling.Linear(a=numpy.array([coupling_strength]))
         white_matter.speed = numpy.array([speed])  # no longer allow scalars to numpy array promotion

--- a/scientific_library/tvb/tests/library/simulator/simulator_test.py
+++ b/scientific_library/tvb/tests/library/simulator/simulator_test.py
@@ -112,7 +112,8 @@ class Simulator(object):
                   coupling_strength=0.00042, method=HeunDeterministic,
                   surface_sim=False,
                   default_connectivity=True,
-                  with_stimulus=False):
+                  with_stimulus=False,
+                  with_subcorticals=False):
         """
         Create an instance of the Simulator class, by default use the
         generic plane oscillator local dynamic model and the deterministic 
@@ -127,6 +128,8 @@ class Simulator(object):
         else:
             white_matter = Connectivity.from_file(source_file="connectivity_192.zip")
             region_mapping = RegionMapping.from_file(source_file="regionMapping_16k_192.txt")
+        if with_subcorticals:
+            BaseTestCase.add_subcorticals_to_conn(white_matter)
         region_mapping.surface = CorticalSurface.from_file()
         region_mapping.connectivity = white_matter
 
@@ -193,14 +196,20 @@ class TestSimulator(BaseTestCase):
 
     @pytest.mark.slow
     @pytest.mark.parametrize('default_connectivity', [True, False])
-    def test_simulator_surface(self, default_connectivity):
+    @pytest.mark.parametrize('with_subcorticals', [True, False])
+    def test_simulator_surface(self, default_connectivity, with_subcorticals):
         """
         This test evaluates if surface simulations run as basic flow.
+        If flag with_subcorticals is set, we test the case when the Connectivity contains subcortical
+        regions, but the RegionMapping does not. The simulator internally fills-in the Cortex.region_mapping
+        to contain also the subcortical regions (a single vertex is associated to each subcortical region).
         """
         test_simulator = Simulator()
 
         with numpy.errstate(all='ignore'):
-            test_simulator.configure(surface_sim=True, default_connectivity=default_connectivity)
+            test_simulator.configure(surface_sim=True,
+                                     default_connectivity=default_connectivity,
+                                     with_subcorticals=with_subcorticals)
             result = test_simulator.run_simulation(simulation_length=2)
 
         assert len(test_simulator.monitors) == len(result)
@@ -297,7 +306,7 @@ class TestSimulator(BaseTestCase):
         finfo = numpy.finfo(dtype="float64")
         assert numpy.all(
             test_simulator.integrator.state_variable_boundaries ==
-                numpy.array([[0.0, 1.0], [finfo.min, 1.0], [0.0, finfo.max], [finfo.min, finfo.max]]))
+            numpy.array([[0.0, 1.0], [finfo.min, 1.0], [0.0, finfo.max], [finfo.min, finfo.max]]))
         assert numpy.all(
             test_simulator.integrator._bounded_integration_state_variable_indices == numpy.array([0, 1, 2]))
         assert numpy.all(

--- a/scientific_library/tvb/tests/library/simulator/stimulation_test.py
+++ b/scientific_library/tvb/tests/library/simulator/stimulation_test.py
@@ -76,6 +76,7 @@ class SetUpSimulator(object):
         # Surface and local connectivity kernel
         surf = cortex.Cortex.from_file() #Initialise a surface
         surf.local_connectivity = local_connectivity.LocalConnectivity.from_file()
+        surf.region_mapping_data.connectivity = con
         surf.configure()
 
         # Model


### PR DESCRIPTION
Starting from a review over the `PseudoCortex` class in NFS code, I am proposing the following changes to the TVB library:
- let the `Cortex` be responsible for computing the full region mapping, in case the subcortical regions are present in the `Connectivity`, but not in the `RegionMapping`, as it already references both of them
- this computation happens internally in the `Cortex` and the `Cortex.region_mapping` property always exposes the full region mapping (pls let me know in case there are places that would need only the cortical region mapping that I might have missed) 
- throughout the simulator, we only use the `Cortex.region_mapping` as a single point to access the region mapping (for NFS it would return the full region mapping of the `RegularSurface`)
- have a property on `Connectivity` to compute the subcortical indices

I added some tests, where I add 2 dummy subcortical regions to the `Connectivity` before calling the `Cortex.region_mapping` or launching simulations.

Let me know what are your thoughts on these, I would like to start bringing generic changes from the **spherical_harmonics** branch to **master**.