### PR TITLE
TVB-2924: Change some libraries to support Python 3.8 environments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo "PATH=$HOME/.local/bin:$PATH" >> $GITHUB_ENV
 
       - name: create a requirements file
-        run: echo "numba scipy numpy networkx scikit-learn cython numexpr psutil pytest pytest-cov pytest-xdist pytest-benchmark pytest-mock matplotlib psycopg2 h5py>=2.10 typing BeautifulSoup4 subprocess32 flask-restplus python-keycloak mako pyAesCrypt pyunicore formencode cfflib jinja2 nibabel sqlalchemy alembic allensdk sphinx==1.2.3 docutils==0.12 werkzeug==0.16.1 flask gevent jupyter cherrypy autopep8" | tr ' ' \\n > requirements.txt
+        run: echo "numba scipy numpy networkx scikit-learn cython numexpr psutil pytest pytest-cov pytest-xdist pytest-benchmark pytest-mock matplotlib psycopg2 h5py>=2.10 typing BeautifulSoup4 subprocess32 flask-restx python-keycloak mako pyAesCrypt pyunicore formencode cfflib jinja2 nibabel sqlalchemy alembic allensdk sphinx==1.2.3 docutils==0.12 werkzeug==0.16.1 flask gevent jupyter cherrypy autopep8" | tr ' ' \\n > requirements.txt
 
       - name: cache ~/.local for pip deps
         id: cache-local

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo "PATH=$HOME/.local/bin:$PATH" >> $GITHUB_ENV
 
       - name: create a requirements file
-        run: echo "numba scipy numpy networkx scikit-learn cython numexpr psutil pytest pytest-cov pytest-xdist pytest-benchmark pytest-mock matplotlib psycopg2 h5py>=2.10 typing BeautifulSoup4 subprocess32 flask-restx python-keycloak mako pyAesCrypt pyunicore formencode cfflib jinja2 nibabel sqlalchemy alembic allensdk sphinx==1.2.3 docutils==0.12 werkzeug==0.16.1 flask gevent jupyter cherrypy autopep8" | tr ' ' \\n > requirements.txt
+        run: echo "numba scipy numpy networkx scikit-learn cython numexpr psutil pytest pytest-cov pytest-xdist pytest-benchmark pytest-mock matplotlib psycopg2 h5py>=2.10 typing BeautifulSoup4 subprocess32 flask-restx python-keycloak mako pyAesCrypt pyunicore formencode cfflib jinja2 nibabel sqlalchemy alembic allensdk sphinx==1.2.3 docutils==0.12 werkzeug flask gevent jupyter cherrypy autopep8" | tr ' ' \\n > requirements.txt
 
       - name: cache ~/.local for pip deps
         id: cache-local

--- a/framework_tvb/setup.py
+++ b/framework_tvb/setup.py
@@ -44,7 +44,7 @@ VERSION = "2.3"
 
 TVB_TEAM = "Mihai Andrei, Lia Domide, Stuart Knock, Bogdan Neacsa, Paula Popa, Paula Sansz Leon, Marmaduke Woodman"
 
-TVB_INSTALL_REQUIREMENTS = ["alembic", "allensdk", "cherrypy", "cryptography", "flask", "flask-restplus",
+TVB_INSTALL_REQUIREMENTS = ["alembic", "allensdk", "cherrypy", "cryptography", "flask", "flask-restx",
                             "formencode", "gevent", "h5py<3", "Jinja2", "nibabel", "numpy", "pandas",
                             "Pillow", "psutil", "pyAesCrypt", "python-keycloak", "requests", "scikit-learn",
                             "scipy", "simplejson", "six", "sqlalchemy", "tvb-data", "tvb-gdist",

--- a/framework_tvb/tvb/interfaces/rest/server/resources/rest_resource.py
+++ b/framework_tvb/tvb/interfaces/rest/server/resources/rest_resource.py
@@ -29,7 +29,7 @@
 #
 
 import flask
-from flask_restplus import Resource
+from flask_restx import Resource
 
 from tvb.interfaces.rest.commons.exceptions import BadRequestException, InvalidInputException
 from tvb.interfaces.rest.commons.strings import RequestFileKey, Strings

--- a/framework_tvb/tvb/interfaces/rest/server/resources/user/user_resource.py
+++ b/framework_tvb/tvb/interfaces/rest/server/resources/user/user_resource.py
@@ -29,7 +29,7 @@
 #
 import flask
 import formencode
-from flask_restplus import Resource
+from flask_restx import Resource
 from tvb.core.services.authorization import AuthorizationManager
 from tvb.interfaces.rest.commons.exceptions import InvalidInputException
 from tvb.interfaces.rest.commons.status_codes import HTTP_STATUS_CREATED

--- a/framework_tvb/tvb/interfaces/rest/server/rest_api.py
+++ b/framework_tvb/tvb/interfaces/rest/server/rest_api.py
@@ -29,7 +29,7 @@
 #
 import json
 
-from flask_restplus import Api
+from flask_restx import Api
 from keycloak.exceptions import KeycloakError
 from tvb.basic.exceptions import TVBException
 from tvb.interfaces.rest.commons.status_codes import HTTP_STATUS_SERVER_ERROR

--- a/framework_tvb/tvb/tests/framework/interfaces/rest/base_resource_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/rest/base_resource_test.py
@@ -33,5 +33,5 @@ from tvb.tests.framework.core.base_testcase import TransactionalTestCase
 
 class RestResourceTest(TransactionalTestCase):
     def _mock_user(self, mocker):
-        request_mock = mocker.patch.object(flask, 'g')
+        request_mock = mocker.patch.object(flask, 'g', spec={})
         request_mock.current_user = self.test_user

--- a/framework_tvb/tvb/tests/framework/interfaces/rest/operation_resource_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/rest/operation_resource_test.py
@@ -71,7 +71,7 @@ class TestOperationResource(RestResourceTest):
         zip_path = os.path.join(os.path.dirname(tvb_data.__file__), 'connectivity', 'connectivity_96.zip')
         TestFactory.import_zip_connectivity(self.test_user, self.test_project, zip_path)
 
-        request_mock = mocker.patch.object(flask, 'request')
+        request_mock = mocker.patch.object(flask, 'request', spec={})
         request_mock.args = {Strings.PAGE_NUMBER: '1'}
 
         operations_and_pages = self.operations_resource.get(project_gid=self.test_project.gid)
@@ -90,7 +90,7 @@ class TestOperationResource(RestResourceTest):
         zip_path = os.path.join(os.path.dirname(tvb_data.__file__), 'connectivity', 'connectivity_96.zip')
         TestFactory.import_zip_connectivity(self.test_user, self.test_project, zip_path)
 
-        request_mock = mocker.patch.object(flask, 'request')
+        request_mock = mocker.patch.object(flask, 'request', spec={})
         request_mock.args = {Strings.PAGE_NUMBER: '1'}
 
         operations_and_pages = self.operations_resource.get(project_gid=self.test_project.gid)
@@ -105,7 +105,7 @@ class TestOperationResource(RestResourceTest):
         with pytest.raises(TVBException):
             TestFactory.import_zip_connectivity(self.test_user, self.test_project, zip_path)
 
-        request_mock = mocker.patch.object(flask, 'request')
+        request_mock = mocker.patch.object(flask, 'request', spec={})
         request_mock.args = {Strings.PAGE_NUMBER: '1'}
 
         operations_and_pages = self.operations_resource.get(project_gid=self.test_project.gid)
@@ -117,7 +117,7 @@ class TestOperationResource(RestResourceTest):
     def test_server_launch_operation_no_file(self, mocker):
         self._mock_user(mocker)
         # Mock flask.request.files to return a dictionary
-        request_mock = mocker.patch.object(flask, 'request')
+        request_mock = mocker.patch.object(flask, 'request', spec={})
         request_mock.files = {}
 
         with pytest.raises(InvalidIdentifierException): self.launch_resource.post(project_gid='', algorithm_module='',
@@ -127,7 +127,7 @@ class TestOperationResource(RestResourceTest):
         self._mock_user(mocker)
         dummy_file = FileStorage(BytesIO(b"test"), 'test.txt')
         # Mock flask.request.files to return a dictionary
-        request_mock = mocker.patch.object(flask, 'request')
+        request_mock = mocker.patch.object(flask, 'request', spec={})
         request_mock.files = {RequestFileKey.LAUNCH_ANALYZERS_MODEL_FILE.value: dummy_file}
 
         with pytest.raises(InvalidIdentifierException): self.launch_resource.post(project_gid='', algorithm_module='',
@@ -138,7 +138,7 @@ class TestOperationResource(RestResourceTest):
         project_gid = "inexistent-gid"
         dummy_file = FileStorage(BytesIO(b"test"), 'test.h5')
         # Mock flask.request.files to return a dictionary
-        request_mock = mocker.patch.object(flask, 'request')
+        request_mock = mocker.patch.object(flask, 'request', spec={})
         request_mock.files = {RequestFileKey.LAUNCH_ANALYZERS_MODEL_FILE.value: dummy_file}
 
         with pytest.raises(InvalidIdentifierException): self.launch_resource.post(project_gid=project_gid,
@@ -151,7 +151,7 @@ class TestOperationResource(RestResourceTest):
 
         dummy_file = FileStorage(BytesIO(b"test"), 'test.h5')
         # Mock flask.request.files to return a dictionary
-        request_mock = mocker.patch.object(flask, 'request')
+        request_mock = mocker.patch.object(flask, 'request', spec={})
         request_mock.files = {RequestFileKey.LAUNCH_ANALYZERS_MODEL_FILE.value: dummy_file}
 
         with pytest.raises(ServiceException): self.launch_resource.post(project_gid=self.test_project.gid,
@@ -173,7 +173,7 @@ class TestOperationResource(RestResourceTest):
         view_model_h5_path = h5.store_view_model(fft_model, input_folder)
 
         # Mock flask.request.files to return a dictionary
-        request_mock = mocker.patch.object(flask, 'request')
+        request_mock = mocker.patch.object(flask, 'request', spec={})
         fp = open(view_model_h5_path, 'rb')
         request_mock.files = {
             RequestFileKey.LAUNCH_ANALYZERS_MODEL_FILE.value: FileStorage(fp, os.path.basename(view_model_h5_path))}

--- a/framework_tvb/tvb/tests/framework/interfaces/rest/project_resource_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/rest/project_resource_test.py
@@ -77,7 +77,7 @@ class TestProjectResource(RestResourceTest):
         self._mock_user(mocker)
         project_gid = "inexistent-gid"
 
-        request_mock = mocker.patch.object(flask, 'request')
+        request_mock = mocker.patch.object(flask, 'request', spec={})
         request_mock.args = {Strings.PAGE_NUMBER: '1'}
 
         with pytest.raises(InvalidIdentifierException): self.operations_resource.get(project_gid=project_gid)
@@ -86,7 +86,7 @@ class TestProjectResource(RestResourceTest):
         self._mock_user(mocker)
         project_gid = self.test_project_without_data.gid
 
-        request_mock = mocker.patch.object(flask, 'request')
+        request_mock = mocker.patch.object(flask, 'request', spec={})
         request_mock.args = {Strings.PAGE_NUMBER: '1'}
 
         result = self.operations_resource.get(project_gid=project_gid)
@@ -97,7 +97,7 @@ class TestProjectResource(RestResourceTest):
         self._mock_user(mocker)
         project_gid = self.test_project_with_data.gid
 
-        request_mock = mocker.patch.object(flask, 'request')
+        request_mock = mocker.patch.object(flask, 'request', spec={})
         request_mock.args = {Strings.PAGE_NUMBER: '1'}
 
         result = self.operations_resource.get(project_gid=project_gid)

--- a/framework_tvb/tvb/tests/framework/interfaces/rest/simulation_resource_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/rest/simulation_resource_test.py
@@ -59,7 +59,7 @@ class TestSimulationResource(RestResourceTest):
         project_gid = "inexistent-gid"
         dummy_file = FileStorage(BytesIO(b"test"), 'test.zip')
         # Mock flask.request.files to return a dictionary
-        request_mock = mocker.patch.object(flask, 'request')
+        request_mock = mocker.patch.object(flask, 'request', spec={})
         request_mock.files = {RequestFileKey.SIMULATION_FILE_KEY.value: dummy_file}
 
         with pytest.raises(InvalidIdentifierException): self.simulation_resource.post(project_gid=project_gid)
@@ -67,7 +67,7 @@ class TestSimulationResource(RestResourceTest):
     def test_server_fire_simulation_no_file(self, mocker):
         self._mock_user(mocker)
         # Mock flask.request.files to return a dictionary
-        request_mock = mocker.patch.object(flask, 'request')
+        request_mock = mocker.patch.object(flask, 'request', spec={})
         request_mock.files = {}
 
         with pytest.raises(InvalidIdentifierException): self.simulation_resource.post(project_gid='')
@@ -76,7 +76,7 @@ class TestSimulationResource(RestResourceTest):
         self._mock_user(mocker)
         dummy_file = FileStorage(BytesIO(b"test"), 'test.txt')
         # Mock flask.request.files to return a dictionary
-        request_mock = mocker.patch.object(flask, 'request')
+        request_mock = mocker.patch.object(flask, 'request', spec={})
         request_mock.files = {RequestFileKey.SIMULATION_FILE_KEY.value: dummy_file}
 
         with pytest.raises(InvalidIdentifierException): self.simulation_resource.post(project_gid='')
@@ -96,7 +96,7 @@ class TestSimulationResource(RestResourceTest):
         self.storage_interface.zip_folder(zip_filename, sim_dir)
 
         # Mock flask.request.files to return a dictionary
-        request_mock = mocker.patch.object(flask, 'request')
+        request_mock = mocker.patch.object(flask, 'request', spec={})
         fp = open(zip_filename, 'rb')
         request_mock.files = {RequestFileKey.SIMULATION_FILE_KEY.value: FileStorage(fp, os.path.basename(zip_filename))}
 

--- a/framework_tvb/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
+++ b/framework_tvb/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
@@ -36,7 +36,7 @@ import tvb_data.regionMapping
 import tvb_data.projectionMatrix
 from os import path
 from uuid import UUID
-from mock import patch
+from unittest.mock import patch
 from datetime import datetime
 from cherrypy.lib.sessions import RamSession
 

--- a/tvb_build/docker/Dockerfile-Windows-build
+++ b/tvb_build/docker/Dockerfile-Windows-build
@@ -14,7 +14,7 @@ RUN conda init powershell
 # Prepare tvb-run env
 RUN activate && conda create -y --name tvb-run python=3.7 numba scipy numpy networkx scikit-learn cython pip numexpr psutil
 RUN activate && conda install -y --name tvb-run pytest pytest-cov pytest-benchmark pytest-mock matplotlib-base
-RUN activate && conda install -y --name tvb-run psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy docutils werkzeug==0.16.1
+RUN activate && conda install -y --name tvb-run psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy docutils werkzeug
 RUN activate && conda install -y --name tvb-run -c conda-forge jupyterlab flask gevent
 
 RUN activate tvb-run && pip install --upgrade pip

--- a/tvb_build/docker/Dockerfile-Windows-build
+++ b/tvb_build/docker/Dockerfile-Windows-build
@@ -20,7 +20,7 @@ RUN activate && conda install -y --name tvb-run -c conda-forge jupyterlab flask 
 RUN activate tvb-run && pip install --upgrade pip
 RUN activate tvb-run && pip install certifi
 RUN activate tvb-run && pip install h5py==2.10 formencode cfflib jinja2 nibabel sqlalchemy alembic allensdk
-RUN activate tvb-run && pip install typing tvb-gdist BeautifulSoup4 subprocess32 flask-restplus python-keycloak mako pyAesCrypt pyunicore==0.6.0
+RUN activate tvb-run && pip install typing tvb-gdist BeautifulSoup4 subprocess32 flask-restx python-keycloak mako pyAesCrypt pyunicore==0.6.0
 RUN activate tvb-run && pip install autopep8
 
 # Download and install tvb data

--- a/tvb_build/docker/Dockerfile-build
+++ b/tvb_build/docker/Dockerfile-build
@@ -25,7 +25,7 @@ RUN conda update -n base -c defaults conda
 
 RUN conda create -y --name tvb-docs python=3.7 nomkl numba scipy numpy networkx scikit-learn cython pip numexpr psutil
 RUN conda install -y --name tvb-docs pytest pytest-cov pytest-benchmark pytest-mock matplotlib-base
-RUN conda install -y --name tvb-docs psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy werkzeug==0.16.1
+RUN conda install -y --name tvb-docs psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy werkzeug
 RUN conda install -y --name tvb-docs -c conda-forge jupyterlab flask gevent
 RUN /opt/conda/envs/tvb-docs/bin/pip install --upgrade pip
 RUN /opt/conda/envs/tvb-docs/bin/pip install h5py==2.10 formencode cfflib jinja2 nibabel sqlalchemy alembic allensdk
@@ -36,7 +36,7 @@ RUN /opt/conda/envs/tvb-docs/bin/pip install sphinx==1.2.3 docutils==0.12
 RUN conda update -n base -c defaults conda
 RUN conda create -y --name tvb-run python=3 nomkl numba scipy numpy networkx scikit-learn cython pip numexpr psutil
 RUN conda install -y --name tvb-run pytest pytest-cov pytest-benchmark pytest-mock matplotlib-base
-RUN conda install -y --name tvb-run psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy werkzeug==0.16.1 docutils
+RUN conda install -y --name tvb-run psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy werkzeug docutils
 RUN conda install -y --name tvb-run -c conda-forge jupyterlab flask gevent
 RUN /opt/conda/envs/tvb-run/bin/pip install --upgrade pip
 RUN /opt/conda/envs/tvb-run/bin/pip install h5py>=2.10 formencode cfflib jinja2 nibabel sqlalchemy alembic allensdk

--- a/tvb_build/docker/Dockerfile-build
+++ b/tvb_build/docker/Dockerfile-build
@@ -30,7 +30,7 @@ RUN conda install -y --name tvb-docs -c conda-forge jupyterlab flask gevent
 RUN /opt/conda/envs/tvb-docs/bin/pip install --upgrade pip
 RUN /opt/conda/envs/tvb-docs/bin/pip install h5py==2.10 formencode cfflib jinja2 nibabel sqlalchemy alembic allensdk
 RUN /opt/conda/envs/tvb-docs/bin/pip install --no-build-isolation tvb-gdist
-RUN /opt/conda/envs/tvb-docs/bin/pip install typing BeautifulSoup4 subprocess32 flask-restplus python-keycloak mako pyAesCrypt pyunicore==0.6.0
+RUN /opt/conda/envs/tvb-docs/bin/pip install typing BeautifulSoup4 subprocess32 flask-restx python-keycloak mako pyAesCrypt pyunicore==0.6.0
 RUN /opt/conda/envs/tvb-docs/bin/pip install sphinx==1.2.3 docutils==0.12
 
 RUN conda update -n base -c defaults conda
@@ -41,7 +41,7 @@ RUN conda install -y --name tvb-run -c conda-forge jupyterlab flask gevent
 RUN /opt/conda/envs/tvb-run/bin/pip install --upgrade pip
 RUN /opt/conda/envs/tvb-run/bin/pip install h5py>=2.10 formencode cfflib jinja2 nibabel sqlalchemy alembic allensdk
 RUN /opt/conda/envs/tvb-run/bin/pip install --no-build-isolation tvb-gdist
-RUN /opt/conda/envs/tvb-run/bin/pip install typing BeautifulSoup4 subprocess32 flask-restplus python-keycloak mako pyAesCrypt pyunicore==0.6.0
+RUN /opt/conda/envs/tvb-run/bin/pip install typing BeautifulSoup4 subprocess32 flask-restx python-keycloak mako pyAesCrypt pyunicore==0.6.0
 RUN /opt/conda/envs/tvb-run/bin/pip install lockfile
 RUN /opt/conda/envs/tvb-run/bin/pip install syncrypto autopep8
 

--- a/tvb_build/docker/Dockerfile-run
+++ b/tvb_build/docker/Dockerfile-run
@@ -29,7 +29,7 @@ RUN conda install -y --name tvb-run -c conda-forge jupyterlab flask gevent
 RUN /opt/conda/envs/tvb-run/bin/pip install --upgrade pip
 RUN /opt/conda/envs/tvb-run/bin/pip install h5py==2.10 formencode cfflib jinja2 nibabel sqlalchemy alembic allensdk
 RUN /opt/conda/envs/tvb-run/bin/pip install --no-build-isolation tvb-gdist
-RUN /opt/conda/envs/tvb-run/bin/pip install typing BeautifulSoup4 subprocess32 flask-restplus python-keycloak mako pyAesCrypt pyunicore==0.6.0
+RUN /opt/conda/envs/tvb-run/bin/pip install typing BeautifulSoup4 subprocess32 flask-restx python-keycloak mako pyAesCrypt pyunicore==0.6.0
 RUN /opt/conda/envs/tvb-run/bin/pip install lockfile
 RUN /opt/conda/envs/tvb-run/bin/pip install syncrypto
 

--- a/tvb_build/docker/Dockerfile-run
+++ b/tvb_build/docker/Dockerfile-run
@@ -24,7 +24,7 @@ USER root
 RUN conda update -n base -c defaults conda
 RUN conda create -y --name tvb-run python=3 nomkl numba scipy numpy networkx scikit-learn cython pip numexpr psutil
 RUN conda install -y --name tvb-run pytest pytest-cov pytest-benchmark pytest-mock matplotlib-base
-RUN conda install -y --name tvb-run psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy docutils werkzeug==0.16.1
+RUN conda install -y --name tvb-run psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy docutils werkzeug
 RUN conda install -y --name tvb-run -c conda-forge jupyterlab flask gevent
 RUN /opt/conda/envs/tvb-run/bin/pip install --upgrade pip
 RUN /opt/conda/envs/tvb-run/bin/pip install h5py==2.10 formencode cfflib jinja2 nibabel sqlalchemy alembic allensdk

--- a/tvb_build/docker/Dockerfile-test
+++ b/tvb_build/docker/Dockerfile-test
@@ -29,7 +29,7 @@ RUN conda install -y --name tvb-run -c conda-forge jupyterlab flask gevent
 RUN /opt/conda/envs/tvb-run/bin/pip install --upgrade pip
 RUN /opt/conda/envs/tvb-run/bin/pip install h5py==2.10 formencode cfflib jinja2 nibabel sqlalchemy alembic allensdk
 RUN /opt/conda/envs/tvb-run/bin/pip install --no-build-isolation tvb-gdist
-RUN /opt/conda/envs/tvb-run/bin/pip install typing BeautifulSoup4 subprocess32 flask-restplus python-keycloak mako pyAesCrypt pyunicore==0.6.0
+RUN /opt/conda/envs/tvb-run/bin/pip install typing BeautifulSoup4 subprocess32 flask-restx python-keycloak mako pyAesCrypt pyunicore==0.6.0
 RUN /opt/conda/envs/tvb-run/bin/pip install lockfile
 RUN /opt/conda/envs/tvb-run/bin/pip install syncrypto
 RUN /opt/conda/envs/tvb-run/bin/pip install autopep8

--- a/tvb_build/docker/Dockerfile-test
+++ b/tvb_build/docker/Dockerfile-test
@@ -24,7 +24,7 @@ USER root
 RUN conda update -n base -c defaults conda
 RUN conda create -y --name tvb-run python=3 nomkl numba scipy numpy networkx scikit-learn cython pip numexpr psutil
 RUN conda install -y --name tvb-run pytest pytest-cov pytest-benchmark pytest-mock matplotlib-base
-RUN conda install -y --name tvb-run psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy docutils werkzeug==0.16.1
+RUN conda install -y --name tvb-run psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy docutils werkzeug
 RUN conda install -y --name tvb-run -c conda-forge jupyterlab flask gevent
 RUN /opt/conda/envs/tvb-run/bin/pip install --upgrade pip
 RUN /opt/conda/envs/tvb-run/bin/pip install h5py==2.10 formencode cfflib jinja2 nibabel sqlalchemy alembic allensdk

--- a/tvb_build/mac_conda_env.sh
+++ b/tvb_build/mac_conda_env.sh
@@ -10,7 +10,7 @@ conda install -y --name mac-distribution -c conda-forge flask gevent pillow
 
 /WORK/anaconda3/anaconda3/envs/mac-distribution/bin/pip install --upgrade pip
 /WORK/anaconda3/anaconda3/envs/mac-distribution/bin/pip install h5py==2.10 formencode cfflib jinja2 nibabel sqlalchemy alembic allensdk
-/WORK/anaconda3/anaconda3/envs/mac-distribution/bin/pip install tvb-gdist typing BeautifulSoup4 subprocess32 flask-restplus python-keycloak mako pyAesCrypt pyunicore==0.6.0
+/WORK/anaconda3/anaconda3/envs/mac-distribution/bin/pip install tvb-gdist typing BeautifulSoup4 subprocess32 flask-restx python-keycloak mako pyAesCrypt pyunicore==0.6.0
 /WORK/anaconda3/anaconda3/envs/mac-distribution/bin/pip install pyobjc
 /WORK/anaconda3/anaconda3/envs/mac-distribution/bin/pip install biplist six
 /WORK/anaconda3/anaconda3/envs/mac-distribution/bin/pip uninstall python-magic

--- a/tvb_build/mac_conda_env.sh
+++ b/tvb_build/mac_conda_env.sh
@@ -5,7 +5,7 @@ conda update -n base -c defaults conda
 conda env remove --name mac-distribution
 conda create -y --name mac-distribution python=3.7 nomkl numba scipy numpy==1.18.1 networkx scikit-learn cython pip numexpr psutil
 conda install -y --name mac-distribution pytest pytest-cov pytest-benchmark pytest-mock matplotlib-base
-conda install -y --name mac-distribution psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy docutils werkzeug==0.16.1
+conda install -y --name mac-distribution psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy docutils werkzeug
 conda install -y --name mac-distribution -c conda-forge flask gevent pillow
 
 /WORK/anaconda3/anaconda3/envs/mac-distribution/bin/pip install --upgrade pip

--- a/tvb_build/tvb_build/third_party_licenses/packages_accepted.xml
+++ b/tvb_build/tvb_build/third_party_licenses/packages_accepted.xml
@@ -2193,7 +2193,7 @@
     <dependency env="[win,mac,linux]" name="werkzeug">
         <full-name value="Werkzeug"/>
         <project-home value="https://palletsprojects.com/p/werkzeug/"/>
-        <version value="0.16.1"/>
+        <version value="2.0.1"/>
         <usage value="dynamic linking"/>
         <license value="LICENSE_werkzeug.txt"/>
         <license-type value="BSD_ 3 clause"/>

--- a/tvb_build/tvb_build/third_party_licenses/packages_accepted.xml
+++ b/tvb_build/tvb_build/third_party_licenses/packages_accepted.xml
@@ -2358,27 +2358,17 @@
         <license value="LICENSE_flask.txt"/>
         <license-type value="BSD_"/>
         <copyright-notice value="Copyright 2010 Pallets"/>
-        <description value="Flask is a lightweight WSGI web application framework."/>
+        <description value="Flask is a lightweight WSGI web appl ication framework."/>
     </dependency>
-    <dependency env="[win,mac,linux]" name="flask-restplus">
+    <dependency env="[win,mac,linux]" name="flask-restx">
         <full-name value="Flask"/>
-        <project-home value="https://github.com/noirbizarre/flask-restplus"/>
-        <version value="0.13.0"/>
+        <project-home value="https://github.com/python-restx/flask-restx"/>
+        <version value="0.4.0"/>
         <usage value="dynamic linking"/>
-        <license value="LICENSE_flask-restplus.txt"/>
+        <license value="LICENSE_flask-x.txt"/>
         <license-type value="BSD_"/>
-        <copyright-notice value="Original work Copyright (c) 2013 Twilio, Inc; Modified work Copyright (c) 2014 Axel Haustant"/>
-        <description value="Flask-RESTPlus is an extension for Flask that adds support for quickly building REST APIs."/>
-    </dependency>
-    <dependency env="[win,mac,linux]" name="flask_restplus">
-        <full-name value="Flask"/>
-        <project-home value="https://github.com/noirbizarre/flask-restplus"/>
-        <version value="0.13.0"/>
-        <usage value="dynamic linking"/>
-        <license value="LICENSE_flask-restplus.txt"/>
-        <license-type value="BSD_"/>
-        <copyright-notice value="Original work Copyright (c) 2013 Twilio, Inc; Modified work Copyright (c) 2014 Axel Haustant"/>
-        <description value="Flask-RESTPlus is an extension for Flask that adds support for quickly building REST APIs."/>
+        <copyright-notice value="©2020, python-restx Authors. | Powered by Sphinx 1.8.5 and Alabaster 0.7.12"/>
+        <description value="Flask-RESTX is an extension for Flask that adds support for quickly building REST APIs."/>
     </dependency>
     <dependency env="[win,mac,linux]" name="brotlipy">
         <full-name value="Brotlipy"/>

--- a/tvb_documentation/manuals/ContributorsManual/ContributorsManual.rst
+++ b/tvb_documentation/manuals/ContributorsManual/ContributorsManual.rst
@@ -50,7 +50,7 @@ Using a virtual environment inside Anaconda is a good idea.
    $ conda create -y --name $envname python=3 nomkl numba scipy numpy networkx scikit-learn cython pip numexpr psutil psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy docutils werkzeug matplotlib-base
    $ source activate $envname
    $ consta install -c conda-forge jupyterlab flask gevent
-   $ pip install h5py==2.10 formencode cfflib jinja2 nibabel sqlalchemy sqlalchemy-migrate allensdk tvb-gdist typing BeautifulSoup4 subprocess32 flask-restplus python-keycloak mako
+   $ pip install h5py==2.10 formencode cfflib jinja2 nibabel sqlalchemy sqlalchemy-migrate allensdk tvb-gdist typing BeautifulSoup4 subprocess32 flask-restx python-keycloak mako
    $ cd [tvb-root]/tvb_build/
    $ sh install_full_tvb.sh
 


### PR DESCRIPTION
Now simulator_controller tests and flask  should work in Python 3.8 envs as well. I added a more detailed comment on the Jira task.