### PR TITLE
TVB-2927: Fix simulation launching with Bold ROI monitor.

### DIFF
--- a/scientific_library/tvb/simulator/monitors.py
+++ b/scientific_library/tvb/simulator/monitors.py
@@ -986,8 +986,9 @@ class BoldRegionROI(Bold):
         if result:
             t, data = result
             # TODO use reduceat
-            return [t, array([data.flat[self.region_mapping==i].mean()
-                              for i in range(self.region_mapping.max())])]
+            res = array([data.flat[self.region_mapping == i].mean() for i in range(self.region_mapping.max())])
+            res = numpy.reshape(res, [data.shape[0], len(res), data.shape[2]])
+            return [t, res]
         else:
             return None
 


### PR DESCRIPTION
This fix makes simulations work with Bold ROI monitor by making the data be of 4 dimensions, not 2 as it happens in the case of Bold ROI monitor without this fix. Me and Paula think that the Time Series look fine.

There is one more problem remaining related only to the Brain Activity Visualizer and we decided to open a new task for that.