### PR TITLE
TVB-2960: Solve problem related to Bold ROI Monitor

### DIFF
--- a/framework_tvb/tvb/adapters/simulator/simulator_adapter.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_adapter.py
@@ -122,10 +122,6 @@ class SimulatorAdapter(ABCAdapter):
     algorithm = None
     branch_simulation_state_gid = None
 
-    # This is a list with the monitors that actually return multi dimensions for the state variable dimension.
-    # We exclude from this for example EEG, MEG or Bold which return 
-    HAVE_STATE_VARIABLES = ["GlobalAverage", "SpatialAverage", "Raw", "SubSample", "TemporalAverage"]
-
     def __init__(self):
         super(SimulatorAdapter, self).__init__()
         self.log.debug("%s: Initialized..." % str(self))
@@ -289,8 +285,8 @@ class SimulatorAdapter(ABCAdapter):
             ts_index.data_ndim = 4
             ts_index.state = 'INTERMEDIATE'
 
-            state_variable_dimension_name = ts.labels_ordering[1]
-            if m_name in self.HAVE_STATE_VARIABLES:
+            if monitor.voi is not None:
+                state_variable_dimension_name = ts.labels_ordering[1]
                 selected_vois = [self.algorithm.model.variables_of_interest[idx] for idx in monitor.voi]
                 ts.labels_dimensions[state_variable_dimension_name] = selected_vois
                 ts_index.labels_dimensions = json.dumps(ts.labels_dimensions)

--- a/scientific_library/tvb/datatypes/time_series.py
+++ b/scientific_library/tvb/datatypes/time_series.py
@@ -213,21 +213,21 @@ class TimeSeriesEEG(SensorsTSBase):
     """ A time series associated with a set of EEG sensors. """
 
     sensors = Attr(field_type=sensors.SensorsEEG)
-    labels_ordering = List(of=str, default=("Time", "1", "EEG Sensor", "1"))
+    labels_ordering = List(of=str, default=("Time", "SV", "EEG Sensor", "Mode"))
 
 
 class TimeSeriesMEG(SensorsTSBase):
     """ A time series associated with a set of MEG sensors. """
 
     sensors = Attr(field_type=sensors.SensorsMEG)
-    labels_ordering = List(of=str, default=("Time", "1", "MEG Sensor", "1"))
+    labels_ordering = List(of=str, default=("Time", "SV", "MEG Sensor", "Mode"))
 
 
 class TimeSeriesSEEG(SensorsTSBase):
     """ A time series associated with a set of Internal sensors. """
 
     sensors = Attr(field_type=sensors.SensorsInternal)
-    labels_ordering = List(of=str, default=("Time", "1", "sEEG Sensor", "1"))
+    labels_ordering = List(of=str, default=("Time", "SV", "sEEG Sensor", "Mode"))
 
 
 class TimeSeriesRegion(TimeSeries):

--- a/scientific_library/tvb/simulator/monitors.py
+++ b/scientific_library/tvb/simulator/monitors.py
@@ -987,9 +987,11 @@ class BoldRegionROI(Bold):
         if result:
             t, data = result
             # TODO use reduceat
-            data = numpy.array([data.flat[self.region_mapping == i].mean()
+            data = data[self.voi, :]
+            data = numpy.array([data[:, self.region_mapping == i, :].mean(axis=1)
                                 for i in range(self.no_regions)])
-            return [t, data[numpy.newaxis, :, numpy.newaxis]]
+            data = numpy.swapaxes(data, 0, 1)
+            return [t, data]
         else:
             return None
 

--- a/scientific_library/tvb/simulator/monitors.py
+++ b/scientific_library/tvb/simulator/monitors.py
@@ -980,21 +980,31 @@ class BoldRegionROI(Bold):
     def config_for_sim(self, simulator):
         super(BoldRegionROI, self).config_for_sim(simulator)
         self.region_mapping = simulator.surface.region_mapping
+        self.no_regions = simulator.surface.region_mapping_data.connectivity.number_of_regions
 
-    def sample(self, step, state, array=numpy.array):
+    def sample(self, step, state):
         result = super(BoldRegionROI, self).sample(step, state)
         if result:
             t, data = result
             # TODO use reduceat
-            res = array([data.flat[self.region_mapping == i].mean() for i in range(self.region_mapping.max())])
-            res = numpy.reshape(res, [data.shape[0], len(res), data.shape[2]])
-            return [t, res]
+            data = numpy.array([data.flat[self.region_mapping == i].mean()
+                                for i in range(self.no_regions)])
+            return [t, data[numpy.newaxis, :, numpy.newaxis]]
         else:
             return None
 
+    def create_time_series(self, connectivity=None, surface=None,
+                           region_map=None, region_volume_map=None):
+
+        return TimeSeriesRegion(connectivity=connectivity,
+                                region_mapping=region_map,
+                                region_mapping_volume=region_volume_map,
+                                sample_period=self.period,
+                                title='Regions ' + self.__class__.__name__)
+
 
 class ProgressLogger(Monitor):
-    "Logs progress of simulation; only for use in console scripts."
+    """Logs progress of simulation; only for use in console scripts."""
 
     def __init__(self, **kwargs):
         super(ProgressLogger, self).__init__(**kwargs)

--- a/scientific_library/tvb/tests/library/datatypes/timeseries_test.py
+++ b/scientific_library/tvb/tests/library/datatypes/timeseries_test.py
@@ -63,7 +63,7 @@ class TestTimeseries(BaseTestCase):
         data = numpy.random.random((10, 10))
         dt = time_series.TimeSeriesEEG(data=data, sensors=SensorsEEG())
         assert dt.data.shape == (10, 10)
-        assert ('Time', '1', 'EEG Sensor', '1') == dt.labels_ordering
+        assert ("Time", "SV", "EEG Sensor", "Mode") == dt.labels_ordering
         assert dt.sample_period == 1.0
         assert dt.sample_rate == 1000
         assert dt.sensors is not None
@@ -74,7 +74,7 @@ class TestTimeseries(BaseTestCase):
         data = numpy.random.random((10, 10))
         dt = time_series.TimeSeriesMEG(data=data, sensors=SensorsMEG(orientations=numpy.array([])))
         assert dt.data.shape == (10, 10)
-        assert ('Time', '1', 'MEG Sensor', '1') == dt.labels_ordering
+        assert ("Time", "SV", "MEG Sensor", "Mode") == dt.labels_ordering
         assert dt.sample_period == 1.0
         assert dt.sample_rate == 1000
         assert dt.sensors is not None


### PR DESCRIPTION
When using **_BoldRegionROI_** (it works only for surface simulations) from tvb web GUI, we encounter few issues:
- the result used to be an object TSSurface, even if the shape of the TS data was (time, 1, **_conn_reg - 1_**, 1)
- SV and Modes dimension was not kept in case the monitor has >1 Sv or modes
- even more, there was a problem in the way "mean" is done for every regions, when sv > 1
- labels for the Ts dimensions were not correct