### PR TITLE
TVB-2930 + TVB-2931 : Solved project deletion issues

### DIFF
--- a/framework_tvb/tvb/adapters/exporters/abcexporter.py
+++ b/framework_tvb/tvb/adapters/exporters/abcexporter.py
@@ -106,7 +106,7 @@ class ABCExporter(metaclass=ABCMeta):
         necessary since all group elements are the same type.
         """
         # first check if current data is a DataTypeGroup
-        if self.is_data_a_group(data):
+        if DataTypeGroup.is_data_a_group(data):
             if self.skip_group_datatypes():
                 return None
 
@@ -123,52 +123,25 @@ class ABCExporter(metaclass=ABCMeta):
     def skip_group_datatypes(self):
         return False
 
-    def __get_all_datatypes_from_data(self, data):
-        """
-        This method builds an array with all data types to be processed later.
-        - If current data is a simple data type is added to an array.
-        - If it is an data type group all its children are loaded and added to array.
-        """
-        # first check if current data is a DataTypeGroup
-        if self.is_data_a_group(data):
-            data_types = ProjectService.get_datatypes_from_datatype_group(data.id)
-
-            result = []
-            if data_types is not None and len(data_types) > 0:
-                for data_type in data_types:
-                    entity = load_entity_by_gid(data_type.gid)
-                    result.append(entity)
-
-            return result
-
-        else:
-            return [data]
-
     @staticmethod
-    def is_data_a_group(data):
-        """
-        Checks if the provided data, ready for export is a DataTypeGroup or not
-        """
-        return isinstance(data, DataTypeGroup)
-
-    def prepare_datatypes_for_export(self, data):
+    def prepare_datatypes_for_export(data):
         """
         Method used for exporting data type groups. This method returns a list of all datatype indexes needed to be
         exported and a dictionary where keys are operation folder names and the values are lists containing the paths
         that belong to one particular operation folder.
         """
-        all_datatypes = self.__get_all_datatypes_from_data(data)
+        all_datatypes = ProjectService.get_all_datatypes_from_data(data)
         first_datatype = all_datatypes[0]
 
         # We are exporting a group of datatype measures so we need to find the group of time series
         if hasattr(first_datatype, 'fk_source_gid'):
             ts = h5.load_entity_by_gid(first_datatype.fk_source_gid)
             dt_metric_group = dao.get_datatypegroup_by_op_group_id(ts.parent_operation.fk_operation_group)
-            datatype_measure_list = self.__get_all_datatypes_from_data(dt_metric_group)
+            datatype_measure_list = ProjectService.get_all_datatypes_from_data(dt_metric_group)
             all_datatypes = datatype_measure_list + all_datatypes
         else:
             ts_group = dao.get_datatype_measure_group_from_ts_from_pse(first_datatype.gid, DatatypeMeasureIndex)
-            time_series_list = self.__get_all_datatypes_from_data(ts_group)
+            time_series_list = ProjectService.get_all_datatypes_from_data(ts_group)
             all_datatypes = all_datatypes + time_series_list
 
         if all_datatypes is None or len(all_datatypes) == 0:

--- a/framework_tvb/tvb/adapters/exporters/tvb_export.py
+++ b/framework_tvb/tvb/adapters/exporters/tvb_export.py
@@ -33,7 +33,7 @@
 """
 
 from tvb.adapters.exporters.abcexporter import ABCExporter
-from tvb.core.entities.model.model_datatype import DataType
+from tvb.core.entities.model.model_datatype import DataType, DataTypeGroup
 from tvb.core.neocom import h5
 from tvb.storage.storage_interface import StorageInterface
 
@@ -60,7 +60,7 @@ class TVBExporter(ABCExporter):
         """
         download_file_name = self._get_export_file_name(data)
 
-        if self.is_data_a_group(data):
+        if DataTypeGroup.is_data_a_group(data):
             _, op_file_dict = self.prepare_datatypes_for_export(data)
 
             # Create ZIP archive
@@ -75,7 +75,7 @@ class TVBExporter(ABCExporter):
             return None, data_file, True
 
     def get_export_file_extension(self, data):
-        if self.is_data_a_group(data):
+        if DataTypeGroup.is_data_a_group(data):
             return StorageInterface.TVB_ZIP_FILE_EXTENSION
         else:
             return StorageInterface.TVB_STORAGE_FILE_EXTENSION

--- a/framework_tvb/tvb/adapters/exporters/tvb_linked_export.py
+++ b/framework_tvb/tvb/adapters/exporters/tvb_linked_export.py
@@ -34,7 +34,7 @@
 
 from tvb.adapters.exporters.abcexporter import ABCExporter
 from tvb.core.entities import load
-from tvb.core.entities.model.model_datatype import DataType
+from tvb.core.entities.model.model_datatype import DataType, DataTypeGroup
 from tvb.core.neocom import h5
 from tvb.core.neotraits.h5 import H5File
 from tvb.storage.storage_interface import StorageInterface
@@ -74,7 +74,7 @@ class TVBLinkedExporter(ABCExporter):
         2. If data is a DataTypeGroup creates a zip with all files for all data types
         """
         download_file_name = self._get_export_file_name(data)
-        if self.is_data_a_group(data):
+        if DataTypeGroup.is_data_a_group(data):
             all_datatypes, op_file_dict = self.prepare_datatypes_for_export(data)
 
             # Copy the linked datatypes

--- a/framework_tvb/tvb/config/__init__.py
+++ b/framework_tvb/tvb/config/__init__.py
@@ -68,3 +68,6 @@ MEASURE_METRICS_MODEL_CLASS = 'TimeseriesMetricsAdapterModel'
 DEFAULT_PROJECT_GID = '2cc58a73-25c1-11e5-a7af-14109fe3bf71'
 
 VIEW_MODEL2ADAPTER = {}
+
+DATATYPE_MEASURE_INDEX_MODULE = 'tvb.adapters.datatypes.db.mapped_value'
+DATATYPE_MEASURE_INDEX_CLASS = 'DatatypeMeasureIndex'

--- a/framework_tvb/tvb/core/entities/model/model_datatype.py
+++ b/framework_tvb/tvb/core/entities/model/model_datatype.py
@@ -310,6 +310,13 @@ class DataTypeGroup(DataType):
         else:
             self.no_of_ranges = 0
 
+    @staticmethod
+    def is_data_a_group(data):
+        """
+        Checks if the provided data, ready for export is a DataTypeGroup or not
+        """
+        return isinstance(data, DataTypeGroup)
+
 
 class Links(Base):
     """

--- a/framework_tvb/tvb/core/entities/model/model_datatype.py
+++ b/framework_tvb/tvb/core/entities/model/model_datatype.py
@@ -203,6 +203,10 @@ class DataType(HasTraitsIndex):
                 pass
         return ret
 
+    @property
+    def is_ts(self):
+        return hasattr(self, 'time_series_type')
+
     def _get_table_columns(self):
         columns = self.__table__.columns.keys()
         if type(self).__bases__[0] is DataType:

--- a/framework_tvb/tvb/core/entities/storage/project_dao.py
+++ b/framework_tvb/tvb/core/entities/storage/project_dao.py
@@ -278,7 +278,7 @@ class CaseDAO(RootDAO):
                                              ).filter(Operation.id == operation_id).one()
         return result
 
-    def get_links_for_project(self, project_id):
+    def get_links_to_project(self, project_id):
         """
         :return all links referring to a given project_id
         """

--- a/framework_tvb/tvb/core/neocom/h5.py
+++ b/framework_tvb/tvb/core/neocom/h5.py
@@ -261,7 +261,10 @@ def gather_all_references_by_index(h5_file, ref_files):
             continue
         index = load_entity_by_gid(gid)
         h5_file = h5_file_for_index(index)
-        ref_files.append(h5_file.path)
+
+        if h5_file.path not in ref_files:
+            ref_files.append(h5_file.path)
+
         gather_all_references_by_index(h5_file, ref_files)
 
 

--- a/framework_tvb/tvb/core/services/algorithm_service.py
+++ b/framework_tvb/tvb/core/services/algorithm_service.py
@@ -196,13 +196,12 @@ class AlgorithmService(object):
         return dao.get_algorithm_by_module(module, classname)
 
     @staticmethod
-    def create_link(data_ids, project_id):
+    def create_link(data_id, project_id):
         """
         For a list of dataType IDs and a project id create all the required links.
         """
-        for data in data_ids:
-            link = Links(data, project_id)
-            dao.store_entity(link)
+        link = Links(data_id, project_id)
+        dao.store_entity(link)
 
     @staticmethod
     def remove_link(dt_id, project_id):

--- a/framework_tvb/tvb/core/services/import_service.py
+++ b/framework_tvb/tvb/core/services/import_service.py
@@ -262,9 +262,9 @@ class ImportService(object):
             self.store_datatype(datatype, dt_path)
             stored_dt_count = 1
         elif datatype_already_in_tvb.parent_operation.project.id != project_id:
-            AlgorithmService.create_link([datatype_already_in_tvb.id], project_id)
+            AlgorithmService.create_link(datatype_already_in_tvb.id, project_id)
             if datatype_already_in_tvb.fk_datatype_group:
-                AlgorithmService.create_link([datatype_already_in_tvb.fk_datatype_group], project_id)
+                AlgorithmService.create_link(datatype_already_in_tvb.fk_datatype_group, project_id)
         return stored_dt_count
 
     def _store_imported_datatypes_in_db(self, project, all_datatypes):

--- a/framework_tvb/tvb/core/services/project_service.py
+++ b/framework_tvb/tvb/core/services/project_service.py
@@ -681,7 +681,8 @@ class ProjectService:
 
         # Datatype Groups were already handled when the first DatatypeMeasureIndex has been found
         if dao.is_datatype_group(datatype_gid):
-            return
+            is_datatype_group = True
+            datatype_group = datatype
         # Found the first DatatypeMeasureIndex from a group
         elif datatype.fk_datatype_group is not None:
             is_datatype_group = True
@@ -704,8 +705,12 @@ class ProjectService:
                 links.extend(dao.get_links_for_datatype(dt_group_for_metric_op_group.id))
 
                 if len(links) > 0:
-                    # We want to get the links for the TSIndex directly, instead of DatatypeMeasureIndex
-                    ts = h5.load_entity_by_gid(datatype.fk_source_gid)
+                    # We want to get the links for the first TSIndex directly
+                    # This code works for all cases
+                    dt_group = dao.get_datatypegroup_by_op_group_id(burst.fk_operation_group)
+                    datatypes = dao.get_datatype_in_group(dt_group.id)
+                    ts = datatypes[0]
+
                     new_dt_links = self._add_links_for_linked_datatypes(ts, links[0].fk_to_project, links[0].id,
                                                                         existing_dt_links)
 

--- a/framework_tvb/tvb/core/services/project_service.py
+++ b/framework_tvb/tvb/core/services/project_service.py
@@ -582,8 +582,6 @@ class ProjectService:
                 # There is no link for this datatype so it has to be deleted
                 specific_remover = get_remover(datatype.type)(datatype)
                 specific_remover.remove_datatype(skip_validation)
-                h5_path = h5.path_for_stored_index(datatype)
-                self.storage_interface.remove_datatype_file(h5_path)
 
                 # Remove burst if dt has one and it still exists
                 if datatype.fk_parent_burst is not None and datatype.is_ts:

--- a/framework_tvb/tvb/interfaces/web/controllers/project/project_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/project/project_controller.py
@@ -615,18 +615,12 @@ class ProjectController(BaseController):
     @cherrypy.expose
     @handle_error(redirect=False)
     @check_user
-    def createlink(self, link_data, project_id, is_group):
+    def createlink(self, link_data, project_id):
         """
-        Delegate the creation of the actual link to the flow service.
+        Delegate the creation of the actual link to the algorithm service.
         """
-        if not string2bool(str(is_group)):
-            self.algorithm_service.create_link([link_data], project_id)
-        else:
-            all_data = self.project_service.get_datatype_in_group(link_data)
-            # Link all Dts in group and the DT_Group entity
-            data_ids = [data.id for data in all_data]
-            data_ids.append(int(link_data))
-            self.algorithm_service.create_link(data_ids, project_id)
+        self.algorithm_service.create_link(link_data, project_id)
+
 
     @cherrypy.expose
     @handle_error(redirect=False)

--- a/framework_tvb/tvb/interfaces/web/static/js/projectTree.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/projectTree.js
@@ -126,11 +126,11 @@ function _postInitializeTree(treeSelector) {
 //                More GENERIC functions from here
 //-----------------------------------------------------------------------
 
-function createLink(dataId, projectId, isGroup) {
+function createLink(dataId, projectId) {
     doAjaxCall({
         async : false,
         type: 'GET',
-        url: "/project/createlink/" + dataId +"/" + projectId + "/" + isGroup,
+        url: "/project/createlink/" + dataId +"/" + projectId,
         success: function(r) {if(r) displayMessage(r,'warningMessage'); },
         error:   function(r) {if(r) displayMessage(r,'warningMessage'); }
     });

--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/project/linkable_projects.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/project/linkable_projects.html
@@ -25,7 +25,7 @@
                     {% for prj in projectsforlink %}
                         <li>
                             <button class="action action-link"
-                                    onclick="createLink('{{ datatype_id }}', '{{ prj }}' , '{{ isGroup }}');
+                                    onclick="createLink('{{ datatype_id }}', '{{ prj }}');
                                             updateLinkableProjects('{{ datatype_id }}', '{{ isGroup }}', '{{ entity_gid }}');">
                                 Link into project: "{{ projectsforlink[prj] }}"
                             </button>

--- a/framework_tvb/tvb/tests/framework/core/services/links_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/links_test.py
@@ -101,20 +101,20 @@ class TestLinks(_BaseLinksTest):
 
     def test_create_link(self, initialize_two_projects):
         dest_id = self.dest_project.id
-        self.algorithm_service.create_link([self.red_datatype.id], dest_id)
+        self.algorithm_service.create_link(self.red_datatype.id, dest_id)
         assert 1 == self.red_datatypes_in(dest_id)
         assert 0 == self.blue_datatypes_in(dest_id)
 
     def test_remove_link(self, initialize_two_projects):
         dest_id = self.dest_project.id
-        self.algorithm_service.create_link([self.red_datatype.id], dest_id)
+        self.algorithm_service.create_link(self.red_datatype.id, dest_id)
         assert 1 == self.red_datatypes_in(dest_id)
         self.algorithm_service.remove_link(self.red_datatype.id, dest_id)
         assert 0 == self.red_datatypes_in(dest_id)
 
     def test_link_appears_in_project_structure(self, initialize_two_projects):
         dest_id = self.dest_project.id
-        self.algorithm_service.create_link([self.red_datatype.id], dest_id)
+        self.algorithm_service.create_link(self.red_datatype.id, dest_id)
         # Test getting information about linked datatypes, from low level methods to the one used by the UI
         dt_1s = dao.get_linked_datatypes_in_project(dest_id)
         assert 1 == len(dt_1s)
@@ -125,7 +125,7 @@ class TestLinks(_BaseLinksTest):
 
     def test_remove_entity_with_links_moves_links(self, initialize_two_projects):
         dest_id = self.dest_project.id
-        self.algorithm_service.create_link([self.red_datatype.id], dest_id)
+        self.algorithm_service.create_link(self.red_datatype.id, dest_id)
         assert 1 == self.red_datatypes_in(dest_id)
         # remove original datatype
         self.project_service.remove_datatype(self.src_project.id, self.red_datatype.gid)
@@ -147,8 +147,8 @@ class TestImportExportProjectWithLinksTest(_BaseLinksTest):
         """
 
         dest_id = self.dest_project.id
-        self.algorithm_service.create_link([self.red_datatype.id], dest_id)
-        self.algorithm_service.create_link([self.blue_datatype.id], dest_id)
+        self.algorithm_service.create_link(self.red_datatype.id, dest_id)
+        self.algorithm_service.create_link(self.blue_datatype.id, dest_id)
         self.export_mng = ExportManager()
 
     def test_export(self, initialize_linked_projects):
@@ -212,13 +212,13 @@ class TestImportExportProjectWithLinksTest(_BaseLinksTest):
             # add a connectivity to src project and link it to dest project
             zip_path = os.path.join(os.path.dirname(tvb_data.__file__), 'connectivity', 'connectivity_96.zip')
             conn = TestFactory.import_zip_connectivity(self.dst_user, self.src_project, zip_path, "John")
-            self.algorithm_service.create_link([conn.id], self.dest_project.id)
+            self.algorithm_service.create_link(conn.id, self.dest_project.id)
 
             # in dest derive a ValueWrapper from the linked conn
             vw_gid = TestFactory.create_value_wrapper(self.dst_user, self.dest_project)[1]
             vw = dao.get_datatype_by_gid(vw_gid)
             # then link the time series in the src project
-            self.algorithm_service.create_link([vw.id], self.src_project.id)
+            self.algorithm_service.create_link(vw.id, self.src_project.id)
 
             assert 3 == len(dao.get_datatypes_in_project(self.src_project.id))
             assert 1 == len(dao.get_linked_datatypes_in_project(self.src_project.id))

--- a/framework_tvb/tvb/tests/framework/core/services/project_service_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/project_service_test.py
@@ -370,7 +370,7 @@ class TestProjectService(TransactionalTestCase):
         project_to_link = dao.store_entity(project_to_link)
         exact_data = dao.get_datatype_by_gid(gid)
         assert exact_data is not None, "Initialization problem!"
-        dao.store_entity(model_datatype.Links(exact_data.id, project_to_link.id))
+        link = dao.store_entity(model_datatype.Links(exact_data.id, project_to_link.id))
 
         vw_h5_path = h5.path_for_stored_index(exact_data)
         assert os.path.exists(vw_h5_path)
@@ -380,7 +380,7 @@ class TestProjectService(TransactionalTestCase):
                                                   TvbProfile.current.web.admin.SYSTEM_USER_NAME, None, None, True,
                                                   None))
 
-        self.project_service._remove_project_node_files(inserted_project.id, gid)
+        self.project_service._remove_project_node_files(inserted_project.id, gid, [link])
 
         assert not os.path.exists(vw_h5_path)
         exact_data = dao.get_datatype_by_gid(gid)
@@ -389,7 +389,7 @@ class TestProjectService(TransactionalTestCase):
         assert os.path.exists(vw_h5_path_new)
         assert vw_h5_path_new != vw_h5_path
 
-        self.project_service._remove_project_node_files(project_to_link.id, gid)
+        self.project_service._remove_project_node_files(project_to_link.id, gid, [])
         assert dao.get_datatype_by_gid(gid) is None
 
     def test_update_meta_data_simple(self):

--- a/framework_tvb/tvb/tests/framework/core/services/project_service_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/project_service_test.py
@@ -476,7 +476,8 @@ class TestProjectService(TransactionalTestCase):
         expected_links.append(dt_group.gid)
 
         # Actually create the links from Prj1 into Prj2
-        AlgorithmService().create_link(link_ids, project2.id)
+        for link_id in link_ids:
+            AlgorithmService().create_link(link_id, project2.id)
 
         # Retrieve the raw data used to compose the tree (for easy parsing)
         dts_in_tree = dao.get_data_in_project(project2.id)

--- a/framework_tvb/tvb/tests/framework/core/services/project_structure_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/project_structure_test.py
@@ -266,28 +266,6 @@ class TestProjectStructure(TransactionalTestCase):
         self.project_service.remove_datatype(self.test_project.id, dt_list[0].gid)
         self._check_if_datatype_was_removed(dt_list[0])
 
-    def test_remove_datatype_from_group(self, datatype_group_factory, project_factory, user_factory):
-        """
-        Tests the deletion of a datatype group.
-        """
-        user = user_factory()
-        project = project_factory(user)
-        group, _ = datatype_group_factory(project=project)
-
-        datatype_group = dao.get_generic_entity(DataTypeGroup, group.id)[0]
-        datatypes = dao.get_datatypes_from_datatype_group(group.id)
-        datatype_measure = dao.get_generic_entity(DatatypeMeasureIndex, datatypes[0].gid, "fk_source_gid")[0]
-
-        # When trying to delete one entity in a group the entire group will be removed
-        #  First remove the DTMeasures, to avoid FK failures
-        self.project_service.remove_datatype(project.id, datatype_measure.gid)
-        self.project_service.remove_datatype(project.id, datatypes[0].gid)
-        self._check_if_datatype_was_removed(datatypes[0])
-        self._check_if_datatype_was_removed(datatypes[1])
-        self._check_if_datatype_was_removed(datatype_group)
-        self._check_if_datatype_was_removed(datatype_measure)
-        self._check_datatype_group_removed(group.id, datatype_group.fk_operation_group)
-
     def test_remove_datatype_group(self, datatype_group_factory, project_factory, user_factory):
         """
         Tests the deletion of a datatype group.
@@ -300,8 +278,8 @@ class TestProjectStructure(TransactionalTestCase):
         datatypes = dao.get_datatypes_from_datatype_group(group.id)
         assert 2 == len(datatype_groups)
 
-        self.project_service.remove_datatype(project.id, datatype_groups[1].gid)
-        self.project_service.remove_datatype(project.id, datatype_groups[0].gid)
+        self.project_service.remove_datatype(project.id, datatype_groups[1].gid, skip_validation=True)
+        self.project_service.remove_datatype(project.id, datatype_groups[0].gid, skip_validation=True)
         self._check_if_datatype_was_removed(datatypes[0])
         self._check_if_datatype_was_removed(datatypes[1])
         self._check_if_datatype_was_removed(datatype_groups[0])

--- a/framework_tvb/tvb/tests/framework/core/services/remove_test.py
+++ b/framework_tvb/tvb/tests/framework/core/services/remove_test.py
@@ -160,7 +160,7 @@ class TestRemove(TransactionalTestCase):
         conn = h5.load_from_index(conn)
         rm = try_get_last_datatype(self.test_project.id, RegionMappingIndex)
         rm = h5.load_from_index(rm)
-        time_series_region_index_factory(conn, rm)
+        time_series_region_index_factory(conn, rm, test_project=self.test_project)
         series = self.get_all_entities(TimeSeriesRegionIndex)
         assert 1 == len(series), "There should be only one time series"
 

--- a/tvb_storage/tvb/storage/storage_interface.py
+++ b/tvb_storage/tvb/storage/storage_interface.py
@@ -316,12 +316,12 @@ class StorageInterface:
         encrypted_path = DataEncryptionHandler.compute_encrypted_folder_path(project_folder)
         FilesHelper.remove_files([encrypted_path, DataEncryptionHandler.project_key_path(project.id)], True)
 
-    def move_datatype_with_sync(self, to_project, to_project_path, new_op_id, full_path, vm_full_path):
+    def move_datatype_with_sync(self, to_project, to_project_path, new_op_id, path_list):
         self.set_project_active(to_project)
         self.sync_folders(to_project_path)
 
-        self.files_helper.move_datatype(to_project.name, str(new_op_id), full_path)
-        self.files_helper.move_datatype(to_project.name, str(new_op_id), vm_full_path)
+        for path in path_list:
+            self.files_helper.move_datatype(to_project.name, str(new_op_id), path)
 
         self.sync_folders(to_project_path)
         self.set_project_inactive(to_project)


### PR DESCRIPTION
I solved both problems because they were related.

Project deletion with links until now only worked if we linked a datatype that is not linked to some other datatypes. If we had, for example, a region mapping then it didn't copy the connectivity and the surface to the new project, thus we couldn't view the region mapping.

However, the bigger problem was that copying linked datatype groups didn't work at all. I managed to solve this as well. Now it doesn't matter if we link the datatype group for TSIndex or DMIndex, in both cases both of them will be copied to the new project.

If we have a datatype that is linked to more projects then it will be moved to the first project returned by the database and it will have a link pointing to the other projects.

I have tested several cases both in Sqlite and Postgres and didn't find any issues.
Maybe the project deletion process is too complicated and we talked with Paula about reviewing generally the remove methods. I intend to do that soon but for now, I think this is okay to be merged.