### PR TITLE
TVB-2889: Suppress numpy warnings

### DIFF
--- a/scientific_library/tvb/tests/library/datatypes/sensors_test.py
+++ b/scientific_library/tvb/tests/library/datatypes/sensors_test.py
@@ -69,7 +69,9 @@ class TestSensors(BaseTestCase):
         dummy_surf = SkinAir()
         dummy_surf.vertices = numpy.array(list(range(30))).reshape(10, 3).astype('f')
         dummy_surf.triangles = numpy.array(list(range(9))).reshape(3, 3)
-        dummy_surf.configure()
+
+        with numpy.errstate(all='ignore'):
+            dummy_surf.configure()
         try:
             dt.sensors_to_surface(dummy_surf)
             self.fail("Should have failed for this simple surface!")

--- a/scientific_library/tvb/tests/library/datatypes/sensors_test.py
+++ b/scientific_library/tvb/tests/library/datatypes/sensors_test.py
@@ -69,12 +69,13 @@ class TestSensors(BaseTestCase):
         dummy_surf = SkinAir()
         dummy_surf.vertices = numpy.array(list(range(30))).reshape(10, 3).astype('f')
         dummy_surf.triangles = numpy.array(list(range(9))).reshape(3, 3)
+        dummy_surf.triangle_normals = numpy.array(list(range(9))).reshape(3, 3)
+        dummy_surf.vertex_normals = numpy.array(list(range(30))).reshape(10, 3).astype('f')
+        dummy_surf.configure()
 
-        with numpy.errstate(all='ignore'):
-            dummy_surf.configure()
         try:
             dt.sensors_to_surface(dummy_surf)
-            self.fail("Should have failed for this simple surface!")
+            pytest.fail("Should have failed for this simple surface!")
         except Exception:
             pass
 

--- a/scientific_library/tvb/tests/library/datatypes/surfaces_test.py
+++ b/scientific_library/tvb/tests/library/datatypes/surfaces_test.py
@@ -51,7 +51,10 @@ class TestSurfaces(BaseTestCase):
         dt = surfaces.Surface(valid_for_simulations=True)
         dt.vertices = numpy.array(list(range(30))).reshape(10, 3).astype(numpy.float64)
         dt.triangles = numpy.array(list(range(9))).reshape(3, 3)
-        dt.configure()
+
+        with numpy.errstate(all='ignore'):
+            dt.configure()
+
         summary_info = dt.summary_info()
         assert summary_info['Number of edges'] == 9
         assert summary_info['Number of triangles'] == 3
@@ -117,7 +120,9 @@ class TestSurfaces(BaseTestCase):
         dt = surfaces.Surface()
         dt.vertices = numpy.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], [0, 0, 2]]).astype(numpy.float64)
         dt.triangles = numpy.array([[0, 2, 1], [0, 1, 3], [0, 3, 2], [1, 2, 3]])
-        dt.configure()
+
+        with numpy.errstate(all='ignore'):
+            dt.configure()
 
         euler, isolated, pinched_off, holes = dt.compute_topological_constants()
         assert 3 == euler

--- a/scientific_library/tvb/tests/library/datatypes/surfaces_test.py
+++ b/scientific_library/tvb/tests/library/datatypes/surfaces_test.py
@@ -51,9 +51,10 @@ class TestSurfaces(BaseTestCase):
         dt = surfaces.Surface(valid_for_simulations=True)
         dt.vertices = numpy.array(list(range(30))).reshape(10, 3).astype(numpy.float64)
         dt.triangles = numpy.array(list(range(9))).reshape(3, 3)
+        dt.triangle_normals = numpy.array(list(range(9))).reshape(3, 3)
+        dt.vertex_normals = numpy.array(list(range(30))).reshape(10, 3).astype('f')
 
-        with numpy.errstate(all='ignore'):
-            dt.configure()
+        dt.configure()
 
         summary_info = dt.summary_info()
         assert summary_info['Number of edges'] == 9
@@ -120,9 +121,9 @@ class TestSurfaces(BaseTestCase):
         dt = surfaces.Surface()
         dt.vertices = numpy.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], [0, 0, 2]]).astype(numpy.float64)
         dt.triangles = numpy.array([[0, 2, 1], [0, 1, 3], [0, 3, 2], [1, 2, 3]])
-
-        with numpy.errstate(all='ignore'):
-            dt.configure()
+        dt.triangle_normals = numpy.array([[0, 2, 1], [0, 1, 3], [0, 3, 2], [1, 2, 3]])
+        dt.vertex_normals = numpy.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], [0, 0, 2]]).astype(numpy.float64)
+        dt.configure()
 
         euler, isolated, pinched_off, holes = dt.compute_topological_constants()
         assert 3 == euler

--- a/scientific_library/tvb/tests/library/simulator/backend/nbbackend_mpr_test.py
+++ b/scientific_library/tvb/tests/library/simulator/backend/nbbackend_mpr_test.py
@@ -27,7 +27,7 @@
 #   Frontiers in Neuroinformatics (7:10. doi: 10.3389/fninf.2013.00010)
 #
 #
-
+import numpy
 import numpy as np
 import scipy.sparse as ss
 
@@ -192,15 +192,16 @@ class TestNbSim(BaseTestSim):
             )
         ).configure()
 
-        r_pdq, V_pdq = run_sim(sim, nstep=1)
+        with numpy.errstate(all='ignore'):
+            r_pdq, V_pdq = run_sim(sim, nstep=1)
 
-        np.testing.assert_allclose(sim.current_state[0,:,0], r_pdq[:,0])
-        np.testing.assert_allclose(sim.current_state[1,:,0], V_pdq[:,0])
-        r_pdq = r_pdq[:,1] # we include initial state, TVB doesn't
-        V_pdq = V_pdq[:,1]
+            np.testing.assert_allclose(sim.current_state[0,:,0], r_pdq[:,0])
+            np.testing.assert_allclose(sim.current_state[1,:,0], V_pdq[:,0])
+            r_pdq = r_pdq[:,1] # we include initial state, TVB doesn't
+            V_pdq = V_pdq[:,1]
 
-        (raw_t, raw_d), = sim.run(simulation_length=1)
-        r_tvb, V_tvb = raw_d[0,:,:,0]
+            (raw_t, raw_d), = sim.run(simulation_length=1)
+            r_tvb, V_tvb = raw_d[0, :, :, 0]
 
         np.testing.assert_allclose(r_tvb, r_pdq, rtol=1e-4)
         np.testing.assert_allclose(V_tvb, V_pdq, rtol=1e-4)

--- a/scientific_library/tvb/tests/library/simulator/monitors_test.py
+++ b/scientific_library/tvb/tests/library/simulator/monitors_test.py
@@ -164,7 +164,9 @@ class TestProjectionMonitorsWithSubcorticalRegions(BaseTestCase):
 
         sim = simulator.Simulator(model=oscillator, connectivity=white_matter, coupling=white_matter_coupling,
                                   integrator=heunint, monitors=mons, surface=default_cortex)
-        sim.configure()
+
+        with numpy.errstate(all='ignore'):
+            sim.configure()
 
         # check configured simulation connectivity attribute
         conn = sim.connectivity

--- a/scientific_library/tvb/tests/library/simulator/simulator_test.py
+++ b/scientific_library/tvb/tests/library/simulator/simulator_test.py
@@ -180,8 +180,10 @@ class TestSimulator(BaseTestCase):
     @pytest.mark.parametrize('model_class,method_class', itertools.product(MODEL_CLASSES, METHOD_CLASSES))
     def test_simulator_region(self, model_class, method_class):
         test_simulator = Simulator()
-        test_simulator.configure(model=model_class, method=method_class, surface_sim=False)
-        result = test_simulator.run_simulation()
+
+        with numpy.errstate(all='ignore'):
+            test_simulator.configure(model=model_class, method=method_class, surface_sim=False)
+            result = test_simulator.run_simulation()
 
         self.assert_equal(len(test_simulator.monitors), len(result))
         for ts in result:
@@ -196,8 +198,9 @@ class TestSimulator(BaseTestCase):
         """
         test_simulator = Simulator()
 
-        test_simulator.configure(surface_sim=True, default_connectivity=default_connectivity)
-        result = test_simulator.run_simulation(simulation_length=2)
+        with numpy.errstate(all='ignore'):
+            test_simulator.configure(surface_sim=True, default_connectivity=default_connectivity)
+            result = test_simulator.run_simulation(simulation_length=2)
 
         assert len(test_simulator.monitors) == len(result)
 
@@ -306,7 +309,9 @@ class TestSimulator(BaseTestCase):
     @pytest.mark.parametrize('default_connectivity', [True, False])
     def test_simulator_regional_stimulus(self, default_connectivity):
         test_simulator = Simulator()
-        test_simulator.configure(surface_sim=False, default_connectivity=default_connectivity, with_stimulus=True)
+
+        with numpy.errstate(all='ignore'):
+            test_simulator.configure(surface_sim=False, default_connectivity=default_connectivity, with_stimulus=True)
         stimulus = test_simulator.sim._prepare_stimulus()
         self.assert_equal(
             stimulus.shape,


### PR DESCRIPTION
The warnings specified in the task come from numpy operations. Most of these warnings come from the test_simulator_region, but I have suppressed all of them. Numpy has 4 types of warnings: overflow, underflow, invalid, divide. We can choose to suppress all of them or only some types as written here: https://numpy.org/doc/stable/reference/generated/numpy.errstate.html

With Lia we thought that there is a problem with the numba logging in the library_logger_test.conf file. I tried to run only one test by trying to edit it in several ways but it did not make a difference. Maybe the numba logging doesn't do anything and is irrelevant. And one important thing: when we run only one test, the profile is set AFTER the logging configurations, so that means that the library_logger.conf file will be used and not the testing one.