### PR TITLE
TVB-2963 pulse train fix

### DIFF
--- a/scientific_library/tvb/tests/library/datatypes/equations_test.py
+++ b/scientific_library/tvb/tests/library/datatypes/equations_test.py
@@ -35,6 +35,7 @@ Created on Mar 20, 2013
 
 from tvb.tests.library.base_testcase import BaseTestCase
 from tvb.datatypes import equations
+import numpy as np
 
 
 class TestEquations(BaseTestCase):
@@ -55,39 +56,57 @@ class TestEquations(BaseTestCase):
         assert dt.parameters == {}
 
     def test_linear(self):
+        t = np.linspace(0,1)
         dt = equations.Linear()
         assert dt.parameters == {'a': 1.0, 'b': 0.0}
+        np.testing.assert_allclose( dt.evaluate(t)[10:], dt.evaluate(t[10:]))
 
     def test_gaussian(self):
+        t = np.linspace(0,10)
         dt = equations.Gaussian()
         assert dt.parameters == {'amp': 1.0, 'sigma': 1.0, 'midpoint': 0.0, 'offset': 0.0}
+        np.testing.assert_allclose( dt.evaluate(t)[10:], dt.evaluate(t[10:]))
 
     def test_doublegaussian(self):
+        t = np.linspace(0,100)
         dt = equations.DoubleGaussian()
         assert dt.parameters == {'midpoint_2': 0.0, 'midpoint_1': 0.0,
                                  'amp_2': 1.0, 'amp_1': 0.5, 'sigma_2': 10.0,
                                  'sigma_1': 20.0}
+        np.testing.assert_allclose( dt.evaluate(t)[10:], dt.evaluate(t[10:]))
 
     def test_sigmoid(self):
+        t = np.linspace(0,10)
         dt = equations.Sigmoid()
         assert dt.parameters == {'amp': 1.0, 'radius': 5.0, 'sigma': 1.0, 'offset': 0.0}
+        np.testing.assert_allclose( dt.evaluate(t)[10:], dt.evaluate(t[10:]))
 
     def test_generalizedsigmoid(self):
+        t = np.linspace(0,2)
         dt = equations.GeneralizedSigmoid()
         assert dt.parameters == {'high': 1.0, 'midpoint': 1.0, 'sigma': 0.3, 'low': 0.0}
+        np.testing.assert_allclose( dt.evaluate(t)[10:], dt.evaluate(t[10:]))
 
     def test_sinusoiddata(self):
+        t = np.linspace(0,100)
         dt = equations.Sinusoid()
         assert dt.parameters == {'amp': 1.0, 'frequency': 0.01}
+        np.testing.assert_allclose( dt.evaluate(t)[10:], dt.evaluate(t[10:]))
 
     def test_cosine(self):
+        t = np.linspace(0,100)
         dt = equations.Cosine()
         assert dt.parameters == {'amp': 1.0, 'frequency': 0.01}
+        np.testing.assert_allclose( dt.evaluate(t)[10:], dt.evaluate(t[10:]))
 
     def test_alpha(self):
+        t = np.linspace(0,1,100)
         dt = equations.Alpha()
         assert dt.parameters == {'onset': 0.5, 'alpha': 13.0, 'beta': 42.0}
+        np.testing.assert_allclose( dt.evaluate(t)[10:], dt.evaluate(t[10:]))
 
     def test_pulsetrain(self):
+        t = np.linspace(0,100)
         dt = equations.PulseTrain()
         assert dt.parameters == {'onset': 30.0, 'tau': 13.0, 'T': 42.0, 'amp': 1.0}
+        np.testing.assert_allclose( dt.evaluate(t)[10:], dt.evaluate(t[10:]))


### PR DESCRIPTION
The evaluation of PulseTrain equation returned wrong results if the provided `var` vector doesn't start at 0. 

e.g.

```python
pt = equations.PulseTrain( parameters={ 'onset': 40, 'T': 15.0 , 'tau': 10.0, 'amp': 1.} )
t = np.linspace(5,100,1000)
plt.plot(t, pt.evaluate(t))
plt.axvline(x=40, c='r', ls=':')
plt.axvline(x=50, c='r', ls=':')
```

![image](https://user-images.githubusercontent.com/833828/130249254-e696f04c-a2db-4971-bb41-810ea6bc366b.png)
