### PR TITLE
Fix small error in simulator.py

### DIFF
--- a/scientific_library/tvb/simulator/simulator.py
+++ b/scientific_library/tvb/simulator/simulator.py
@@ -419,7 +419,7 @@ class Simulator(HasTraits):
         elif nsig.shape == (self.number_of_nodes,):
             nsig = nsig.reshape((1, self.number_of_nodes, 1))
         elif nsig.shape == (self.model.nvar, self.number_of_nodes):
-            nsig = nsig[self.model.state_variable_mask].reshape((self.n_intvar, self.number_of_nodes, 1))
+            nsig = nsig[self.model.state_variable_mask].reshape((self.model.nintvar, self.number_of_nodes, 1))
         elif nsig.shape == (self.model.nintvar, self.number_of_nodes):
             nsig = nsig.reshape((self.model.nintvar, self.number_of_nodes, 1))
         else:


### PR DESCRIPTION
I found this error while doing UI testing. There is no n_intvar parameter, there is only nintvar and that's on the model classes, not the simulator.

Also, there is another small issue I found and discussed with Paula: the equation for local connectivity is unrequired in the code when in the UI it definetely should be required. Are there some examples in the library where you can use LCs without an equation? If not, I shall fix that as well in this PR.