### PR TITLE
TVB-2968: Add Cortex.Coupling_Strength as a range parameter

### DIFF
--- a/framework_tvb/tvb/adapters/simulator/range_parameters.py
+++ b/framework_tvb/tvb/adapters/simulator/range_parameters.py
@@ -32,20 +32,19 @@ from collections import OrderedDict
 from tvb.basic.neotraits.api import NArray, Range
 from tvb.core.entities.transient.range_parameter import RangeParameter
 from tvb.datatypes.connectivity import Connectivity
-from tvb.datatypes.surfaces import Surface
 from tvb.simulator.integrators import IntegratorStochastic
 from tvb.simulator.simulator import Simulator
 
 
 class SimulatorRangeParameters(object):
 
-    def __init__(self, connectivity_filters=None, surface_filters=None, coupling=None, model=None,
-                 integrator_noise=None):
-        self.connectivity_filters = connectivity_filters
-        self.surface_filters = surface_filters
-        self.coupling_parameters = coupling
-        self.model_parameters = model
-        self.integrator_noise_parameters = integrator_noise
+    def __init__(self):
+        self.connectivity_filters = None
+        self.surface_filters = None
+        self.coupling_parameters = None
+        self.surface_parameters = None
+        self.model_parameters = None
+        self.integrator_noise_parameters = None
 
     def _default_range_parameters(self):
         conduction_speed = RangeParameter(Simulator.conduction_speed.field_name, float,
@@ -73,11 +72,14 @@ class SimulatorRangeParameters(object):
             dynamic_parameters.update({param.name: param})
         return dynamic_parameters
 
-    def _prepare_model_parameters(self):
-        return self._prepare_dynamic_parameters(Simulator.model.field_name, self.model_parameters)
-
     def _prepare_coupling_parameters(self):
         return self._prepare_dynamic_parameters(Simulator.coupling.field_name, self.coupling_parameters)
+
+    def _prepare_surface_parameters(self):
+        return self._prepare_dynamic_parameters(Simulator.surface.field_type.__name__, self.surface_parameters)
+
+    def _prepare_model_parameters(self):
+        return self._prepare_dynamic_parameters(Simulator.model.field_name, self.model_parameters)
 
     def _prepare_integrator_noise_parameters(self):
         return self._prepare_dynamic_parameters(
@@ -87,6 +89,7 @@ class SimulatorRangeParameters(object):
     def get_all_range_parameters(self):
         all_range_parameters = self._default_range_parameters()
         all_range_parameters.update(self._prepare_coupling_parameters())
+        all_range_parameters.update(self._prepare_surface_parameters())
         all_range_parameters.update(self._prepare_model_parameters())
         all_range_parameters.update(self._prepare_integrator_noise_parameters())
 

--- a/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
+++ b/framework_tvb/tvb/adapters/simulator/simulator_fragments.py
@@ -33,6 +33,7 @@ import formencode
 from formencode import validators
 
 from tvb.adapters.datatypes.db.patterns import StimuliRegionIndex, SpatioTemporalPatternIndex
+from tvb.adapters.simulator.form_with_ranges import FormWithRanges
 from tvb.adapters.simulator.integrator_forms import get_form_for_integrator
 from tvb.adapters.simulator.model_forms import get_ui_name_to_model
 from tvb.adapters.simulator.monitor_forms import get_ui_name_to_monitor_dict, get_monitor_to_ui_name_dict
@@ -76,7 +77,7 @@ class SimulatorSurfaceFragment(ABCAdapterForm):
                                                                    project_id)
 
 
-class SimulatorRMFragment(ABCAdapterForm):
+class SimulatorRMFragment(FormWithRanges):
     def __init__(self, surface_index=None, connectivity_gid=None):
         super(SimulatorRMFragment, self).__init__()
         rm_conditions = None

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator/simulator_controller.py
@@ -223,6 +223,7 @@ class SimulatorController(BurstBaseController):
             form = SimulatorSurfaceFragment()
             form.fill_from_post(data)
             self.simulator_service.reset_at_surface_change(is_simulation_copy, form, session_stored_simulator)
+            self.range_parameters.surface_parameters = None
             form.fill_trait(session_stored_simulator)
 
             if session_stored_simulator.surface:
@@ -361,6 +362,8 @@ class SimulatorController(BurstBaseController):
                 self.context.add_last_loaded_form_url_to_session(SimulatorWizzardURLs.SET_NOISE_PARAMS_URL)
             else:
                 self.context.add_last_loaded_form_url_to_session(SimulatorWizzardURLs.SET_MONITORS_URL)
+
+            self.range_parameters.integrator_noise_parameters = None
 
         rendering_rules = SimulatorFragmentRenderingRules(
             None, None, SimulatorWizzardURLs.SET_INTEGRATOR_PARAMS_URL, is_simulation_copy,

--- a/framework_tvb/tvb/interfaces/web/controllers/simulator/simulator_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/simulator/simulator_controller.py
@@ -42,7 +42,6 @@ from tvb.adapters.simulator.noise_forms import get_form_for_noise
 from tvb.adapters.simulator.range_parameters import SimulatorRangeParameters
 from tvb.adapters.simulator.simulator_adapter import SimulatorAdapterForm
 from tvb.adapters.simulator.simulator_fragments import *
-from tvb.basic.neotraits.ex import TraitValueError
 from tvb.config.init.introspector_registry import IntrospectionRegistry
 from tvb.core.entities.file.simulator.view_model import AdditiveNoiseViewModel, BoldViewModel
 from tvb.core.entities.file.simulator.view_model import IntegratorStochasticViewModel
@@ -238,13 +237,14 @@ class SimulatorController(BurstBaseController):
     @expose_fragment('simulator_fragment')
     def set_cortex(self, **data):
         session_stored_simulator, is_simulation_copy, is_simulation_load, _ = self.context.get_common_params()
+        rm_fragment = SimulatorRMFragment()
 
         if cherrypy.request.method == POST_REQUEST:
             self.context.add_last_loaded_form_url_to_session(SimulatorWizzardURLs.SET_STIMULUS_URL)
-            rm_fragment = SimulatorRMFragment()
             rm_fragment.fill_from_post(data)
             rm_fragment.fill_trait(session_stored_simulator.surface)
 
+        self.range_parameters.surface_parameters = rm_fragment.get_range_parameters()
         rendering_rules = SimulatorFragmentRenderingRules(
             None, None, SimulatorWizzardURLs.SET_CORTEX_URL, is_simulation_copy, is_simulation_load,
             self.context.last_loaded_fragment_url, cherrypy.request.method)


### PR DESCRIPTION
Just adding FormWithRanges as a superclass to SurfaceRMFragment was not enough.

We have only one surface range parameter but I added in the same way as the other parameter for consistency.

Also, I removed the constructor arguments for SimulatorRangeParameters because they are always None.