### PR TITLE
Model specific stimulus

### DIFF
--- a/scientific_library/tvb/simulator/models/base.py
+++ b/scientific_library/tvb/simulator/models/base.py
@@ -157,7 +157,7 @@ class Model(HasTraits):
         dt = integrator.dt
         return self.initial(dt, shape, rng)
 
-    def _update_stimulus(self, step, dt):
+    def update_stimulus(self, step, dt):
         """
         When needed, and if stimulus is not None,
         this should be a method for computing a model specific, time-dependent stimulus.

--- a/scientific_library/tvb/simulator/simulator.py
+++ b/scientific_library/tvb/simulator/simulator.py
@@ -310,7 +310,7 @@ class Simulator(HasTraits):
             stim_step = step - (self.current_step + 1)
             stimulus[self.model.stvar, :, :] = self.stimulus(stim_step).reshape((1, -1, 1))
         if self.model.stimulus is not None:
-            self.model._loop_update_stimulus(step, self.integrator.dt)
+            self.model.update_stimulus(step, self.integrator.dt)
 
     def _loop_update_history(self, step, state):
         """Update history."""


### PR DESCRIPTION
I added a simple mechanism for having model specific time dependent stimuli, i.e., stimuli that will be computed and applied to model.dfun, at each time step, by code specific to each TVB model.

I find the application of stimuli in the integrator. scheme as not flexible enough.

I only added model.stimulus (default = None) and a method update_stimulus (originally empty) in model base.py

as well as a call to model.update_stimulus(step, integrator.dt) inside simulator._loop_update_stimulus() method, in order that the stimulus is updated at each time step, knowing the time. 

I SUGGEST WE CANCEL THIS AND WE TURN INSTEAD TO THIS ONE:
[https://github.com/the-virtual-brain/tvb-root/pull/489]
