### PR TITLE
Move dependencies (cryptography, pyAesCrypt) 

### DIFF
--- a/framework_tvb/setup.py
+++ b/framework_tvb/setup.py
@@ -44,9 +44,9 @@ VERSION = "2.4.1"
 
 TVB_TEAM = "Mihai Andrei, Lia Domide, Stuart Knock, Bogdan Neacsa, Paula Prodan, Paula Sansz Leon, Marmaduke Woodman"
 
-TVB_INSTALL_REQUIREMENTS = ["alembic", "allensdk", "cherrypy", "cryptography", "flask==1.1.4", "flask-restx",
+TVB_INSTALL_REQUIREMENTS = ["alembic", "allensdk", "cherrypy", "flask==1.1.4", "flask-restx",
                             "formencode", "gevent", "h5py<3", "Jinja2<2.12.0", "nibabel", "numpy", "pandas",
-                            "Pillow", "psutil", "pyAesCrypt", "python-keycloak", "requests", "scikit-learn",
+                            "Pillow", "psutil", "python-keycloak", "requests", "scikit-learn",
                             "scipy", "simplejson", "six", "sqlalchemy", "tvb-data", "tvb-gdist",
                             "tvb-library", "tvb-storage", "werkzeug"]
 

--- a/tvb_storage/setup.py
+++ b/tvb_storage/setup.py
@@ -42,7 +42,7 @@ STORAGE_VERSION = "2.4.1"
 
 STORAGE_TEAM = "Lia Domide, Paula Prodan, Bogdan Valean, Robert Vincze"
 
-STORAGE_REQUIRED_PACKAGES = ["h5py", "numpy", "scipy"]
+STORAGE_REQUIRED_PACKAGES = ["cryptography", "h5py", "numpy", "pyAesCrypt", "scipy"]
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as fd:
     DESCRIPTION = fd.read()


### PR DESCRIPTION
Move dependencies from tvb-framework into tvb-storage, as the encryption mechanism has been moved there.
Can you confirm that this is correct ?