### PR TITLE
fix-filter-chain: Keep operator between fields.

### DIFF
--- a/framework_tvb/tvb/core/entities/filters/chain.py
+++ b/framework_tvb/tvb/core/entities/filters/chain.py
@@ -119,7 +119,7 @@ class FilterChain(object):
         new_values.extend(other.values)
         operations = self.operations[:]
         operations.extend(other.operations)
-        return FilterChain(new_display_name, new_fields, new_values, operations, 'and')
+        return FilterChain(new_display_name, new_fields, new_values, operations, self.operator_between_fields)
 
     def __str__(self):
         return self.__class__.__name__ + "(fields=%s, operations=%s, values=%s, operator_between_fields=%s)" % (
@@ -186,8 +186,7 @@ class FilterChain(object):
                            values=filter_dictionary[KEY_VALUES], operations=filter_dictionary[KEY_OPERATIONS],
                            operator_between_fields=filter_dictionary[KEY_OPERATOR])
 
-    def get_python_filter_equivalent(self, datatype_to_check=None, algorithm_to_check=None,
-                                     algocategory_to_check=None, operation_to_check=None):
+    def get_python_filter_equivalent(self, datatype_to_check=None):
         """
         Python evaluate of the filter against a current given DataType
         Check a filter instance next to a given input.

--- a/framework_tvb/tvb/core/services/algorithm_service.py
+++ b/framework_tvb/tvb/core/services/algorithm_service.py
@@ -110,6 +110,10 @@ class AlgorithmService(object):
     def fill_selectfield_with_datatypes(self, field, project_id, extra_conditions=None):
         # type: (TraitDataTypeSelectField, int, list) -> None
         filtering_conditions = FilterChain()
+
+        if field.conditions is not None:
+            filtering_conditions.operator_between_fields = field.conditions.operator_between_fields
+
         filtering_conditions += field.conditions
         filtering_conditions += extra_conditions
         datatypes, _ = dao.get_values_of_datatype(project_id, field.datatype_index, filtering_conditions)


### PR DESCRIPTION
The operator between fields in FilterChain is almost always "and" (if not always) but I needed to use an 'or' for TVB-2615 (now we need a cortical OR a brain surface when importing a region mapping) so I found this issue and solved it.