### PR TITLE
TVB-2122: Parallelize library tests

### DIFF
--- a/scientific_library/setup.py
+++ b/scientific_library/setup.py
@@ -46,7 +46,7 @@ LIBRARY_TEAM = "Marmaduke Woodman, Stuart Knock, Paula Sanz Leon, Viktor Jirsa"
 LIBRARY_REQUIRED_PACKAGES = ["mako>=1.1.4", "matplotlib", "networkx", "numba", "numexpr", "numpy", 
                              "requests", "autopep8", "scipy", "six", "typing", "pylems", "lxml"]
 
-LIBRARY_REQUIRED_EXTRA = ["h5py", "mpl_toolkits", "pytest", "pytest-benchmark", "tvb-gdist", "tvb-data"]
+LIBRARY_REQUIRED_EXTRA = ["h5py", "mpl_toolkits", "pytest", "pytest-benchmark", "pytest-xdist", "tvb-gdist", "tvb-data"]
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as fd:
     DESCRIPTION = fd.read()

--- a/tvb_bin/run_tests.bat
+++ b/tvb_bin/run_tests.bat
@@ -12,7 +12,7 @@ echo 'Starting TVB tests...'
 pytest --pyargs tvb.tests.framework --junitxml=TEST_OUTPUT\results_frw.xml > TEST_OUTPUT\frw.out 2>&1
 
 echo 'Starting TVB Scientific Library tests'
-pytest --pyargs tvb.tests.library --junitxml=TEST_OUTPUT\results_lib.xml > TEST_OUTPUT\lib.out 2>&1
+pytest -n auto --pyargs tvb.tests.library --junitxml=TEST_OUTPUT\results_lib.xml > TEST_OUTPUT\lib.out 2>&1
 
 echo 'Starting TVB Storage tests'
 pytest --pyargs tvb.tests.storage --junitxml=TEST_OUTPUT/results_sto.xml > TEST_OUTPUT/sto.out 2>&1

--- a/tvb_bin/run_tests.sh
+++ b/tvb_bin/run_tests.sh
@@ -37,7 +37,7 @@ else
 fi
 
 echo 'Starting TVB Scientific Library tests'
-pytest --pyargs tvb.tests.library --junitxml=TEST_OUTPUT/results_lib.xml > TEST_OUTPUT/lib.out 2>&1
+pytest -n auto --pyargs tvb.tests.library --junitxml=TEST_OUTPUT/results_lib.xml > TEST_OUTPUT/lib.out 2>&1
 
 echo 'Starting TVB Storage tests'
 pytest --pyargs tvb.tests.storage --junitxml=TEST_OUTPUT/results_sto.xml > TEST_OUTPUT/sto.out 2>&1

--- a/tvb_build/docker/Dockerfile-Windows-build
+++ b/tvb_build/docker/Dockerfile-Windows-build
@@ -13,7 +13,7 @@ RUN conda init powershell
 
 # Prepare tvb-run env
 RUN activate && conda create -y --name tvb-run python=3.7 numba scipy numpy networkx scikit-learn cython pip numexpr psutil
-RUN activate && conda install -y --name tvb-run pytest pytest-cov pytest-benchmark pytest-mock matplotlib-base
+RUN activate && conda install -y --name tvb-run pytest pytest-cov pytest-benchmark pytest-mock pytest-xdist matplotlib-base
 RUN activate && conda install -y --name tvb-run psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy docutils werkzeug
 RUN activate tvb-run && pip install --upgrade pip
 RUN activate tvb-run && pip install certifi

--- a/tvb_build/docker/Dockerfile-build
+++ b/tvb_build/docker/Dockerfile-build
@@ -24,7 +24,7 @@ USER root
 RUN conda update -n base -c defaults conda
 
 RUN conda create -y --name tvb-docs python=3.7 nomkl numba scipy numpy networkx scikit-learn cython pip numexpr psutil
-RUN conda install -y --name tvb-docs pytest pytest-cov pytest-benchmark pytest-mock matplotlib-base
+RUN conda install -y --name tvb-docs pytest pytest-cov pytest-benchmark pytest-mock pytest-xdist matplotlib-base
 RUN conda install -y --name tvb-docs psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy werkzeug
 RUN conda install -y --name tvb-docs -c conda-forge jupyterlab gevent
 RUN /opt/conda/envs/tvb-docs/bin/pip install --upgrade pip
@@ -35,7 +35,7 @@ RUN /opt/conda/envs/tvb-docs/bin/pip install sphinx==1.2.3 docutils==0.12
 
 RUN conda update -n base -c defaults conda
 RUN conda create -y --name tvb-run python=3 nomkl numba scipy numpy networkx scikit-learn cython pip numexpr psutil
-RUN conda install -y --name tvb-run pytest pytest-cov pytest-benchmark pytest-mock matplotlib-base
+RUN conda install -y --name tvb-run pytest pytest-cov pytest-benchmark pytest-mock pytest-xdist matplotlib-base
 RUN conda install -y --name tvb-run psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy werkzeug docutils
 RUN /opt/conda/envs/tvb-run/bin/pip install --upgrade pip
 RUN /opt/conda/envs/tvb-run/bin/pip install h5py>=2.10 formencode cfflib flask==1.1.4 jinja2==2.11.3 nibabel sqlalchemy alembic allensdk # h5py and jinja2 versions are constrained by allensdk

--- a/tvb_build/docker/Dockerfile-build
+++ b/tvb_build/docker/Dockerfile-build
@@ -24,7 +24,7 @@ USER root
 RUN conda update -n base -c defaults conda
 
 RUN conda create -y --name tvb-docs python=3.7 nomkl numba scipy numpy networkx scikit-learn cython pip numexpr psutil
-RUN conda install -y --name tvb-docs pytest pytest-cov pytest-benchmark pytest-mock pytest-xdist matplotlib-base
+RUN conda install -y --name tvb-docs pytest pytest-mock matplotlib-base
 RUN conda install -y --name tvb-docs psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy werkzeug
 RUN conda install -y --name tvb-docs -c conda-forge jupyterlab gevent
 RUN /opt/conda/envs/tvb-docs/bin/pip install --upgrade pip

--- a/tvb_build/docker/Dockerfile-run
+++ b/tvb_build/docker/Dockerfile-run
@@ -23,7 +23,7 @@ RUN service postgresql start && createdb -O postgres tvb-test && psql --command 
 USER root
 RUN conda update -n base -c defaults conda
 RUN conda create -y --name tvb-run python=3 nomkl numba scipy numpy networkx scikit-learn cython pip numexpr psutil
-RUN conda install -y --name tvb-run pytest pytest-cov pytest-benchmark pytest-mock matplotlib-base
+RUN conda install -y --name tvb-run pytest pytest-cov pytest-benchmark pytest-mock pytest-xdist matplotlib-base
 RUN conda install -y --name tvb-run psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy docutils werkzeug
 RUN /opt/conda/envs/tvb-run/bin/pip install --upgrade pip
 RUN /opt/conda/envs/tvb-run/bin/pip install h5py==2.10 formencode cfflib flask==1.1.4 jinja2==2.11.3 nibabel sqlalchemy alembic allensdk # h5py and jinja2 versions are constrained by allensdk

--- a/tvb_build/docker/Dockerfile-test
+++ b/tvb_build/docker/Dockerfile-test
@@ -23,7 +23,7 @@ RUN service postgresql start && createdb -O postgres tvb-test && psql --command 
 USER root
 RUN conda update -n base -c defaults conda
 RUN conda create -y --name tvb-run python=3 nomkl numba scipy numpy networkx scikit-learn cython pip numexpr psutil
-RUN conda install -y --name tvb-run pytest pytest-cov pytest-benchmark pytest-mock matplotlib-base
+RUN conda install -y --name tvb-run pytest pytest-cov pytest-benchmark pytest-mock pytest-xdist matplotlib-base
 RUN conda install -y --name tvb-run psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy docutils werkzeug
 RUN /opt/conda/envs/tvb-run/bin/pip install --upgrade pip
 RUN /opt/conda/envs/tvb-run/bin/pip install h5py==2.10 formencode cfflib flask==1.1.4 jinja2==2.11.3 nibabel sqlalchemy alembic allensdk # h5py and jinja2 versions are constrained by allensdk

--- a/tvb_build/mac_conda_env.sh
+++ b/tvb_build/mac_conda_env.sh
@@ -4,7 +4,7 @@
 conda update -n base -c defaults conda
 conda env remove --name mac-distribution
 conda create -y --name mac-distribution python=3.7 nomkl numba scipy numpy==1.18.1 networkx scikit-learn cython pip numexpr psutil
-conda install -y --name mac-distribution pytest pytest-cov pytest-benchmark pytest-mock matplotlib-base
+conda install -y --name mac-distribution pytest pytest-cov pytest-benchmark pytest-mock pytest-xdist matplotlib-base
 conda install -y --name mac-distribution psycopg2 pytables scikit-image==0.14.2 simplejson cherrypy docutils werkzeug
 conda install -y --name mac-distribution -c conda-forge gevent pillow
 

--- a/tvb_build/tvb_build/third_party_licenses/license/LICENSE_pytest_xdist.txt
+++ b/tvb_build/tvb_build/third_party_licenses/license/LICENSE_pytest_xdist.txt
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tvb_build/tvb_build/third_party_licenses/packages_accepted.xml
+++ b/tvb_build/tvb_build/third_party_licenses/packages_accepted.xml
@@ -1500,6 +1500,16 @@
         <copyright-notice value="Copyright (c) 2010 Meme Dough"/>
         <description value="Used for TVB unit-tests coverage"/>
     </dependency>
+        <dependency env="[win,linux]" name="pytest-xdist">
+        <full-name value="xdist: pytest distributed testing plugin"/>
+        <project-home value="https://pypi.org/project/pytest-xdist"/>
+        <version value="[2.4.0]"/>
+        <usage value="dynamic linking"/>
+        <license value="LICENSE_pytest_xdist.txt"/>
+        <license-type value="MIT_"/>
+        <copyright-notice value="Copyright (c) 2010 pytest-xdist authors"/>
+        <description value="Used for running scientific-library tests on multiple cores"/>
+    </dependency>
     <dependency env="[win,mac,linux]" name="python">
         <full-name value="Python"/>
         <project-home value="http://docs.python.org/license.html"/>


### PR DESCRIPTION
I found a pretty easy way to parallelize the library tests. We need a plug-in called pytest-xdist and we need to add the -n NUMBER_OF_CORES when running the pytest command. Using the -n auto option it will run the tests on as many cores as your machine has.

Running the library tests normally took 580.90 s on my machine.
Using parallelization (I have 8 cores) they ran in 173.20, which means more than 3 times faster.