### PR TITLE
Added nonzero of weights to the determination of min delay for cosimulator

### DIFF
--- a/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
+++ b/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
@@ -97,7 +97,9 @@ class CoSimulator(Simulator):
         self.synchronization_n_step = iround(self.synchronization_time / self.integrator.dt)
         # Check if the synchronization time is smaller than the delay of the connectivity
         # the condition is probably not correct. It will change with usage.
-        if self.synchronization_n_step > numpy.min(self.connectivity.idelays[numpy.nonzero(self.connectivity.idelays)]):
+        if self.synchronization_n_step > numpy.min(self.connectivity.idelays[
+                                                       numpy.nonzero(self.connectivity.weights *
+                                                                     self.connectivity.idelays)]):
             raise ValueError('the synchronization time is too long')
 
         # Check if the couplings variables are in the cosimulation variables of interest

--- a/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
+++ b/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
@@ -95,11 +95,10 @@ class CoSimulator(Simulator):
         self.synchronization_time = numpy.maximum(self.synchronization_time, self.integrator.dt)
         # Compute the number of synchronization time steps:
         self.synchronization_n_step = iround(self.synchronization_time / self.integrator.dt)
-        # Check if the synchronization time is smaller than the delay of the connectivity
-        # the condition is probably not correct. It will change with usage.
-        if self.synchronization_n_step > numpy.min(self.connectivity.idelays[
-                                                       numpy.nonzero(self.connectivity.weights *
-                                                                     self.connectivity.idelays)]):
+        # Check if the synchronization time is smaller than the delay of the connectivity:
+        mask =  numpy.logical_and(self.connectivity.weights != 0,
+                                  self.connectivity.idelays != 0 )
+        if self.synchronization_n_step > self.connectivity.idelays[mask].min():
             raise ValueError('the synchronization time is too long')
 
         # Check if the couplings variables are in the cosimulation variables of interest

--- a/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
+++ b/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
@@ -97,7 +97,7 @@ class CoSimulator(Simulator):
         self.synchronization_n_step = iround(self.synchronization_time / self.integrator.dt)
         # Check if the synchronization time is smaller than the minimum delay of the connectivity:
         mask =  numpy.logical_and(self.connectivity.weights != 0,
-                                  self.connectivity.idelays != 0 )
+                                  self.connectivity.idelays != 0)
         if self.synchronization_n_step > self.connectivity.idelays[mask].min():
             raise ValueError('the synchronization time is too long')
 

--- a/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
+++ b/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
@@ -99,10 +99,10 @@ class CoSimulator(Simulator):
         if numpy.any(existing_connections.size):
             min_idelay = self.connectivity.idelays[existing_connections].min()
             if self.synchronization_n_step > min_idelay:
-                raise ValueError('The synchronization time is longer than '
+                raise ValueError('The synchronization time %g is longer than '
                                  'the minimum delay time %g '
                                  'of all existing connections (i.e., of nonzero weight)!'
-                                 % min_idelay * self.integrator.dt)
+                                 % (self.synchronization_time, min_idelay * self.integrator.dt))
 
     def _configure_cosimulation(self):
         """This method will

--- a/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
+++ b/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
@@ -95,7 +95,7 @@ class CoSimulator(Simulator):
         self.synchronization_time = numpy.maximum(self.synchronization_time, self.integrator.dt)
         # Compute the number of synchronization time steps:
         self.synchronization_n_step = iround(self.synchronization_time / self.integrator.dt)
-        # Check if the synchronization time is smaller than the delay of the connectivity:
+        # Check if the synchronization time is smaller than the minimum delay of the connectivity:
         mask =  numpy.logical_and(self.connectivity.weights != 0,
                                   self.connectivity.idelays != 0 )
         if self.synchronization_n_step > self.connectivity.idelays[mask].min():

--- a/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
+++ b/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
@@ -83,6 +83,27 @@ class CoSimulator(Simulator):
     _cosim_monitors_noncoupling_indices = []
     _cosim_monitors_coupling_indices = []
 
+    def _configure_synchronization_time(self):
+        """This method will set the synchronization time and number of steps,
+           and certainly longer or equal to the integration time step.
+           Moreover, the synchronization time must be equal or shorter
+           than the minimum delay of all existing connections.
+           Existing connections are considered those with nonzero weights.
+        """
+        # The synchronization time should be at least equal to integrator.dt:
+        self.synchronization_time = numpy.maximum(self.synchronization_time, self.integrator.dt)
+        # Compute the number of synchronization time steps:
+        self.synchronization_n_step = iround(self.synchronization_time / self.integrator.dt)
+        # Check if the synchronization time is smaller than the minimum delay of the connectivity:
+        existing_connections = self.connectivity.weights != 0
+        if numpy.any(existing_connections.size):
+            min_idelay = self.connectivity.idelays[existing_connections].min()
+            if self.synchronization_n_step > min_idelay:
+                raise ValueError('The synchronization time is longer than '
+                                 'the minimum delay time %g '
+                                 'of all existing connections (i.e., of nonzero weight)!'
+                                 % min_idelay * self.integrator.dt)
+
     def _configure_cosimulation(self):
         """This method will
            - set the synchronization time and number of steps,
@@ -91,15 +112,8 @@ class CoSimulator(Simulator):
            - configure the cosimulation monitor
            - zero connectivity weights to/from nodes modelled exclusively by the other cosimulator
            """
-        # the synchronization time should be at least equal to integrator.dt:
-        self.synchronization_time = numpy.maximum(self.synchronization_time, self.integrator.dt)
-        # Compute the number of synchronization time steps:
-        self.synchronization_n_step = iround(self.synchronization_time / self.integrator.dt)
-        # Check if the synchronization time is smaller than the minimum delay of the connectivity:
-        mask =  numpy.logical_and(self.connectivity.weights != 0,
-                                  self.connectivity.idelays != 0)
-        if self.synchronization_n_step > self.connectivity.idelays[mask].min():
-            raise ValueError('the synchronization time is too long')
+        # Configure the synchronizatin time and number of steps
+        self._configure_synchronization_time()
 
         # Check if the couplings variables are in the cosimulation variables of interest
         for cvar in self.model.cvar:

--- a/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
+++ b/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
@@ -96,7 +96,7 @@ class CoSimulator(Simulator):
         self.synchronization_n_step = iround(self.synchronization_time / self.integrator.dt)
         # Check if the synchronization time is smaller than the minimum delay of the connectivity:
         existing_connections = self.connectivity.weights != 0
-        if numpy.any(existing_connections.size):
+        if numpy.any(existing_connections):
             min_idelay = self.connectivity.idelays[existing_connections].min()
             if self.synchronization_n_step > min_idelay:
                 raise ValueError('The synchronization time %g is longer than '


### PR DESCRIPTION
This is a minor modification to the cosimulator.py to determine the minimum delay of the connectome, and therefore the ideal synchronization time for cosimulation, by discarding all connections that have a zero weight, as well as a zero idelay, instead of the current version that considers only the idelays.

The reason is that a zero weight represents a missing connection more robustly than a zero idelay.

For instance, in some cases, and for my own reasons, I initialize zero delays to be equal to 0.1 (=integrator.dt; this might be stupid, but there are many users out there that might do something similar, given that they can still use the weights to determine a missing connection).

Still, the corresponding weights = 0.0, if this is a missing connection.

In this scenario, the current if statement:

        if self.synchronization_n_step > numpy.min(self.connectivity.idelays[numpy.nonzero(self.connectivity.idelays)]):
            raise ValueError('the synchronization time is too long')

in the cosimulator's configure_cosimulation() will give an error, because it will receive the 0.1 as the minimum delay and this is actually equal to the integrators.dt.

Instead: numpy.nonzero(self.connectivity.weights * self.connectivity.idelays) will be correct.
