### PR TITLE
Bug fixing + improvements on Surface model page.

### DIFF
--- a/framework_tvb/tvb/interfaces/web/controllers/spatial/surface_model_parameters_controller.py
+++ b/framework_tvb/tvb/interfaces/web/controllers/spatial/surface_model_parameters_controller.py
@@ -202,7 +202,7 @@ class SurfaceModelParametersController(SpatioTemporalController):
         self.model_params_list = self._prepare_model_params_list(model)
         context_model_parameters = SurfaceContextModelParameters(surface_index, model,
                                                                  SurfaceModelParametersForm.default_equation,
-                                                                 self.model_params_list[0].label)
+                                                                 self.model_params_list[0].name)
         common.add2session(KEY_CONTEXT_MPS, context_model_parameters)
 
         template_specification = dict(title="Spatio temporal - Model parameters")
@@ -313,7 +313,7 @@ class SurfaceModelParametersController(SpatioTemporalController):
             simulator = self.simulator_context.simulator
 
             for param in list(self.model_params_list):
-                param_data = context_model_parameters.get_data_for_model_param(param.label)
+                param_data = context_model_parameters.get_data_for_model_param(param.name)
                 if param_data is None:
                     continue
                 setattr(simulator.model, param.name, param_data)

--- a/framework_tvb/tvb/interfaces/web/static/js/bursts.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/bursts.js
@@ -170,8 +170,7 @@ function loadBurstHistory(initBurst = false) {
         async: false,
         success: function (r) {
             const historyElem = $('#section-view-history');
-            historyElem.empty();
-            renderWithMathjax(historyElem, r);
+            renderWithMathjax(historyElem, r, true);
             //setupMenuEvents(historyElem);
         },
         error: function () {

--- a/framework_tvb/tvb/interfaces/web/static/js/bursts.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/bursts.js
@@ -141,8 +141,8 @@ function renderAllSimulatorForms(url, stop_at_url = '', onFinishFunction = null)
             url: url,
             success: function (response) {
                 const t = document.createRange().createContextualFragment(response);
-                simulator_params.appendChild(t);
-                MathJax.Hub.Queue(["Typeset", MathJax.Hub, "div-simulator-parameters"]);
+                renderWithMathjax(simulator_params, t);
+
 
                 const next_url = $(response).attr("action");
                 if (next_url && next_url.length > 0) {
@@ -171,8 +171,7 @@ function loadBurstHistory(initBurst = false) {
         success: function (r) {
             const historyElem = $('#section-view-history');
             historyElem.empty();
-            historyElem.append(r);
-            MathJax.Hub.Queue(["Typeset", MathJax.Hub, "section-view-history"]);
+            renderWithMathjax(historyElem, r);
             //setupMenuEvents(historyElem);
         },
         error: function () {
@@ -757,8 +756,7 @@ function wizzard_submit(currentForm, success_function = null, div_id = 'div-simu
                 fieldset.disabled = true;
                 var t = document.createRange().createContextualFragment(response);
                 const simulator_params = document.getElementById(div_id);
-                simulator_params.appendChild(t);
-                MathJax.Hub.Queue(["Typeset", MathJax.Hub, div_id]);
+                renderWithMathjax(simulator_params, t);
                 setInitialFocusOnButton(simulator_params);
                 setupMenuEvents();
             }

--- a/framework_tvb/tvb/interfaces/web/static/js/bursts_dynamic.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/bursts_dynamic.js
@@ -418,13 +418,11 @@ function onModelChanged(name){
             data = JSON.parse(data);
 
             var sliderContainer = $('#div_spatial_model_params');
-            sliderContainer.empty();
-            renderWithMathjax(sliderContainer, data.model_param_sliders_fragment);
+            renderWithMathjax(sliderContainer, data.model_param_sliders_fragment, true);
             setupMenuEvents(sliderContainer);
 
             var axisSliderContainer = $('#div_phase_plane_settings');
-            axisSliderContainer.empty();
-            renderWithMathjax(axisSliderContainer, data.axis_sliders_fragment);
+            renderWithMathjax(axisSliderContainer, data.axis_sliders_fragment, true);
             setupMenuEvents(axisSliderContainer);
 
             _initialize_grafic(data.params, data.graph_params);

--- a/framework_tvb/tvb/interfaces/web/static/js/bursts_dynamic.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/bursts_dynamic.js
@@ -418,13 +418,13 @@ function onModelChanged(name){
             data = JSON.parse(data);
 
             var sliderContainer = $('#div_spatial_model_params');
-            sliderContainer.html(data.model_param_sliders_fragment);
-            MathJax.Hub.Queue(["Typeset", MathJax.Hub, 'div_spatial_model_params']);
+            sliderContainer.empty();
+            renderWithMathjax(sliderContainer, data.model_param_sliders_fragment);
             setupMenuEvents(sliderContainer);
 
             var axisSliderContainer = $('#div_phase_plane_settings');
-            axisSliderContainer.html(data.axis_sliders_fragment);
-            MathJax.Hub.Queue(["Typeset", MathJax.Hub, 'div_phase_plane_settings']);
+            axisSliderContainer.empty();
+            renderWithMathjax(axisSliderContainer, data.axis_sliders_fragment);
             setupMenuEvents(axisSliderContainer);
 
             _initialize_grafic(data.params, data.graph_params);

--- a/framework_tvb/tvb/interfaces/web/static/js/genericTVB.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/genericTVB.js
@@ -134,7 +134,10 @@ function fireOnClick(redirectElem) {
 }
 
 // ---------- Function for rendering HTML elements with Mathjax
-function renderWithMathjax(element, elementToAppend){
+function renderWithMathjax(element, elementToAppend, empty=false){
+    if(empty){
+        element.empty();
+    }
     element.append(elementToAppend);
     MathJax.Hub.Queue(["Typeset", MathJax.Hub, element.id]);
 }
@@ -1213,8 +1216,7 @@ function refreshSubform(currentElem, elementType, subformDiv) {
         type: 'POST',
         success: function (r) {
             const subform = $('#' + subformDiv);
-            subform.empty();
-            renderWithMathjax(subform, r);
+            renderWithMathjax(subform, r, true);
             setEventsOnFormFields(elementType, subformDiv);
             setupMenuEvents();
             plotEquation(subformDiv);

--- a/framework_tvb/tvb/interfaces/web/static/js/genericTVB.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/genericTVB.js
@@ -133,6 +133,11 @@ function fireOnClick(redirectElem) {
     }
 }
 
+// ---------- Function for rendering HTML elements with Mathjax
+function renderWithMathjax(element, elementToAppend){
+    element.append(elementToAppend);
+    MathJax.Hub.Queue(["Typeset", MathJax.Hub, element.id]);
+}
 
 // ---------- Function on the top left call-out
 function updateCallOutProject() {
@@ -1207,8 +1212,9 @@ function refreshSubform(currentElem, elementType, subformDiv) {
         url: url,
         type: 'POST',
         success: function (r) {
-            $('#' + subformDiv).html(r);
-            MathJax.Hub.Queue(["Typeset", MathJax.Hub, subformDiv]);
+            const subform = $('#' + subformDiv);
+            subform.empty();
+            renderWithMathjax(subform, r);
             setEventsOnFormFields(elementType, subformDiv);
             setupMenuEvents();
             plotEquation(subformDiv);

--- a/framework_tvb/tvb/interfaces/web/static/js/spatial/model_parameters.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/spatial/model_parameters.js
@@ -50,8 +50,7 @@ function MP_applyEquationForParameter() {
         url:url,
         success:function (data) {
             const spatial_div = $("#div_spatial_model_params");
-            spatial_div.empty();
-            renderWithMathjax(spatial_div, data);
+            renderWithMathjax(spatial_div, data, true);
             MP_displayFocalPoints();
         }
     });
@@ -141,8 +140,7 @@ function setModelParam(methodToCall, currentModelParam) {
         type: 'POST',
         success: function (data) {
             const spatial_model_div = $("#div_spatial_model_params");
-            spatial_model_div.empty();
-            renderWithMathjax(spatial_model_div, data)
+            renderWithMathjax(spatial_model_div, data, true)
             MP_displayFocalPoints();
         }
     })

--- a/framework_tvb/tvb/interfaces/web/static/js/spatial/model_parameters.js
+++ b/framework_tvb/tvb/interfaces/web/static/js/spatial/model_parameters.js
@@ -49,7 +49,9 @@ function MP_applyEquationForParameter() {
         type:'POST',
         url:url,
         success:function (data) {
-            $("#div_spatial_model_params").empty().append(data);
+            const spatial_div = $("#div_spatial_model_params");
+            spatial_div.empty();
+            renderWithMathjax(spatial_div, data);
             MP_displayFocalPoints();
         }
     });
@@ -138,8 +140,9 @@ function setModelParam(methodToCall, currentModelParam) {
         url: url,
         type: 'POST',
         success: function (data) {
-            $("#div_spatial_model_params").html(data);
-            MathJax.Hub.Queue(["Typeset", MathJax.Hub, 'div_spatial_model_params']);
+            const spatial_model_div = $("#div_spatial_model_params");
+            spatial_model_div.empty();
+            renderWithMathjax(spatial_model_div, data)
             MP_displayFocalPoints();
         }
     })


### PR DESCRIPTION
Applying the html() method in JS is like calling empty() + append(). I thought of generalizing the way the rendering is done with mathjax. Also, there was a bug left on the model surface page after merging TVB-2977.