### PR TITLE
HBP-178 Extend the common landing page with links towards prototypes

### DIFF
--- a/framework_tvb/tvb/interfaces/web/run_landing_page.py
+++ b/framework_tvb/tvb/interfaces/web/run_landing_page.py
@@ -32,30 +32,14 @@
 Launches the common landing page
 
 .. moduleauthor:: Bogdan Valean
+.. moduleauthor:: Lia Domide <lia.domide@codemart.ro>
 """
 
 import os
-
 from flask import Flask, render_template
 from gevent.pywsgi import WSGIServer
 from tvb.basic.logger.builder import get_logger
 
-LOGGER = get_logger('tvb.interfaces.web.run_landing_page')
-
-CSCS_LINK = os.environ.get('CSCS_LINK', None)
-CSCS_LABEL = os.environ.get('CSCS_LABEL', None)
-if CSCS_LABEL is None:
-    CSCS_LABEL = CSCS_LINK
-
-JUL_LINK = os.environ.get('JUL_LINK', None)
-JUL_LABEL = os.environ.get('JUL_LABEL', None)
-if JUL_LABEL is None:
-    JUL_LABEL = JUL_LINK
-
-if CSCS_LINK is None or JUL_LINK is None:
-    raise Exception("Make sure you set CSCS_LINK and JUL_LINK env variables.")
-
-server_port = int(os.environ.get('SERVER_PORT', 8080))
 CURRENT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 try:
     import tvb.interfaces
@@ -63,18 +47,57 @@ try:
     CURRENT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(tvb.interfaces.__file__)))
 except ImportError:
     pass
+
+LOGGER = get_logger('tvb.interfaces.web.run_landing_page')
 TEMPLATE_FOLDER = os.path.join(CURRENT_DIR, 'interfaces', 'web', 'templates', 'landing_page')
 STATIC_FOLDER = os.path.join(CURRENT_DIR, 'interfaces', 'web', 'static')
+REDIRECT_OPTIONS = []
+app = Flask(__name__, template_folder=TEMPLATE_FOLDER,
+            static_folder=STATIC_FOLDER, static_url_path='/static')
 
-app = Flask(__name__, template_folder=TEMPLATE_FOLDER, static_folder=STATIC_FOLDER, static_url_path='/static')
+
+class RedirectOption(object):
+    def __init__(self, url, label, description):
+        self.url = url
+        self.label = label
+        self.description = description
+
+    def __repr__(self):
+        return "RedirectOption( " + self.label + " , " + self.url + ")"
+
+
+def parse_config_file(file_name=os.path.expanduser("~/.tvb.landing.page.configuration")):
+    result = []
+    no_of_redirect_options = "0"
+    try:
+        config_dict = {}
+        with open(file_name, 'r') as cfg_file:
+            data = cfg_file.read()
+            entries = [line for line in data.split('\n') if not line.startswith('#') and len(line.strip()) > 0]
+            for one_entry in entries:
+                name, value = one_entry.split('=', 1)
+                config_dict[name] = value
+
+        no_of_redirect_options = config_dict.get('no_of_options')
+        for i in range(int(no_of_redirect_options)):
+            result.append(RedirectOption(config_dict.get(str(i) + ".option.url"),
+                                         config_dict.get(str(i) + ".option.label"),
+                                         config_dict.get(str(i) + ".option.description")))
+    except Exception:
+        LOGGER.exception("Could not parse the configuration file:" + str(file_name))
+
+    LOGGER.info("Parsed " + no_of_redirect_options + " redirect options")
+    LOGGER.info(result)
+    return result
 
 
 @app.route('/')
 def index():
-    return render_template('landing.html',
-                           apps=[{'link': CSCS_LINK, 'label': CSCS_LABEL}, {'link': JUL_LINK, 'label': JUL_LABEL}])
+    return render_template('landing.html', apps=REDIRECT_OPTIONS)
 
 
 if __name__ == '__main__':
+    REDIRECT_OPTIONS = parse_config_file()
+    server_port = int(os.environ.get('SERVER_PORT', 8080))
     http_server = WSGIServer(("0.0.0.0", server_port), app)
     http_server.serve_forever()

--- a/framework_tvb/tvb/interfaces/web/static/style/section_user.css
+++ b/framework_tvb/tvb/interfaces/web/static/style/section_user.css
@@ -214,6 +214,11 @@ margin-left: 116px;
 width: 404px;
 }
 
+body#s-user.user-authorized div#main section.sites {
+margin-left: 116px;
+width: 604px;
+}
+
 body#s-user.user-authorized div#main section.updates {
 margin-left: 85px;
 }
@@ -254,6 +259,10 @@ text-transform: uppercase;
 width: 131px;
 }
 
+body#s-user.user-authorized div#main section.sites dt {
+    width: 151px;
+}
+
 body#s-user.user-authorized div#main dd {
 border-top: 1px solid #2272a3;
 color: #194343;
@@ -261,6 +270,11 @@ float: left;
 font-family: "Georgia", "Times", serif;
 padding: 10px 0 5px 0;
 width: 273px;
+}
+
+body#s-user.user-authorized div#main section.sites dd {
+width: 373px;
+padding-left: 10px;
 }
 
 body#s-user.user-authorized div#main dt:first-child, 

--- a/framework_tvb/tvb/interfaces/web/templates/landing_page/landing.html
+++ b/framework_tvb/tvb/interfaces/web/templates/landing_page/landing.html
@@ -4,22 +4,22 @@
     <link rel="shortcut icon" href="/static/style/img/favicon.ico"/>
     <meta charset="UTF-8">
     <link rel="stylesheet" type="text/css" href="/static/style/base.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/style/section_user.css?"/>
+    <link rel="stylesheet" type="text/css" href="/static/style/section_user.css"/>
     <title>The Virtual Brain</title>
 </head>
 <body id="s-user" class="user-authorized style-default v-odinson">
 <div id="main">
-    <section class="profile">
+    <section class="sites">
         <h2>
-            <mark>Deployment</mark>
-            Site
+            <mark>TVB - EBRAINS</mark> Deployment Sites
         </h2>
         {% for app in apps %}
-        <button onclick="go_to_selected_site('{{ app.link }}')">{{ app.label }}</button>
-        <dl>
-            <dt></dt>
-            <dd></dd>
-        </dl>
+            <dl>
+                <dt><input type="button" value="{{ app.label }}"
+                           onclick="go_to_selected_site('{{ app.url }}')"
+                           title="{{ app.description }}"/></dt>
+                <dd>{{ app.description }}</dd>
+            </dl>
         {% endfor %}
     </section>
     <script type="text/javascript">

--- a/tvb_build/hbp_openshift_deployer/.tvb.landing.page.configuration
+++ b/tvb_build/hbp_openshift_deployer/.tvb.landing.page.configuration
@@ -1,0 +1,17 @@
+no_of_options=4
+
+0.option.label=TVB @ CSCS
+0.option.description= Latest stable version of TVB Distribution, deployed in Zurich at CSCS
+0.option.url=https://thevirtualbrain.apps.hbp.eu/
+
+1.option.label=TVB @ Juelich
+1.option.description= Latest stable version of TVB Distribution, deployed in Juelich, with a separate storage from CSCS
+1.option.url=https://thevirtualbrain.apps.jsc.hbp.eu/
+
+2.option.label=TVB & Pipeline
+2.option.description= Prototype version of TVB, featuring a new web page for integrating the images preprocessing pipeline running on HPC
+2.option.url=https://pipeline-tvb.apps.hbp.eu/
+
+3.option.label=TVB on HPC
+3.option.description= Prototype version of TVB using encrypted backend and pushing high demanding jobs on an HPC
+3.option.url=https://tvb-hpc.apps.hbp.eu/


### PR DESCRIPTION
Separate redirect links in a configuration file, so that we can change their number or URLs without a redeploy.