### PR TITLE
User tab from footer not active on user page

### DIFF
--- a/framework_tvb/tvb/interfaces/web/templates/jinja2/footer.html
+++ b/framework_tvb/tvb/interfaces/web/templates/jinja2/footer.html
@@ -2,6 +2,9 @@
 <!--!    Main Navigation - Common footer for all pages           -->
 <!--! ========================================================== -->
 <footer>
+    {% if section_name is not defined %}
+        {% set section_name = 'user' %}
+    {% endif %}
     {% set currentTab='nav-' ~ section_name %}
     <nav>
         <ul>


### PR DESCRIPTION
User tab is not selected when the user page is opened.
![user_tab_not_enabled](https://user-images.githubusercontent.com/62694340/159061561-0ea6e3a6-dd54-40cd-9ea8-34c4cdac8c85.jpg)

I found that the `section_name`  inside [footer.html](https://github.com/the-virtual-brain/tvb-root/blob/master/framework_tvb/tvb/interfaces/web/templates/jinja2/footer.html) is empty for user's page.
So added 
```
{% if section_name is not defined %}
        {% set section_name = 'user' %}
{% endif %}
```
![user_tab_enabled](https://user-images.githubusercontent.com/62694340/159062316-44e5b3d1-1c4f-4f13-918c-525c0ec2de7a.jpg)

