### PR TITLE
Fix warnings in library

### DIFF
--- a/scientific_library/tvb/basic/neotraits/_attr.py
+++ b/scientific_library/tvb/basic/neotraits/_attr.py
@@ -402,7 +402,7 @@ class Dim(Final):
 class NArray(Attr):
     """
     Declares a numpy array.
-    dtype enforces the dtype. The default dtype is float32.
+    dtype enforces the dtype. The default dtype is float64.
     An optional symbolic shape can be given, as a tuple of Dim attributes from the owning class.
     The shape will be enforced, but no broadcasting will be done.
     domain declares what values are allowed in this array.
@@ -417,7 +417,7 @@ class NArray(Attr):
             required=True,
             doc='',
             label='',
-            dtype=numpy.float,
+            dtype=numpy.float64,
             shape=None,
             dim_names=(),
             domain=None,

--- a/scientific_library/tvb/datatypes/connectivity.py
+++ b/scientific_library/tvb/datatypes/connectivity.py
@@ -376,7 +376,7 @@ class Connectivity(HasTraits):
                         hemispheres = None
                         break
             if hemispheres is not None:
-                self.hemispheres = numpy.array(hemispheres, dtype=numpy.bool)
+                self.hemispheres = numpy.array(hemispheres, dtype=numpy.bool_)
 
     def transform_remove_self_connections(self):
         """
@@ -724,13 +724,13 @@ class Connectivity(HasTraits):
             result.weights = reader.read_array_from_file("weights")
             if reader.has_file_like("centres"):
                 result.centres = reader.read_array_from_file("centres", use_cols=(1, 2, 3))
-                result.region_labels = reader.read_array_from_file("centres", dtype=numpy.str, use_cols=(0,))
+                result.region_labels = reader.read_array_from_file("centres", dtype=numpy.str_, use_cols=(0,))
             else:
                 result.centres = reader.read_array_from_file("centers", use_cols=(1, 2, 3))
                 result.region_labels = reader.read_array_from_file("centers", dtype=numpy.str, use_cols=(0,))
             result.orientations = reader.read_optional_array_from_file("average_orientations")
-            result.cortical = reader.read_optional_array_from_file("cortical", dtype=numpy.bool)
-            result.hemispheres = reader.read_optional_array_from_file("hemispheres", dtype=numpy.bool)
+            result.cortical = reader.read_optional_array_from_file("cortical", dtype=numpy.bool_)
+            result.hemispheres = reader.read_optional_array_from_file("hemispheres", dtype=numpy.bool_)
             result.areas = reader.read_optional_array_from_file("areas")
             result.tract_lengths = reader.read_array_from_file("tract_lengths")
 

--- a/scientific_library/tvb/datatypes/sensors.py
+++ b/scientific_library/tvb/datatypes/sensors.py
@@ -82,7 +82,7 @@ class Sensors(HasTraits):
         source_full_path = try_get_absolute_path("tvb_data.sensors", source_file)
         reader = FileReader(source_full_path)
 
-        result.labels = reader.read_array(dtype=numpy.str, use_cols=(0,))
+        result.labels = reader.read_array(dtype=numpy.str_, use_cols=(0,))
         result.locations = reader.read_array(use_cols=(1, 2, 3))
         return result
 
@@ -199,15 +199,15 @@ class SensorsEEG(Sensors):
 
 
 class SensorsMEG(Sensors):
-    """
+    r"""
     These are actually just SQUIDS. Axial or planar gradiometers are achieved
     by calculating lead fields for two sets of sensors and then subtracting...
     ::
 
                               position  orientation
                                  |           |
-                                / \         / \\
-                               /   \       /   \\
+                                / \         /  \
+                               /   \       /    \
         file columns: labels, x, y, z,   dx, dy, dz
 
     """
@@ -243,7 +243,7 @@ class SensorsInternal(Sensors):
     def _split_string_text_numbers(labels):
         items = []
         for i, s in enumerate(labels):
-            match = re.findall('(\d+|\D+)', s)
+            match = re.findall(r'(\d+|\D+)', s)
             if match:
                 items.append((match[0], i))
             else:

--- a/scientific_library/tvb/simulator/history.py
+++ b/scientific_library/tvb/simulator/history.py
@@ -214,7 +214,7 @@ class SparseHistory(DenseHistory):
     n_nnzw = Dim()
     n_nnzr = Dim()
     time_stride = Dim()
-    nnz_mask = NDArray(('n_node', 'n_node'), numpy.bool)
+    nnz_mask = NDArray(('n_node', 'n_node'), numpy.bool_)
     const_indices = NDArray(('n_cvar', n_nnzw, 'n_mode'), 'i')
     nnz_idelays = NDArray((n_nnzw,), 'i')
     nnz_row_el_idx = NDArray((n_nnzw, ), 'i')

--- a/scientific_library/tvb/simulator/models/wilson_cowan.py
+++ b/scientific_library/tvb/simulator/models/wilson_cowan.py
@@ -345,7 +345,7 @@ class WilsonCowan(ModelNumbaDfun):
         Constant intensity.Entry point for coupling.""")
 
     shift_sigmoid = NArray(
-        dtype= numpy.bool,
+        dtype= numpy.bool_,
         label=r":math:`shift sigmoid`",
         default=numpy.array([True]),
         doc="""In order to have resting state (E=0 and I=0) in absence of external input,

--- a/scientific_library/tvb/simulator/models/zerlaut.py
+++ b/scientific_library/tvb/simulator/models/zerlaut.py
@@ -236,7 +236,7 @@ class ZerlautAdaptationFirstOrder(Model):
         doc="""inhibitory decay [ms]""")
 
     N_tot = NArray(
-        dtype=numpy.int,
+        dtype=numpy.int64,
         label=":math:`N_{tot}`",
         default=numpy.array([10000]),
         domain=Range(lo=1000, hi=50000, step=1000),
@@ -255,14 +255,14 @@ class ZerlautAdaptationFirstOrder(Model):
         doc="""fraction of inhibitory cells""")
 
     K_ext_e = NArray(
-        dtype=numpy.int,
+        dtype=numpy.int64,
         label=":math:`K_ext_e`",
         default=numpy.array([400]),
         domain=Range(lo=0, hi=10000, step=1),  # inhibitory cell number never overcomes excitatory ones
         doc="""Number of excitatory connexions from external population""")
 
     K_ext_i = NArray(
-        dtype=numpy.int,
+        dtype=numpy.int64,
         label=":math:`K_ext_i`",
         default=numpy.array([0]),
         domain=Range(lo=0, hi=10000, step=1),  # inhibitory cell number never overcomes excitatory ones

--- a/scientific_library/tvb/tests/library/basic/neotraits/neotraits_test.py
+++ b/scientific_library/tvb/tests/library/basic/neotraits/neotraits_test.py
@@ -260,7 +260,7 @@ def test_mro_fail():
 
 def test_narr_simple():
     class Boo(HasTraits):
-        x = NArray(shape=(Dim.any, Dim.any), dtype=np.dtype(np.int))
+        x = NArray(shape=(Dim.any, Dim.any), dtype=np.dtype(np.int64))
 
     boo = Boo(x=np.array([[1, 4]]))
     boo.x = np.array([[1], [2]])
@@ -269,7 +269,7 @@ def test_narr_simple():
 def test_narr_enforcing():
     with pytest.raises(TypeError):
         class Boo(HasTraits):
-            x = NArray(dtype=np.dtype(np.int), default=np.eye(2))
+            x = NArray(dtype=np.dtype(np.int64), default=np.eye(2))
 
     with pytest.raises(ValueError):
         # bad ndim default
@@ -556,7 +556,7 @@ def test_int_attribute():
     ainst.b = int(42)
     # values are not only checked for compatibility but converted to the declared type
     assert type(ainst.b) == np.int8
-    ainst.b = np.int(4)
+    ainst.b = np.int64(4)
 
     with pytest.raises(TypeError):
         # out of bounds for a int8

--- a/scientific_library/tvb/tests/library/simulator/backend/nbbackend_mpr_test.py
+++ b/scientific_library/tvb/tests/library/simulator/backend/nbbackend_mpr_test.py
@@ -118,7 +118,7 @@ class TestNbSim(BaseTestSim):
         (pdq_t, pdq_d), = NbMPRBackend().run_sim(sim, nstep=1)
         (raw_t, raw_d), = sim.run(simulation_length=1)
 
-        np.testing.assert_allclose(raw_d[0,:], pdq_d[0,:], rtol=1e-5)
+        np.testing.assert_allclose(raw_d[0,:], pdq_d[0,:], rtol=1e-5, atol=1e-3)
 
 
     def test_local_stochastic(self):

--- a/scientific_library/tvb/tests/library/simulator/integrators_test.py
+++ b/scientific_library/tvb/tests/library/simulator/integrators_test.py
@@ -39,7 +39,7 @@ Test for tvb.simulator.coupling module
 import numpy
 import pytest
 from tvb.tests.library.base_testcase import BaseTestCase
-from tvb.tests.library.simulator.models_test import TestUpdateVariablesModel, TestUpdateVariablesBoundsModel
+from tvb.tests.library.simulator.models_test import ModelTestUpdateVariables, ModelTestUpdateVariablesBounds
 from tvb.simulator import integrators
 from tvb.simulator import noise
 
@@ -230,7 +230,7 @@ class TestIntegrators(BaseTestCase):
             assert numpy.all(x1 == x0)
 
     def test_update_variables(self):
-        self._test_update_variables(TestUpdateVariablesModel())
+        self._test_update_variables(ModelTestUpdateVariables())
 
     def test_update_variables_with_boundaries(self):
-        self._test_update_variables(TestUpdateVariablesBoundsModel())
+        self._test_update_variables(ModelTestUpdateVariablesBounds())

--- a/scientific_library/tvb/tests/library/simulator/models_test.py
+++ b/scientific_library/tvb/tests/library/simulator/models_test.py
@@ -41,7 +41,7 @@ from tvb.simulator.models.base import Model
 from tvb.tests.library.base_testcase import BaseTestCase
 
 
-class TestBoundsModel(Model):
+class ModelTestBounds(Model):
     # Used for phase-plane axis ranges and to bound random initial() conditions.
     state_variable_boundaries = Final(
         label="State Variable boundaries [lo, hi]",
@@ -77,7 +77,7 @@ class TestBoundsModel(Model):
         return 0.0 * state
 
 
-class TestUpdateVariablesModel(Model):
+class ModelTestUpdateVariables(Model):
     variables_of_interest = List(
         of=str,
         label="Variables watched by Monitors",
@@ -116,7 +116,7 @@ class TestUpdateVariablesModel(Model):
         return state
 
 
-class TestUpdateVariablesBoundsModel(TestUpdateVariablesModel, TestBoundsModel):
+class ModelTestUpdateVariablesBounds(ModelTestUpdateVariables, ModelTestBounds):
     pass
 
 
@@ -150,7 +150,7 @@ class TestModels(BaseTestCase):
         return state, obser
 
     def test_sv_boundaries_setup(self):
-        model = TestBoundsModel()
+        model = ModelTestBounds()
         model.configure()
         min_float = numpy.finfo("double").min
         max_float = numpy.finfo("double").max
@@ -164,11 +164,11 @@ class TestModels(BaseTestCase):
             assert numpy.allclose(sv_bounds, model.state_variable_boundaries[sv], min_positive)
 
     def test_stvar_init(self):
-        model = TestBoundsModel()
+        model = ModelTestBounds()
         model.configure()
         numpy.testing.assert_array_equal(model.stvar, model.cvar)
 
-        model = TestBoundsModel()
+        model = ModelTestBounds()
         model.stvar=numpy.r_[1,3]
         model.configure()
         numpy.testing.assert_array_equal(model.stvar, numpy.r_[1,3])

--- a/scientific_library/tvb/tests/library/simulator/monitors_test.py
+++ b/scientific_library/tvb/tests/library/simulator/monitors_test.py
@@ -256,7 +256,7 @@ class TestAllAnalyticWithSubcortical(BaseTestCase):
         conn = connectivity.Connectivity()
         conn.generate_surrogate_connectivity(4)
         conn.centres /= 100.0
-        conn.cortical = numpy.array([1, 0, 1, 1], numpy.bool)
+        conn.cortical = numpy.array([1, 0, 1, 1], numpy.bool_)
         seeg_sensors = SensorsInternal(
             locations=conn.centres,
             labels=conn.region_labels)

--- a/scientific_library/tvb/tests/library/simulator/simulator_test.py
+++ b/scientific_library/tvb/tests/library/simulator/simulator_test.py
@@ -218,9 +218,9 @@ class TestSimulator(BaseTestCase):
         assert len(test_simulator.monitors) == len(result)
 
     def test_integrator_boundaries_config(self):
-        from .models_test import TestBoundsModel
+        from .models_test import ModelTestBounds
         test_simulator = simulator.Simulator()
-        test_simulator.model = TestBoundsModel()
+        test_simulator.model = ModelTestBounds()
         test_simulator.model.configure()
         test_simulator.integrator = HeunDeterministic()
         test_simulator.integrator.configure()
@@ -247,9 +247,9 @@ class TestSimulator(BaseTestCase):
             assert test_simulator.current_state[sv_ind, :, :].max() <= sv_boundaries[1]
 
     def test_history_bound_and_clamp_only_bound(self):
-        from .models_test import TestBoundsModel
+        from .models_test import ModelTestBounds
         test_simulator = simulator.Simulator()
-        test_simulator.model = TestBoundsModel()
+        test_simulator.model = ModelTestBounds()
         test_simulator.model.configure()
         test_simulator.integrator = HeunDeterministic()
         test_simulator.integrator.configure()
@@ -264,9 +264,9 @@ class TestSimulator(BaseTestCase):
         self._assert_history_inside_boundaries(test_simulator)
 
     def test_history_bound_and_clamp(self):
-        from .models_test import TestBoundsModel
+        from .models_test import ModelTestBounds
         test_simulator = simulator.Simulator()
-        test_simulator.model = TestBoundsModel()
+        test_simulator.model = ModelTestBounds()
         test_simulator.model.configure()
         self._config_connectivity(test_simulator)
 
@@ -281,9 +281,9 @@ class TestSimulator(BaseTestCase):
         assert numpy.array_equal(test_simulator.current_state[1:3, :, :], value_for_clamp)
 
     def test_integrator_update_variables_config(self):
-        from .models_test import TestUpdateVariablesModel
+        from .models_test import ModelTestUpdateVariables
         test_simulator = simulator.Simulator()
-        test_simulator.model = TestUpdateVariablesModel()
+        test_simulator.model = ModelTestUpdateVariables()
         test_simulator.model.configure()
         test_simulator.integrator.configure()
         test_simulator.configure_integration_for_model()
@@ -297,9 +297,9 @@ class TestSimulator(BaseTestCase):
                (test_simulator.model.nvar - numpy.sum(test_simulator.model.state_variable_mask)) == 2
 
     def test_integrator_update_variables_with_boundaries_and_clamp_config(self):
-        from .models_test import TestUpdateVariablesBoundsModel
+        from .models_test import ModelTestUpdateVariablesBounds
         test_simulator = simulator.Simulator()
-        test_simulator.model = TestUpdateVariablesBoundsModel()
+        test_simulator.model = ModelTestUpdateVariablesBounds()
         test_simulator.model.configure()
         test_simulator.integrator.clamped_state_variable_indices = numpy.array([0, 4])
         test_simulator.integrator.clamped_state_variable_values = numpy.array([0.0, 0.0])

--- a/scientific_library/tvb/tests/library/simulator/simulator_test.py
+++ b/scientific_library/tvb/tests/library/simulator/simulator_test.py
@@ -155,7 +155,7 @@ class Simulator(object):
             else:
                 default_cortex.local_connectivity = LocalConnectivity()
             default_cortex.local_connectivity.surface = default_cortex.region_mapping_data.surface
-            # TODO stimulus
+            # Surface simulations will run without stimulus - OK for now
         else:
             default_cortex = None
             if with_stimulus:


### PR DESCRIPTION
A bunch of warnings crop up when running pytest on the library.  These include

- deprecation warnings of use of NumPy aliases like `bool`, `int`, `float` and `str`, which I replaced with concrete data types
- test model classes starting with `Test` are seen by pytest as unit tests but warns that it can't initialize them because they implement `__init__`, so I renamed them to `ModelTestBlaBla`
- one numerical test had no `atol`, fixed generously at 1e-3