### PR TITLE
nvar property returns length of state variables

### DIFF
--- a/scientific_library/tvb/simulator/models/base.py
+++ b/scientific_library/tvb/simulator/models/base.py
@@ -110,6 +110,7 @@ class Model(HasTraits):
     @property
     def nvar(self):
         """ The number of state variables in this model. """
+        self._nvar = len(self.state_variables)
         return self._nvar
 
     @property


### PR DESCRIPTION
This PR resolves issue #549 

Previously the Models could specify incorrect _nvar. 
**The nvar property is now updated and returns the length of state_variables.**

Existing behavior: 

```
class Model:
    _nvar = 3
    state_variables = 'r', 'V'

m = Model()
m.nvar()  != len(m.state_variables)
```

New behavior:
```
class Model:
    state_variables = 'r', 'V'

m = Model()
m.nvar()  == len(m.state_variables)
```