### PR TITLE
Add few readers from byte streams in tvb_library

### DIFF
--- a/scientific_library/tvb/datatypes/connectivity.py
+++ b/scientific_library/tvb/datatypes/connectivity.py
@@ -37,6 +37,7 @@ The Connectivity datatype.
 """
 
 from copy import copy
+from io import BytesIO
 
 import numpy
 import scipy.stats
@@ -700,8 +701,25 @@ class Connectivity(HasTraits):
 
         return numpy.setdiff1d(numpy.r_[:self.number_of_regions], region_mapping)
 
-    @staticmethod
-    def from_file(source_file="connectivity_76.zip"):
+    @classmethod
+    def _read(cls, reader):
+        result = Connectivity()
+        result.weights = reader.read_array_from_file("weights")
+        if reader.has_file_like("centres"):
+            result.centres = reader.read_array_from_file("centres", use_cols=(1, 2, 3))
+            result.region_labels = reader.read_array_from_file("centres", dtype=numpy.str_, use_cols=(0,))
+        else:
+            result.centres = reader.read_array_from_file("centers", use_cols=(1, 2, 3))
+            result.region_labels = reader.read_array_from_file("centers", dtype=numpy.str_, use_cols=(0,))
+        result.orientations = reader.read_optional_array_from_file("average_orientations")
+        result.cortical = reader.read_optional_array_from_file("cortical", dtype=numpy.bool_)
+        result.hemispheres = reader.read_optional_array_from_file("hemispheres", dtype=numpy.bool_)
+        result.areas = reader.read_optional_array_from_file("areas")
+        result.tract_lengths = reader.read_array_from_file("tract_lengths")
+        return result
+
+    @classmethod
+    def from_file(cls, source_file="connectivity_76.zip"):
 
         result = Connectivity()
         source_full_path = try_get_absolute_path("tvb_data.connectivity", source_file)
@@ -720,21 +738,15 @@ class Connectivity(HasTraits):
 
         else:
             reader = ZipReader(source_full_path)
-
-            result.weights = reader.read_array_from_file("weights")
-            if reader.has_file_like("centres"):
-                result.centres = reader.read_array_from_file("centres", use_cols=(1, 2, 3))
-                result.region_labels = reader.read_array_from_file("centres", dtype=numpy.str_, use_cols=(0,))
-            else:
-                result.centres = reader.read_array_from_file("centers", use_cols=(1, 2, 3))
-                result.region_labels = reader.read_array_from_file("centers", dtype=numpy.str, use_cols=(0,))
-            result.orientations = reader.read_optional_array_from_file("average_orientations")
-            result.cortical = reader.read_optional_array_from_file("cortical", dtype=numpy.bool_)
-            result.hemispheres = reader.read_optional_array_from_file("hemispheres", dtype=numpy.bool_)
-            result.areas = reader.read_optional_array_from_file("areas")
-            result.tract_lengths = reader.read_array_from_file("tract_lengths")
+            result = cls._read(reader)
 
         return result
+
+    @classmethod
+    def from_bytes_stream(cls, bytes_stream):
+        """Construct a Connectivity from a stream of bytes."""
+        reader = ZipReader(BytesIO(bytes_stream))
+        return cls._read(reader)
 
     @property
     def horizon(self):

--- a/scientific_library/tvb/datatypes/sensors.py
+++ b/scientific_library/tvb/datatypes/sensors.py
@@ -39,6 +39,7 @@ The Sensors dataType.
 
 import re
 import numpy
+from io import StringIO
 
 from tvb.basic.readers import FileReader, try_get_absolute_path
 from tvb.basic.neotraits.api import HasTraits, Attr, NArray, Int, TVBEnum, Final
@@ -84,6 +85,17 @@ class Sensors(HasTraits):
 
         result.labels = reader.read_array(dtype=numpy.str_, use_cols=(0,))
         result.locations = reader.read_array(use_cols=(1, 2, 3))
+        return result
+
+    @classmethod
+    def from_bytes_stream(cls, bytes_stream):
+        """Construct Sensors from source_file."""
+        result = Sensors()
+        content_str = StringIO(bytes_stream.decode())
+        result.labels = numpy.loadtxt(content_str, dtype=numpy.str, skiprows=0, usecols=(0,))
+        content_str.seek(0)
+        result.locations = numpy.loadtxt(content_str, dtype=numpy.float64, skiprows=0, usecols=(1, 2, 3))
+
         return result
 
     def configure(self):

--- a/scientific_library/tvb/datatypes/time_series.py
+++ b/scientific_library/tvb/datatypes/time_series.py
@@ -104,6 +104,7 @@ class TimeSeries(HasTraits):
             "Dimensions": self.labels_ordering,
             "Time units": self.sample_period_unit,
             "Sample period": self.sample_period,
+            "Start time": self.start_time,
             "Length": self.sample_period * self.data.shape[0]
         }
         summary.update(narray_summary_info(self.data))


### PR DESCRIPTION
We want to expose in the main DataTypes API also the possibility to be built from a file stream, similarly with building a DT from a file path (connectivity.zip).
This need arise in tvb-widgets module, when building tvb DataTypes from files stored on EBRAIN Drive, but it is generic enough to worth a place in the DataTypes API, and allows us not to duplicate the building part of a DT someplace else
