### PR TITLE
fix for MEG monitor - corrected projection shape

### DIFF
--- a/scientific_library/tvb/simulator/monitors.py
+++ b/scientific_library/tvb/simulator/monitors.py
@@ -563,7 +563,7 @@ class Projection(Monitor):
             non_cortical_rmap_idx = numpy.hstack([numpy.argwhere(self.rmap==i)[:,0] for i in non_cortical_indices])
             cortical_rmap = numpy.delete(cortical_rmap, non_cortical_rmap_idx)
         if not using_cortical_surface and self.gain.shape[1] == cortical_rmap.size:
-            gain = numpy.zeros((self.gain.shape[0], conn.number_of_regions))
+            gain = numpy.zeros((self.gain.shape[0], conn.number_of_regions - len(numpy.where(~conn.cortical)[0])))
             numpy_add_at(gain.T, cortical_rmap, self.gain.T)
             self.log.debug('Region mapping gain shape %s to %s', self.gain.shape, gain.shape)
             self.gain = gain


### PR DESCRIPTION
The bug:

in monitors.py file in line 559 when the gain matrix for the MEG monitor is specified (when running region-wise simulation) 

the code was:
>>> gain = numpy.zeros((self.gain.shape[0], conn.number_of_regions))

this causes the gain matrix shape to have shape[1] equal to the number of regions regardless of whether they are cortical or subcortical. The resulting gain matrix has shape:  
[number of sources,  number of regions]

A few lines later in line 569, when considering subcortical regions (if they are specified in the connectome), they are stacked onto the gain matrix again, causing the matrix to have the shape of:
[number of sources,  number of regions + number of subcortical regions]

When running the simulation this causes an error related to the mismatch in the shape of the specified and resulting outputs of the monitor.

I have changed the line 559 to adjust the shape[1] of the gain matrix:

>>> gain = numpy.zeros((self.gain.shape[0], conn.number_of_regions -len(numpy.where(~conn.cortical)[0]))) 

and this created correct outputs. 