### PR TITLE
TVB-2946 Adjust sample rate in wavelet to be in kHz 

### DIFF
--- a/tvb_library/tvb/analyzers/wavelet.py
+++ b/tvb_library/tvb/analyzers/wavelet.py
@@ -114,7 +114,8 @@ def compute_continuous_wavelet_transform(time_series, frequencies, sample_period
     log.debug("freqs")
     log.debug(narray_describe(freqs))
 
-    sample_rate = time_series.sample_rate
+    # We need this to be kHz (see TVB-2946)
+    sample_rate = time_series.sample_rate/1000
 
     # Duke: code below is as given by Andreas Spiegler, I've just wrapped
     # some of the original argument names

--- a/tvb_library/tvb/analyzers/wavelet.py
+++ b/tvb_library/tvb/analyzers/wavelet.py
@@ -79,10 +79,10 @@ def compute_continuous_wavelet_transform(time_series, frequencies, sample_period
 
     frequencies : Range
     The frequency resolution and range returned. Requested frequencies
-    are converted internally into appropriate scales.
+    are expected to be in kHz.
 
     sample_period : float
-    The sampling period of the computed wavelet spectrum.
+    The sampling period in ms of the computed wavelet spectrum.
 
     q_ratio : float
     NFC. Must be greater than 5. Ratios of the center frequencies to bandwidths.
@@ -99,8 +99,7 @@ def compute_continuous_wavelet_transform(time_series, frequencies, sample_period
         log.warning("Frequency step can't be 0! Trying default step, 2e-3.")
         frequencies.step = 0.002
 
-    freqs = numpy.arange(frequencies.lo, frequencies.hi,
-                         frequencies.step)
+    freqs = numpy.arange(frequencies.lo, frequencies.hi, frequencies.step)
 
     if (freqs.size == 0) or any(freqs <= 0.0):
         # TODO: Maybe should limit number of freqs... ~100 is probably a reasonable upper bound.
@@ -108,19 +107,18 @@ def compute_continuous_wavelet_transform(time_series, frequencies, sample_period
         log.debug("freqs")
         log.debug(narray_describe(freqs))
         frequencies = Range(lo=0.008, hi=0.060, step=0.002)
-        freqs = numpy.arange(frequencies.lo, frequencies.hi,
-                             frequencies.step)
+        freqs = numpy.arange(frequencies.lo, frequencies.hi, frequencies.step)
 
     log.debug("freqs")
     log.debug(narray_describe(freqs))
 
     # We need this to be kHz (see TVB-2946)
-    sample_rate = time_series.sample_rate/1000
+    sample_rate = time_series.sample_rate / 1000
 
     # Duke: code below is as given by Andreas Spiegler, I've just wrapped
     # some of the original argument names
     nf = len(freqs)
-    temporal_step = max((1, ReferenceBackend.iround(sample_period / time_series.sample_period)))
+    temporal_step = max((1, ReferenceBackend.iround(sample_period / time_series.sample_period_ms)))
     nt = int(numpy.ceil(ts_shape[0] / temporal_step))
 
     if not isinstance(q_ratio, numpy.ndarray):

--- a/tvb_library/tvb/datatypes/time_series.py
+++ b/tvb_library/tvb/datatypes/time_series.py
@@ -94,6 +94,18 @@ class TimeSeries(HasTraits):
         else:
             raise ValueError(f"{self.sample_period_unit} is not a recognized time unit")
 
+    @property
+    def sample_period_ms(self):
+        """:returns sample_period is ms """
+        if self.sample_period_unit in ("s", "sec"):
+            return 1000 * self.sample_period
+        elif self.sample_period_unit in ("ms", "msec"):
+            return self.sample_period
+        elif self.sample_period_unit in ("us", "usec"):
+            return self.sample_period / 1000.0
+        else:
+            raise ValueError(f"{self.sample_period_unit} is not a recognized time unit")
+
     def summary_info(self):
         """
         Gather scientifically interesting summary information from an instance of this datatype.


### PR DESCRIPTION
In the past TimeSeries.sample_rate property was always returning 1/sample_period (which in most of the cases - e.g. the default simulations was returning kHz).

Changes in 2020 - 2021 into TimeSeries.sample_rate implementation improved that, to take into account the Ts.sample_period_unit, but also made the result Hz.

To reproduce results like here: https://docs.thevirtualbrain.org/tutorials/tutorial_1_BuildingYourOwnBrainNetworkModel.html#tutorial-1-buildingyourownbrainnetworkmodel
As reported here https://groups.google.com/g/tvb-users/c/lLT9j7i-ehI/m/KANAqlEKAQAJ?utm_medium=email&utm_source=footer, we should use in the Wavelet analyzer kHz.

@i-Zaak @maedoc  please have a look and confirm this is the right way to fix this bug