### PR TITLE
TVB-2513 CI: Adjust usage of cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,8 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
+        id: setPy
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -28,9 +29,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.local
-          key: pip-${{ matrix.python-version }}-${{ hashFiles('tvb_framework/requirements.txt') }}
+          key: pip-${{ steps.setPy.outputs.version }}-${{ hashFiles('tvb_framework/requirements.txt') }}
 
       - name: install tools and dependencies
+        if: steps.cache-local.outputs.cache-hit != 'true'
         run: |
           sudo apt install libbz2-dev libhdf5-serial-dev liblzo2-dev octave
           python3 -m pip install --upgrade setuptools==59.8.0 pip wheel

--- a/.github/workflows/pg-tests.yml
+++ b/.github/workflows/pg-tests.yml
@@ -23,7 +23,8 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
+        id: cp310
         with:
           python-version: "3.10"
 
@@ -35,9 +36,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.local
-          key: pip-${{ hashFiles('tvb_framework/requirements.txt') }}
+          key: pip-${{ steps.cp310.outputs.version }}-${{ hashFiles('tvb_framework/requirements.txt') }}
 
       - name: install tools and dependencies
+        if: steps.cache-local.outputs.cache-hit != 'true'
         run: |
           sudo apt install libbz2-dev libhdf5-serial-dev liblzo2-dev octave
           python3 -m pip install --upgrade setuptools==59.8.0 pip wheel


### PR DESCRIPTION
Inside Github actions, cache on python libraries should be invalidated when minor version of Python changes 
e.g. from Python 3.10.6 to 3.10.7