### PR TITLE
TVB-3037 Fix DirLoader.load 

### DIFF
--- a/tvb_framework/tvb/core/neocom/_h5loader.py
+++ b/tvb_framework/tvb/core/neocom/_h5loader.py
@@ -115,7 +115,7 @@ class DirLoader(object):
             if gid is None:
                 raise ValueError("Neither gid nor filename is provided to load!")
             fname = self.find_file_by_gid(gid)
-        if not os.path.isabs(fname):
+        elif not os.path.isabs(fname):
             fname = os.path.join(self.base_dir, fname)
 
         sub_dt_refs = []

--- a/tvb_framework/tvb/core/neocom/_h5loader.py
+++ b/tvb_framework/tvb/core/neocom/_h5loader.py
@@ -115,6 +115,8 @@ class DirLoader(object):
             if gid is None:
                 raise ValueError("Neither gid nor filename is provided to load!")
             fname = self.find_file_by_gid(gid)
+        if not os.path.isabs(fname):
+            fname = os.path.join(self.base_dir, fname)
 
         sub_dt_refs = []
 
@@ -134,7 +136,7 @@ class DirLoader(object):
         return datatype
 
     def store(self, datatype, fname=None):
-        # type: (HasTraits, str) -> None
+        # type: (HasTraits, str) -> str
         h5file_cls = self.registry.get_h5file_for_datatype(type(datatype))
         if fname is None:
             path = self.path_for(h5file_cls, datatype.gid)
@@ -155,6 +157,8 @@ class DirLoader(object):
             subdt = getattr(datatype, traited_attr.field_name)
             if subdt is not None:  # Because a non required reference may be not populated
                 self.store(subdt)
+
+        return path
 
     def path_for(self, h5_file_class, gid):
         """

--- a/tvb_framework/tvb/core/neocom/h5.py
+++ b/tvb_framework/tvb/core/neocom/h5.py
@@ -207,14 +207,14 @@ def load_with_references_from_dir(base_dir, gid):
 
 
 def store_to_dir(datatype, base_dir, recursive=False):
-    # type: (HasTraits, str, bool) -> None
+    # type: (HasTraits, str, bool) -> str
     """
     Stores the given datatype in the given directory.
     The name and location of the stored file(s) is chosen for you by this function.
     If recursive is true than datatypes referenced by this one are stored as well.
     """
     loader = DirLoader(base_dir, REGISTRY, recursive)
-    loader.store(datatype)
+    return loader.store(datatype)
 
 
 def determine_filepath(gid, base_dir):

--- a/tvb_framework/tvb/interfaces/command/demos/datatypes/store_into_h5.py
+++ b/tvb_framework/tvb/interfaces/command/demos/datatypes/store_into_h5.py
@@ -46,14 +46,14 @@ if __name__ == '__main__':
     conn_ht.configure()
 
     # Store in a given folder the HasTraits entity
-    PATH = "."
+    PATH = ".."
     h5.store_complete_to_dir(conn_ht, PATH)
 
     # Reproduce the just written file name containing GUID
     file_name = h5.path_by_dir(PATH, ConnectivityH5, conn_ht.gid)
 
     # Load back from a file name a HasTraits instance
-    conn_back = h5.load(file_name)
+    conn_back = h5.load(file_name, with_references=True)
 
     # Check that the loaded and written entities are correct
     assert conn_ht.number_of_regions == 76

--- a/tvb_framework/tvb/tests/framework/core/neocom_test.py
+++ b/tvb_framework/tvb/tests/framework/core/neocom_test.py
@@ -29,9 +29,6 @@
 #
 import os
 import numpy
-from tvb.adapters.datatypes.h5.projections_h5 import ProjectionMatrixH5
-from tvb.core.adapters.abcadapter import ABCAdapter
-
 from tvb.core.entities.file.simulator.view_model import SimulatorAdapterModel, EEGViewModel, HeunStochasticViewModel, \
     TemporalAverageViewModel
 from tvb.core.entities.storage import dao
@@ -55,6 +52,15 @@ def test_store_load_rec(tmpdir, connectivity_factory, region_mapping_factory):
     store_to_dir(region_mapping, str(tmpdir), recursive=True)
 
     rmap = load_from_dir(str(tmpdir), region_mapping.gid, recursive=True)
+    numpy.testing.assert_equal(connectivity.weights, rmap.connectivity.weights)
+
+
+def test_store_load_rec_path(tmpdir, connectivity_factory, region_mapping_factory):
+    connectivity = connectivity_factory(2)
+    region_mapping = region_mapping_factory(connectivity=connectivity)
+    region_mapping_path = store_to_dir(region_mapping, str(tmpdir), recursive=True)
+
+    rmap = load(region_mapping_path, with_references=True)
     numpy.testing.assert_equal(connectivity.weights, rmap.connectivity.weights)
 
 


### PR DESCRIPTION
When a file_path from outside the current folder is given, the read is not happening.