### PR TITLE
Refactor coord_to_dict as assert_coord_dict to list() all values

### DIFF
--- a/tvb_contrib/tvb/contrib/scripts/utils/data_structures_utils.py
+++ b/tvb_contrib/tvb/contrib/scripts/utils/data_structures_utils.py
@@ -31,7 +31,11 @@
 """
 
 import re
-from collections import OrderedDict, Hashable
+from collections import OrderedDict
+try:
+    from collections import Hashable
+except ImportError:
+    from collections.abc import Hashable
 import itertools
 from copy import deepcopy
 import numpy as np


### PR DESCRIPTION
Minor correction for processing labels_dimensions as an input to XarrayTimeSeries, to always convert the values of coords to lists, no matter if coords are dicts or xarray.DataArray.coords