### PR TITLE
TVB-3017 AllenSDK incompatibility

### DIFF
--- a/tvb_build/Jenkinsfile-Mac
+++ b/tvb_build/Jenkinsfile-Mac
@@ -24,7 +24,7 @@ pipeline {
                     conda update -n base -c defaults conda
                     conda env remove --name mac-distribution
                     conda create -y --name mac-distribution python=3.10 nomkl numba scipy numpy cython psycopg2
-                    conda install -y --name mac-distribution -c conda-forge jupyterlab tvb-gdist
+                    conda install -y --name mac-distribution -c conda-forge jupyterlab tvb-gdist tvb-data
 
                     /Applications/anaconda3/envs/mac-distribution/bin/pip install --upgrade pip
                     /Applications/anaconda3/envs/mac-distribution/bin/pip install lockfile scikit-build

--- a/tvb_build/Jenkinsfile-Mac
+++ b/tvb_build/Jenkinsfile-Mac
@@ -36,27 +36,39 @@ pipeline {
             }
         }
         stage ('Install TVB') {
-                steps {
-                    unstash 'step1'
-                    sh '''#!/bin/bash
-                        source /Applications/anaconda3/etc/profile.d/conda.sh
-                        conda activate mac-distribution
-                        cd tvb_build
-                        /bin/bash install_full_tvb.sh
-                    '''
-                }
+            steps {
+                unstash 'step1'
+                sh '''#!/bin/bash
+                    source /Applications/anaconda3/etc/profile.d/conda.sh
+                    conda activate mac-distribution
+                    cd tvb_build
+                    /bin/bash install_full_tvb.sh
+                '''
             }
+        }
         stage ('Build TVB Distribution') {
-                steps {
-                    sh '''#!/bin/bash
-                        source /Applications/anaconda3/etc/profile.d/conda.sh
-                        conda activate mac-distribution
-                        echo "Start setup_mac"
-                        python tvb_build/setup_mac.py
-                    '''
-                    archiveArtifacts artifacts: 'TVB_Mac*.zip'
-                }
+            steps {
+                sh '''#!/bin/bash
+                    source /Applications/anaconda3/etc/profile.d/conda.sh
+                    conda activate mac-distribution
+                    echo "Start setup_mac"
+                    python tvb_build/setup_mac.py
+                '''
+                archiveArtifacts artifacts: 'TVB_Mac*.zip'
             }
+        }
+        stage ('Tests on SqLite') {
+            steps {
+                sh '''#!/bin/bash
+                    source /Applications/anaconda3/etc/profile.d/conda.sh
+                    conda activate mac-distribution
+                    cd tvb_bin
+                    /bin/bash run_tests.sh
+                    exit 0
+                '''
+                junit 'tvb_bin/TEST_OUTPUT/results_*.xml'
+            }
+        }
     }
     post {
         changed {
@@ -65,7 +77,8 @@ pipeline {
             body: """
                 Result: ${currentBuild.result}
                 Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'
-                Check console output at ${env.BUILD_URL}"""
+                Check console output at ${env.BUILD_URL}
+                """
         }
     }
 }

--- a/tvb_build/docker/requirements_group
+++ b/tvb_build/docker/requirements_group
@@ -54,3 +54,4 @@ bctpy
 Deprecated
 kubernetes
 watchdog
+requests-toolbelt>=0.10


### PR DESCRIPTION
In TVB-Distributions we had allensdk 0.16.3 and request-toolbelt 0.9
This combination is incompatible with Python 3.10

We found that `allensdk 0.16.3 and request-toolbelt 0.10.1` works, but we are also interested why allensdk is pinned so old