### PR TITLE
TVB-3054: Fix description not being saved

### DIFF
--- a/tvb_framework/tvb/interfaces/web/templates/jinja2/project/editone.html
+++ b/tvb_framework/tvb/interfaces/web/templates/jinja2/project/editone.html
@@ -120,7 +120,7 @@
                     <dd>
                         <p class="field-data"><input tabindex='6' id="max_operation_size" type="number"
                                                      name="max_operation_size"
-                                                     value="{{ data.max_operation_size }}" {{ 'disabled' if not
+                                                     value="{{ data.max_operation_size }}" {{ 'readonly' if not
                             editUsersEnabled }}/>
                         </p>
                         {% if 'max_operation_size' in errors %}


### PR DESCRIPTION
- make max_operation_size field in project properties page readonly for members instead of disabled (being disabled prevented saving description changes by members-only)