### PR TITLE
TVB-3076: Improve logs for PhasePlane web page

### DIFF
--- a/tvb_framework/tvb/interfaces/web/controllers/burst/base_controller.py
+++ b/tvb_framework/tvb/interfaces/web/controllers/burst/base_controller.py
@@ -29,12 +29,10 @@
 """
 
 from tvb.interfaces.web.controllers import common
-from tvb.interfaces.web.controllers.autologging import traced
 from tvb.interfaces.web.controllers.base_controller import BaseController
 from tvb.interfaces.web.structure import WebStructure
 
 
-@traced
 class BurstBaseController(BaseController):
 
     def fill_default_attributes(self, template_dictionary, subsection='burst'):

--- a/tvb_framework/tvb/interfaces/web/controllers/burst/dynamic_model_controller.py
+++ b/tvb_framework/tvb/interfaces/web/controllers/burst/dynamic_model_controller.py
@@ -110,7 +110,7 @@ class _InputTreeFragment(ABCAdapterForm):
                                          doc="""The name of this parameter configuration"""), name='dynamic_name')
 
 
-@traced
+@traced('fill_default_attributes', exclude=True)
 class DynamicModelController(BurstBaseController):
     KEY_CACHED_DYNAMIC_MODEL = 'cache.DynamicModelController'
     LOGGER = get_logger(__name__)

--- a/tvb_framework/tvb/interfaces/web/controllers/burst/matjax.py
+++ b/tvb_framework/tvb/interfaces/web/controllers/burst/matjax.py
@@ -44,6 +44,15 @@ def configure_matjax_doc():
     """
     models_docs = []
 
+    kwargs = {
+        'writer_name': 'html',
+        'settings_overrides': {
+            '_disable_config': True,
+            'report_level': 5,
+            'math_output': "MathJax /dummy.js",
+        },
+    }
+
     for member in list(ModelsEnum):
         clz_name = str(member)
         clz = member.value
@@ -53,7 +62,7 @@ def configure_matjax_doc():
             # 'description': _format_doc(clz.__doc__).replace('\n', '<br/>')
             # I let this here since the html parse has a small flaw regarding some overlapping text
             # and we might consider switching back to plain text
-            'description': publish_parts(clz.__doc__, writer_name='html')['html_body']
+            'description': publish_parts(clz.__doc__, **kwargs)['html_body']
         })
 
     return models_docs


### PR DESCRIPTION
- [x] turn off  `TRACE_USER` logging for `fill_default_attributes` controller method in `Burst` area
- [x] disable logs for `docutils.publish_parts` calls (we were having many and lengthy warnings in case the docstring on some `Model.dfun` methods is invalid)