### PR TITLE
Small fixes to Zerlaut form and labels, for PhasePlane usage

### DIFF
--- a/tvb_framework/tvb/adapters/forms/model_forms.py
+++ b/tvb_framework/tvb/adapters/forms/model_forms.py
@@ -500,7 +500,8 @@ class ZerlautAdaptationFirstOrderModelForm(ModelForm):
         self.tau_e = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.value.tau_e)
         self.tau_i = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.value.tau_i)
         self.N_tot = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.value.N_tot)
-        self.p_connect = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.value.p_connect)
+        self.p_connect_e = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.value.p_connect_e)
+        self.p_connect_i = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.value.p_connect_i)
         self.g = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.value.g)
         self.K_ext_e = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.value.K_ext_e)
         self.K_ext_i = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.value.K_ext_i)
@@ -511,13 +512,17 @@ class ZerlautAdaptationFirstOrderModelForm(ModelForm):
         self.external_input_ex_in = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.value.external_input_ex_in)
         self.external_input_in_ex = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.value.external_input_in_ex)
         self.external_input_in_in = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.value.external_input_in_in)
+        self.tau_OU = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.value.tau_OU)
+        self.weight_noise = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.value.weight_noise)
+        self.S_i = ArrayField(ModelsEnum.ZERLAUT_FIRST_ORDER.value.S_i)
         self.variables_of_interest = MultiSelectField(ModelsEnum.ZERLAUT_FIRST_ORDER.value.variables_of_interest)
 
     def get_params_configurable_in_phase_plane(self):
         return [self.g_L, self.E_L_e, self.E_L_i, self.C_m, self.b_e, self.b_i, self.a_e, self.a_i, self.tau_w_e,
                 self.tau_w_i, self.E_e, self.E_i, self.Q_e, self.Q_i, self.tau_e, self.tau_i, self.N_tot,
-                self.p_connect, self.g, self.K_ext_e, self.K_ext_i, self.T, self.external_input_ex_ex,
-                self.external_input_ex_in, self.external_input_in_ex, self.external_input_in_in]
+                self.p_connect_e, self.p_connect_i, self.g, self.K_ext_e, self.K_ext_i, self.T,
+                self.external_input_ex_ex, self.external_input_ex_in, self.external_input_in_ex,
+                self.external_input_in_in, self.tau_OU, self.weight_noise, self.S_i]
 
 
 class ZerlautAdaptationSecondOrderModelForm(ZerlautAdaptationFirstOrderModelForm):

--- a/tvb_library/tvb/simulator/models/zerlaut.py
+++ b/tvb_library/tvb/simulator/models/zerlaut.py
@@ -186,13 +186,13 @@ class ZerlautAdaptationFirstOrder(Model):
         doc="""Inhibitory adaptation conductance [nS]""")
 
     tau_w_e = NArray(
-        label=":math:`tau_{we}`",
+        label=r":math:`\tau_{we}`",
         default=numpy.array([500.0]),
         domain=Range(lo=1.0, hi=1000.0, step=1.0),
         doc="""Adaptation time constant of excitatory neurons [ms]""")
 
     tau_w_i = NArray(
-        label=":math:`tau_{wi}`",
+        label=r":math:`\tau_{wi}`",
         default=numpy.array([1.0]),
         domain=Range(lo=1.0, hi=1000.0, step=1.0),
         doc="""Adaptation time constant of inhibitory neurons [ms]""")
@@ -320,24 +320,23 @@ class ZerlautAdaptationFirstOrder(Model):
         doc="""external drive""")
 
     tau_OU = NArray(
-        label=":math:`\ntau noise`",
+        label=r":math:`\tau` noise",
         default=numpy.array([5.0]),
         domain=Range(lo=0.10, hi=10.0, step=0.01),
         doc="""time constant noise""")
 
-    weight_noise =  NArray(
-        label=":math:`\nweight noise`",
+    weight_noise = NArray(
+        label="Weight noise",
         default=numpy.array([10.5]),
         domain=Range(lo=0., hi=50.0, step=1.0),
         doc="""weight noise""")
 
     S_i = NArray(
-        label="",
+        label="Scaling Inh",
         default=numpy.array([1.]),
         domain=Range(lo=0., hi=2., step=0.01),
         doc="""Scaling of the remote input for the inhibitory population with
         respect to the excitatory population.""")
-
 
     # Used for phase-plane axis ranges and to bound random initial() conditions.
     state_variable_range = Final(


### PR DESCRIPTION
I suggest this small fixes to #573 for the Phase Plane page to be correctly rendered with these changes Zerlaut models.

![image](https://user-images.githubusercontent.com/674853/233918406-894e4dad-b183-40b1-a232-801202243bba.png)
