### PR TITLE
Corrected stim_step computation in _loop_update_stimulus of simulator.py

### DIFF
--- a/tvb_library/tvb/simulator/simulator.py
+++ b/tvb_library/tvb/simulator/simulator.py
@@ -302,8 +302,7 @@ class Simulator(HasTraits):
         """Update stimulus values for current time step."""
         if self.stimulus is not None:
             # TODO stim_step != current step
-            stim_step = step - (self.current_step + 1)
-            stimulus[self.model.stvar, :, :] = self.stimulus(stim_step).reshape((1, -1, 1))
+            stimulus[self.model.stvar, :, :] = self.stimulus(step-1).reshape((1, -1, 1))
 
     def _loop_update_history(self, step, state):
         """Update history."""


### PR DESCRIPTION
I think there was an error in the computation of stim_step in _loop_update_stimulus of simulator.py, which was:

stim_step = step - (current_step+1), 

leading always to the value of 0, and therefore to NO stimulus being ever applied, or, in any case, to the value of stimulus at time = 0 to be applied for the whole simulation.

I modified this now to stim_step = step - 1, assuming that step 1 is applied when current_step = step - 1