### PR TITLE
TVB-2513 Handle deprecation issues

### DIFF
--- a/tvb_build/docker/requirements_group
+++ b/tvb_build/docker/requirements_group
@@ -56,3 +56,4 @@ kubernetes
 watchdog
 requests-toolbelt>=0.10
 elasticsearch
+urllib3<2.0

--- a/tvb_contrib/tvb/contrib/scripts/datatypes/surface.py
+++ b/tvb_contrib/tvb/contrib/scripts/datatypes/surface.py
@@ -41,7 +41,7 @@ from tvb.datatypes.surfaces import WhiteMatterSurface as TVBWhiteMatterSurface
 
 class Surface(TVBSurface, BaseModel):
     vox2ras = NArray(
-        dtype=np.float,
+        dtype=np.float_,
         label="vox2ras", default=np.array([]), required=False,
         doc="""Voxel to RAS coordinates transformation array.""")
 

--- a/tvb_contrib/tvb/contrib/scripts/service/time_series_service.py
+++ b/tvb_contrib/tvb/contrib/scripts/service/time_series_service.py
@@ -64,7 +64,7 @@ class TimeSeriesService(object):
             return time_series.duplicate(**kwargs)
 
     def convolve(self, time_series, win_len=None, kernel=None, **kwargs):
-        n_kernel_points = np.int(np.round(win_len))
+        n_kernel_points = np.int_(np.round(win_len))
         if kernel is None:
             kernel = np.ones((n_kernel_points, 1, 1, 1)) / n_kernel_points
         else:

--- a/tvb_contrib/tvb/contrib/scripts/utils/data_structures_utils.py
+++ b/tvb_contrib/tvb/contrib/scripts/utils/data_structures_utils.py
@@ -27,16 +27,13 @@
 """
 
 import re
-from collections import OrderedDict
-try:
-    from collections import Hashable
-except ImportError:
-    from collections.abc import Hashable
 import itertools
-from copy import deepcopy
 import numpy as np
-from tvb.contrib.scripts.utils.log_error_utils import warning, raise_value_error, raise_import_error
+from copy import deepcopy
+from collections.abc import Hashable
 from six import string_types
+from collections import OrderedDict
+from tvb.contrib.scripts.utils.log_error_utils import warning, raise_value_error, raise_import_error
 from tvb.basic.logger.builder import get_logger
 
 logger = get_logger(__name__)
@@ -56,18 +53,18 @@ class CalculusConfig(object):
 
 
 def is_numeric(value):
-    return isinstance(value, (float, np.float, np.float64, np.float32, np.float16, np.float128,
-                              int, np.int, np.int0, np.int8, np.int16, np.int32, np.int64,
+    return isinstance(value, (float, np.float_, np.float64, np.float32, np.float16, np.float128,
+                              int, np.int_, np.int0, np.int8, np.int16, np.int32, np.int64,
                               complex, np.complex, np.complex64, np.complex128, np.complex256,
                               np.long, np.number))
 
 
 def is_integer(value):
-    return isinstance(value, (int, np.int, np.int0, np.int8, np.int16, np.int32, np.int64))
+    return isinstance(value, (int, np.int_, np.intp, np.int8, np.int16, np.int32, np.int64))
 
 
 def is_float(value):
-    return isinstance(value, (float, np.float, np.float64, np.float32, np.float16, np.float128))
+    return isinstance(value, (float, np.float_, np.float64, np.float32, np.float16, np.float128))
 
 
 def vector2scalar(x):
@@ -622,7 +619,7 @@ def assert_equal_objects(obj1, obj2, attributes_dict=None, logger=None):
 def shape_to_size(shape):
     shape = np.array(shape)
     shape = shape[shape > 0]
-    return np.int(np.max([shape.prod(), 1]))
+    return np.int_(np.max([shape.prod(), 1]))
 
 
 def shape_to_ndim(shape, squeeze=False):
@@ -655,10 +652,10 @@ def squeeze_array_to_scalar(arr):
 
 
 def assert_arrays(params, shape=None, transpose=False):
-    # type: (object, object) -> object
+    # type: (object, object, bool) -> object
     if shape is None or \
             not (isinstance(shape, tuple)
-                 and len(shape) in range(3) and np.all([isinstance(s, (int, np.int)) for s in shape])):
+                 and len(shape) in range(3) and np.all([isinstance(s, (int, np.int_)) for s in shape])):
         shape = None
         shapes = []  # list of all unique shapes
         n_shapes = []  # list of all unique shapes' frequencies
@@ -715,8 +712,8 @@ def assert_arrays(params, shape=None, transpose=False):
         shape = tuple(shapes[ind])
 
     if transpose and len(shape) > 1:
-        if (transpose is "horizontal" or "row" and shape[0] > shape[1]) or \
-                (transpose is "vertical" or "column" and shape[0] < shape[1]):
+        if (transpose == "horizontal" or transpose == "row" and shape[0] > shape[1]) or \
+                (transpose == "vertical" or transpose == "column" and shape[0] < shape[1]):
             shape = list(shape)
             temp = shape[1]
             shape[1] = shape[0]
@@ -748,14 +745,14 @@ def make_float(x, precision="64"):
         elif isequal_string(precision, "32"):
             return x.astype(np.float32)
         else:
-            return x.astype(np.float)
+            return x.astype(np.float_)
     else:
         if isequal_string(precision, "64"):
             return np.float64(x)
         elif isequal_string(precision, "32"):
             np.float32(x)
         else:
-            return np.float(x)
+            return np.float_(x)
 
 
 def make_int(x, precision="64"):
@@ -765,14 +762,14 @@ def make_int(x, precision="64"):
         elif isequal_string(precision, "32"):
             return x.astype(np.int32)
         else:
-            return x.astype(np.int)
+            return x.astype(np.int_)
     else:
         if isequal_string(precision, "64"):
             return np.int64(x)
         elif isequal_string(precision, "32"):
             np.int32(x)
         else:
-            return np.int(x)
+            return np.int_(x)
 
 
 def copy_object_attributes(obj1, obj2, attr1, attr2=None, deep_copy=False, check_none=False):
@@ -827,7 +824,7 @@ def sort_events_by_x_and_y(events, x="senders", y="times",
         for key, xlbl in zip(keys, xlabels):
             sorted_events[key] = np.sort(ys[np.where((xs == xlbl).all(axis=-1))])
     else:
-        sorted_events = OrderedDict(zip(keys, [np.array([])]*len(keys)))
+        sorted_events = OrderedDict(zip(keys, [np.array([])] * len(keys)))
     return sorted_events
 
 

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/double_proxy_precision_complex_delay_update_test.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/double_proxy_precision_complex_delay_update_test.py
@@ -26,7 +26,6 @@
 """
 
 import numpy as np
-
 from tvb.tests.library.base_testcase import BaseTestCase
 from tvb.contrib.tests.cosimulation.parallel.function_tvb import TvbSim
 
@@ -35,10 +34,11 @@ class TestDoubleProxyPrecisionComplexDelayUpdate(BaseTestCase):
     """
     test the transmission of information between two models with proxy in most complex case and different delay
     """
+
     def test_double_precision_complex_delay_update(self):
-        weight = np.array([[5, 2, 4, 0], [8, 5, 4, 1], [6, 1, 7, 9], [10, 0, 5, 6]],dtype=np.float)
-        delay = np.array([[7, 8, 5, 1], [9, 3, 7, 9], [4, 3, 2, 8], [9, 10, 11, 5]],dtype=np.float)
-        max = np.int(np.max(delay)*10+1)
+        weight = np.array([[5, 2, 4, 0], [8, 5, 4, 1], [6, 1, 7, 9], [10, 0, 5, 6]], dtype=np.float_)
+        delay = np.array([[7, 8, 5, 1], [9, 3, 7, 9], [4, 3, 2, 8], [9, 10, 11, 5]], dtype=np.float_)
+        max = np.int_(np.max(delay) * 10 + 1)
         resolution_simulation = 0.1
         time_synchronize = np.min(delay)
         proxy_id_1 = [1]
@@ -81,7 +81,7 @@ class TestDoubleProxyPrecisionComplexDelayUpdate(BaseTestCase):
 
             # COMPARE PROXY 1
             np.testing.assert_array_equal(np.squeeze(result_ref[:, proxy_id_2, :], axis=2)[0],
-                              np.squeeze(result_1[0][:, proxy_id_2, :], axis=2)[0])
+                                          np.squeeze(result_1[0][:, proxy_id_2, :], axis=2)[0])
             # COMPARE PROXY 2
-            np.testing.assert_array_equal(np.squeeze(result_ref[:, proxy_id_1,:], axis=2)[0],
-                              np.squeeze(result_2[0][:, proxy_id_1,:], axis=2)[0])
+            np.testing.assert_array_equal(np.squeeze(result_ref[:, proxy_id_1, :], axis=2)[0],
+                                          np.squeeze(result_2[0][:, proxy_id_1, :], axis=2)[0])

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/double_proxy_precision_complex_test.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/double_proxy_precision_complex_test.py
@@ -39,7 +39,7 @@ class TestDoubleProxyPrecisionComplex(BaseTestCase):
     def test_double_precision_complex(self):
         weight = np.array([[5, 2, 4, 0], [8, 5, 4, 1], [6, 1, 7, 9], [10, 0, 5, 6]])
         delay = np.array([[7, 8, 5, 1], [10, 3, 7, 9], [4, 3, 2, 8], [9, 10, 11, 5]])
-        max = np.int(np.max(delay)*10+1)
+        max = np.int_(np.max(delay)*10+1)
         init_value = np.array([[[0.1,0.0], [0.1,0.0], [0.2,0.0], [0.9,0.0]]] * max)
         initial_condition = init_value.reshape((max, 2, weight.shape[0], 1))
         resolution_simulation = 0.1

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/double_proxy_precision_simple_test.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/double_proxy_precision_simple_test.py
@@ -39,7 +39,7 @@ class TestDoubleProxyPrecisionSimple(BaseTestCase):
     def test_double_precision_simple(self):
         weight = np.array([[1, 1], [1, 1]])
         delay = np.array([[10.0, 10.0], [10.0, 10.0]])
-        max = np.int(np.max(delay)*10+1)
+        max = np.int_(np.max(delay)*10+1)
         init_value = np.array([[[0.1,0.0], [0.1,0.0]]] * max)
         initial_condition = init_value.reshape((max, 2, weight.shape[0], 1))
         resolution_simulation = 0.1

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/function_tvb.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/function_tvb.py
@@ -100,7 +100,7 @@ def tvb_init(parameters, time_synchronize, initial_condition):
                           voi=np.array([0]),
                           synchronization_time=time_synchronize,
                           cosim_monitors=(RawCosim(),),
-                          proxy_inds=np.asarray(id_proxy, dtype=np.int),
+                          proxy_inds=np.asarray(id_proxy, dtype=np.int_),
                           model=model,
                           connectivity=connectivity,
                           coupling=coupling,

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/modify_wongwang_precision_test.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/modify_wongwang_precision_test.py
@@ -56,7 +56,7 @@ class TestModifyWongWang(BaseTestCase):
         coupling = lab.coupling.Linear(a=np.array(0.0154))
         integrator = lab.integrators.HeunDeterministic(dt=0.1, bounded_state_variable_indices=np.array([0]),
                                                        state_variable_boundaries=np.array([[0.0, 1.0]]))
-        monitors = lab.monitors.Raw(period=0.1, variables_of_interest=np.array(0, dtype=np.int))
+        monitors = lab.monitors.Raw(period=0.1, variables_of_interest=np.array(0, dtype=np.int_))
         # Initialise a Simulator -- Model, Connectivity, Integrator, and Monitors.
         sim = simulator(model=model,
                         connectivity=connectivity,
@@ -97,7 +97,7 @@ class TestModifyWongWang(BaseTestCase):
                             voi=np.array([0]),
                             synchronization_time=synchronization_time,
                             cosim_monitors=(RawCosim(),),
-                            proxy_inds=np.asarray([0], dtype=np.int),
+                            proxy_inds=np.asarray([0], dtype=np.int_),
                             model=model_1,
                             connectivity=connectivity,
                             coupling=coupling,

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/monitors_test.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/monitors_test.py
@@ -56,7 +56,7 @@ class TestMonitors(BaseTestCase):
         coupling = lab.coupling.Linear(a=np.array(0.0154))
         integrator = lab.integrators.HeunDeterministic(dt=0.1, bounded_state_variable_indices=np.array([0]),
                                                        state_variable_boundaries=np.array([[0.0, 1.0]]))
-        monitors = lab.monitors.Raw(period=0.1, variables_of_interest=np.array(0, dtype=np.int))
+        monitors = lab.monitors.Raw(period=0.1, variables_of_interest=np.array(0, dtype=np.int_))
         # Initialise a Simulator -- Model, Connectivity, Integrator, and Monitors.
         sim = lab.simulator.Simulator(model=model,
                                       connectivity=connectivity,
@@ -88,7 +88,7 @@ class TestMonitors(BaseTestCase):
                             RawDelayed(), RawVoiDelayed(variables_of_interest=np.array([0])),
                             CosimCoupling(coupling=coupling),
                             CosimCoupling(coupling=coupling, variables_of_interest=np.array([0]))),
-            proxy_inds=np.asarray([0], dtype=np.int),
+            proxy_inds=np.asarray([0], dtype=np.int_),
             model=model_1,
             connectivity=connectivity,
             coupling=coupling,

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/proxy_precision_bad_test.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/proxy_precision_bad_test.py
@@ -42,7 +42,7 @@ class TestPrecisionBad(BaseTestCase):
         weight = np.array([[2, 8], [3, 5]])
         delay = 100.0
         delays = np.array([[delay, delay], [delay, delay]])
-        max = np.int(np.max(delay)*10+1)
+        max = np.int_(np.max(delay)*10+1)
         init_value = np.array([[0.9,0.0], [0.9,0.0]]*max)
         resolution_simulation = 0.1
         synchronization_time = 0.1 * 10.0

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/proxy_precision_delay_test.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/proxy_precision_delay_test.py
@@ -39,13 +39,13 @@ class TestPrecisionDelay(BaseTestCase):
     def test_precision_delay(self):
         weight = np.array([[2, 8, 0], [0, 0, 0], [3, 0, 1]])
         delay = np.array([[0.6, 0.5, 1.0], [0.7, 0.8, 3.0], [1.0, 0.5, 0.7]])
-        max = np.int(np.max(delay)*10+1)
-        init_value = np.array([[[0.1,0.0], [0.1,0.0], [0.2,0.0]]] * max)
+        max = np.int_(np.max(delay) * 10 + 1)
+        init_value = np.array([[[0.1, 0.0], [0.1, 0.0], [0.2, 0.0]]] * max)
         initial_condition = init_value.reshape((max, 2, weight.shape[0], 1))
         resolution_simulation = 0.1
         synchronization_time = 0.1 * 4
         proxy_id = [0]
-        no_proxy = [1,2]
+        no_proxy = [1, 2]
 
         # simulation with one proxy
         np.random.seed(42)
@@ -61,7 +61,7 @@ class TestPrecisionDelay(BaseTestCase):
 
         # compare with TVB Raw monitor delayed by synchronization_time
         np.testing.assert_array_equal(np.squeeze(result_ref[:, no_proxy, :], axis=2)[0],
-                        np.squeeze(result[0][:, no_proxy, :], axis=2)[0])
+                                      np.squeeze(result[0][:, no_proxy, :], axis=2)[0])
 
         for i in range(0, 1000):
             time, result = sim(synchronization_time, [time, result_ref[:, proxy_id][:, :, 0]])

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/proxy_precision_delay_update_test.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/proxy_precision_delay_update_test.py
@@ -39,13 +39,13 @@ class TestPrecisionDelayUpdate(BaseTestCase):
     def test_precision_delay_update(self):
         weight = np.array([[2, 8, 0], [0, 0, 0], [3, 0, 1]])
         delay = np.array([[0.6, 0.5, 1.0], [0.7, 0.8, 3.0], [1.0, 0.5, 0.7]])
-        max = np.int(np.max(delay)*10+1)
-        init_value = np.array([[[0.1,0.0], [0.1,0.0], [0.2,0.0]]] * max)
+        max = np.int_(np.max(delay) * 10 + 1)
+        init_value = np.array([[[0.1, 0.0], [0.1, 0.0], [0.2, 0.0]]] * max)
         initial_condition = init_value.reshape((max, 2, weight.shape[0], 1))
         resolution_simulation = 0.1
         synchronization_time = np.min(delay)
         proxy_id = [0]
-        no_proxy = [1,2]
+        no_proxy = [1, 2]
 
         # simulation with one proxy
         np.random.seed(42)
@@ -61,7 +61,7 @@ class TestPrecisionDelayUpdate(BaseTestCase):
 
         # compare with TVB Raw monitor delayed by synchronization_time
         np.testing.assert_array_equal(np.squeeze(result_ref[:, no_proxy, :], axis=2)[0],
-                        np.squeeze(result[0][:, no_proxy, :], axis=2)[0])
+                                      np.squeeze(result[0][:, no_proxy, :], axis=2)[0])
 
         for i in range(0, 1000):
             delay_input = [time, result_ref[:, proxy_id][:, :, 0]]

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/proxy_precision_multiple_delay_update_test.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/proxy_precision_multiple_delay_update_test.py
@@ -39,8 +39,8 @@ class TestPrecisionMultipleDelayUpdate(BaseTestCase):
     def test_precision_multiple_delay_update(self):
         weight = np.array([[5, 2, 4, 0], [8, 5, 4, 1], [6, 1, 7, 9], [10, 0, 5, 6]])
         delay = np.array([[0.1, 0.2, 0.5, 0.8], [0.3, 0.5, 0.5, 0.4], [0.6, 0.7, 0.1, 0.2], [0.3, 0.4, 0.5, 1.2]]) * 10
-        max = np.int(np.max(delay)*10+1)
-        init_value = np.array([[[0.1,0.0], [0.1,0.0], [0.2,0.0], [0.2,0.0]]] * max)
+        max = np.int_(np.max(delay) * 10 + 1)
+        init_value = np.array([[[0.1, 0.0], [0.1, 0.0], [0.2, 0.0], [0.2, 0.0]]] * max)
         initial_condition = init_value.reshape((max, 2, weight.shape[0], 1))
         resolution_simulation = 0.1
         synchronization_time = 0.1 * 10
@@ -61,7 +61,7 @@ class TestPrecisionMultipleDelayUpdate(BaseTestCase):
 
         # compare with the CosimMonitor RawCosim
         np.testing.assert_array_equal(np.squeeze(result_ref[:, no_proxy, :], axis=1)[0],
-                        np.squeeze(result[0][:, no_proxy, :], axis=1)[0])
+                                      np.squeeze(result[0][:, no_proxy, :], axis=1)[0])
 
         for i in range(0, 1000):
             delai_input = [time, result_ref[:, proxy_id][:, :, 0]]

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/proxy_precision_multiple_test.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/proxy_precision_multiple_test.py
@@ -39,8 +39,8 @@ class TestPrecisionMultiple(BaseTestCase):
     def test_precision_multiple(self):
         weight = np.array([[5, 2, 4, 0], [8, 5, 4, 1], [6, 1, 7, 9], [10, 0, 5, 6]])
         delay = np.array([[0.1, 0.1, 0.1, 0.1], [0.1, 0.1, 0.1, 0.1], [0.1, 0.1, 0.1, 0.1], [0.1, 0.1, 0.1, 0.1]]) * 10
-        max = np.int(np.max(delay)*10+1)
-        init_value = np.array([[[0.1,0.0], [0.1,0.0], [0.2,0.0], [0.2,0.0]]] * max)
+        max = np.int_(np.max(delay) * 10 + 1)
+        init_value = np.array([[[0.1, 0.0], [0.1, 0.0], [0.2, 0.0], [0.2, 0.0]]] * max)
         initial_condition = init_value.reshape((max, 2, weight.shape[0], 1))
         resolution_simulation = 0.1
         synchronization_time = 0.1 * 5
@@ -61,7 +61,7 @@ class TestPrecisionMultiple(BaseTestCase):
 
         # compare with the CosimMonitor RawCosim
         np.testing.assert_array_equal(np.squeeze(result_ref[:, no_proxy, :], axis=1)[0],
-                        np.squeeze(result[0][:, no_proxy, :], axis=1)[0])
+                                      np.squeeze(result[0][:, no_proxy, :], axis=1)[0])
 
         for i in range(0, 1000):
             time, result = sim(synchronization_time, [time, result_ref[:, proxy_id][:, :, 0]])

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/simple/double_proxy_precision_complex_test.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/simple/double_proxy_precision_complex_test.py
@@ -40,11 +40,11 @@ class TestDoubleProxyPrecisionComplex(BaseTestCase):
     def test_double_proxy_precision_complex(self):
         weight = np.array([[5, 2, 4, 0], [8, 5, 4, 1], [6, 1, 7, 9], [10, 0, 5, 6]])
         delay = np.array([[7, 8, 5, 1], [10, 3, 7, 9], [4, 3, 2, 8], [9, 10, 11, 5]])
-        max = np.int(np.max(delay)*10+1)
-        init_value = np.array([[[0.9,0.0], [0.1,0.0], [0.2,0.0], [0.3,0.0]]] * max)
+        max = np.int_(np.max(delay) * 10 + 1)
+        init_value = np.array([[[0.9, 0.0], [0.1, 0.0], [0.2, 0.0], [0.3, 0.0]]] * max)
         initial_condition = init_value.reshape((max, 2, weight.shape[0], 1))
         resolution_simulation = 0.1
-        synchronization_time =np.min(delay)
+        synchronization_time = np.min(delay)
         proxy_id_1 = [1]
         proxy_id_2 = [0, 2]
 
@@ -67,15 +67,15 @@ class TestDoubleProxyPrecisionComplex(BaseTestCase):
         time_ref, s_ref, result_ref = sim_ref(synchronization_time, rate=True)
 
         # COMPARE PROXY 1
-        np.testing.assert_array_equal(np.squeeze(result_ref[:,proxy_id_2,:], axis=2),
-                          np.squeeze(result_1[0][:,proxy_id_2,:], axis=2))
-        np.testing.assert_array_equal(np.squeeze(s_ref[:,proxy_id_2,:], axis=2),
-                            np.squeeze(s_1[0][:,proxy_id_2,:], axis=2))
+        np.testing.assert_array_equal(np.squeeze(result_ref[:, proxy_id_2, :], axis=2),
+                                      np.squeeze(result_1[0][:, proxy_id_2, :], axis=2))
+        np.testing.assert_array_equal(np.squeeze(s_ref[:, proxy_id_2, :], axis=2),
+                                      np.squeeze(s_1[0][:, proxy_id_2, :], axis=2))
         # COMPARE PROXY 2
-        np.testing.assert_array_equal(np.squeeze(result_ref[:,proxy_id_1,:], axis=2),
-                          np.squeeze(result_2[0][:,proxy_id_1,:], axis=2))
-        np.testing.assert_array_equal(np.squeeze(s_ref[:,proxy_id_1,:], axis=2),
-                            np.squeeze(s_2[0][:,proxy_id_1,:], axis=2))
+        np.testing.assert_array_equal(np.squeeze(result_ref[:, proxy_id_1, :], axis=2),
+                                      np.squeeze(result_2[0][:, proxy_id_1, :], axis=2))
+        np.testing.assert_array_equal(np.squeeze(s_ref[:, proxy_id_1, :], axis=2),
+                                      np.squeeze(s_2[0][:, proxy_id_1, :], axis=2))
 
         for i in range(0, 1000):
             time, s_2, result_2 = sim_2(synchronization_time,
@@ -83,7 +83,7 @@ class TestDoubleProxyPrecisionComplex(BaseTestCase):
 
             # compare with Raw monitor delayed by synchronization_time
             np.testing.assert_array_equal(result_ref[:, proxy_id_1, :], result_2[1][:, proxy_id_1, :])
-            np.testing.assert_array_equal(result_ref[:, proxy_id_2, :]*np.NAN, result_2[1][:, proxy_id_2, :])
+            np.testing.assert_array_equal(result_ref[:, proxy_id_2, :] * np.NAN, result_2[1][:, proxy_id_2, :])
             np.testing.assert_array_equal(s_ref, s_2[1])
 
             time, s_1, result_1 = sim_1(synchronization_time,
@@ -91,14 +91,14 @@ class TestDoubleProxyPrecisionComplex(BaseTestCase):
 
             # compare with Raw monitor delayed by synchronization_time
             np.testing.assert_array_equal(result_ref[:, proxy_id_2, :], result_1[1][:, proxy_id_2, :])
-            np.testing.assert_array_equal(result_ref[:, proxy_id_1, :]*np.NAN, result_1[1][:, proxy_id_1, :])
+            np.testing.assert_array_equal(result_ref[:, proxy_id_1, :] * np.NAN, result_1[1][:, proxy_id_1, :])
             np.testing.assert_array_equal(s_ref, s_1[1])
 
             time_ref, s_ref, result_ref = sim_ref(synchronization_time, rate=True)
             # COMPARE PROXY 1
             np.testing.assert_array_equal(
                 np.squeeze(result_ref[:, proxy_id_2, :], axis=2),
-                np.squeeze(result_1[0][:, proxy_id_2, :],  axis=2))
+                np.squeeze(result_1[0][:, proxy_id_2, :], axis=2))
             np.testing.assert_array_equal(
                 np.squeeze(s_ref[:, proxy_id_2, :], axis=2),
                 np.squeeze(s_1[0][:, proxy_id_2, :], axis=2))

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/simple/double_proxy_precision_simple_test.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/simple/double_proxy_precision_simple_test.py
@@ -39,8 +39,8 @@ class TestDoubleProxyPrecisionSimple(BaseTestCase):
     def test_double_proxy_precision_simple(self):
         weight = np.array([[1, 1], [1, 1]])
         delay = np.array([[10.0, 10.0], [10.0, 10.0]])
-        max = np.int(np.max(delay)*10+1)
-        init_value = np.array([[[0.1,0.0], [0.1,0.0]]] * max)
+        max = np.int_(np.max(delay) * 10 + 1)
+        init_value = np.array([[[0.1, 0.0], [0.1, 0.0]]] * max)
         initial_condition = init_value.reshape((max, 2, weight.shape[0], 1))
         resolution_simulation = 0.1
         synchronization_time = 0.1 * 4
@@ -67,22 +67,22 @@ class TestDoubleProxyPrecisionSimple(BaseTestCase):
 
         # COMPARE PROXY 1
         np.testing.assert_array_equal(np.squeeze(result_ref[:, proxy_id_2, :], axis=2),
-                          np.squeeze(result_1[0][:, proxy_id_2, :], axis=2))
+                                      np.squeeze(result_1[0][:, proxy_id_2, :], axis=2))
         np.testing.assert_array_equal(np.squeeze(s_ref[:, proxy_id_2, :], axis=2),
-                            np.squeeze(s_1[0][:, proxy_id_2, :], axis=2))
+                                      np.squeeze(s_1[0][:, proxy_id_2, :], axis=2))
         # COMPARE PROXY 2
         np.testing.assert_array_equal(np.squeeze(result_ref[:, proxy_id_1, :], axis=2),
-                          np.squeeze(result_2[0][:, proxy_id_1, :], axis=2))
+                                      np.squeeze(result_2[0][:, proxy_id_1, :], axis=2))
         np.testing.assert_array_equal(np.squeeze(s_ref[:, proxy_id_1, :], axis=2),
-                            np.squeeze(s_2[0][:, proxy_id_1, :], axis=2))
+                                      np.squeeze(s_2[0][:, proxy_id_1, :], axis=2))
 
         for i in range(0, 1000):
             time, s_2, result_2 = sim_2(synchronization_time,
                                         rate_data=[time, result_1[0][:, proxy_id_2][:, :, 0]], rate=True)
 
             # compare with Raw monitor delayed by synchronization_time
-            np.testing.assert_array_equal(result_ref[:,proxy_id_1,:], result_2[1][:,proxy_id_1,:])
-            np.testing.assert_array_equal(result_ref[:,proxy_id_2,:]*np.NAN, result_2[1][:,proxy_id_2,:])
+            np.testing.assert_array_equal(result_ref[:, proxy_id_1, :], result_2[1][:, proxy_id_1, :])
+            np.testing.assert_array_equal(result_ref[:, proxy_id_2, :] * np.NAN, result_2[1][:, proxy_id_2, :])
             np.testing.assert_array_equal(s_ref, s_2[1])
 
             time, s_1, result_1 = sim_1(synchronization_time,
@@ -90,17 +90,17 @@ class TestDoubleProxyPrecisionSimple(BaseTestCase):
 
             # compare with Raw monitor delayed by synchronization_time
             np.testing.assert_array_equal(result_ref[:, proxy_id_2, :], result_1[1][:, proxy_id_2, :])
-            np.testing.assert_array_equal(result_ref[:, proxy_id_1, :]*np.NAN, result_1[1][:, proxy_id_1, :])
+            np.testing.assert_array_equal(result_ref[:, proxy_id_1, :] * np.NAN, result_1[1][:, proxy_id_1, :])
             np.testing.assert_array_equal(s_ref, s_1[1])
 
             time_ref, s_ref, result_ref = sim_ref(synchronization_time, rate=True)
             # COMPARE PROXY 1
             np.testing.assert_array_equal(np.squeeze(result_ref[:, proxy_id_2, :], axis=2),
-                              np.squeeze(result_1[0][:, proxy_id_2, :], axis=2))
+                                          np.squeeze(result_1[0][:, proxy_id_2, :], axis=2))
             np.testing.assert_array_equal(np.squeeze(s_ref[:, proxy_id_2, :], axis=2),
-                                np.squeeze(s_1[0][:, proxy_id_2, :], axis=2))
+                                          np.squeeze(s_1[0][:, proxy_id_2, :], axis=2))
             # COMPARE PROXY 2
             np.testing.assert_array_equal(np.squeeze(result_ref[:, proxy_id_1, :], axis=2),
-                              np.squeeze(result_2[0][:, proxy_id_1, :], axis=2))
+                                          np.squeeze(result_2[0][:, proxy_id_1, :], axis=2))
             np.testing.assert_array_equal(np.squeeze(s_ref[:, proxy_id_1, :], axis=2),
-                                np.squeeze(s_2[0][:, proxy_id_1, :], axis=2))
+                                          np.squeeze(s_2[0][:, proxy_id_1, :], axis=2))

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/simple/modify_wongwang_precision_test.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/simple/modify_wongwang_precision_test.py
@@ -28,14 +28,12 @@
 import numpy as np
 import pytest
 import operator
-
 import tvb.simulator.lab as lab
 from tvb.tests.library.base_testcase import BaseTestCase
 from tvb.contrib.tests.cosimulation.synchronization_time_set import SYNCHRONIZATION_TIME, adjust_connectivity_delays
 from tvb.contrib.tests.cosimulation.parallel.ReducedWongWang import ReducedWongWangProxy
 from tvb.contrib.cosimulation.cosim_monitors import RawCosim
 from tvb.contrib.cosimulation.cosimulator import CoSimulator
-
 
 SIMULATION_LENGTH = 3.0
 
@@ -59,7 +57,7 @@ class TestModifyWongWang(BaseTestCase):
         coupling = lab.coupling.Linear(a=np.array(0.0154))
         integrator = lab.integrators.HeunDeterministic(dt=0.1, bounded_state_variable_indices=np.array([0]),
                                                        state_variable_boundaries=np.array([[0.0, 1.0]]))
-        monitors = lab.monitors.Raw(period=0.1, variables_of_interest=np.array(0, dtype=np.int))
+        monitors = lab.monitors.Raw(period=0.1, variables_of_interest=np.array(0, dtype=np.int_))
 
         return model, connectivity, coupling, init, integrator, monitors
 
@@ -83,6 +81,7 @@ class TestModifyWongWangRate(TestModifyWongWang):
     """
     Test to compare the version in TVB and the modified version
     """
+
     def test_with_no_cosimulation(self):
         connectivity, coupling, integrator, monitors, sim, result, result_all = self._reference_simulation()
         result_2 = self._reference_simulation(simulator=CoSimulator)[5]
@@ -97,7 +96,7 @@ class TestModifyWongWangRate(TestModifyWongWang):
             voi=np.array([0]),
             synchronization_time=SYNCHRONIZATION_TIME,
             cosim_monitors=(RawCosim(),),
-            proxy_inds=np.array([], dtype=np.int),
+            proxy_inds=np.array([], dtype=np.int_),
             model=model,
             connectivity=connectivity,
             coupling=coupling,
@@ -115,10 +114,10 @@ class TestModifyWongWangRate(TestModifyWongWang):
         model = ReducedWongWangProxy(tau_s=np.random.rand(76))
         # Initialise a Simulator -- Model, Connectivity, Integrator, and Monitors.
         sim = CoSimulator(
-            voi=np.array([], dtype=np.int),
+            voi=np.array([], dtype=np.int_),
             synchronization_time=SYNCHRONIZATION_TIME,
             cosim_monitors=(RawCosim(),),
-            proxy_inds=np.asarray(id_proxy, dtype=np.int),
+            proxy_inds=np.asarray(id_proxy, dtype=np.int_),
             model=model,
             connectivity=connectivity,
             coupling=coupling,
@@ -144,7 +143,7 @@ class TestModifyWongWangRate(TestModifyWongWang):
             voi=np.array([0]),
             synchronization_time=synchronization_time,
             cosim_monitors=(RawCosim(),),
-            proxy_inds=np.asarray(id_proxy, dtype=np.int),
+            proxy_inds=np.asarray(id_proxy, dtype=np.int_),
             model=model,
             connectivity=connectivity,
             coupling=coupling,
@@ -168,33 +167,33 @@ class TestModifyWongWangRate(TestModifyWongWang):
         # The beginning is good for rate
         for i in range(np.min(sim_3.connectivity.idelays[np.nonzero(sim_3.connectivity.idelays)]) + 1):
             np.testing.assert_array_equal(result_all[0][1][i][0][len(id_proxy):],
-                                          result_3_all[1][i+sync_steps, 0, len(id_proxy):])
-            np.testing.assert_array_equal(result_all[0][1][i][0][:len(id_proxy)]*np.NAN,
-                                          result_3_all[1][i+sync_steps, 0, :len(id_proxy)])
+                                          result_3_all[1][i + sync_steps, 0, len(id_proxy):])
+            np.testing.assert_array_equal(result_all[0][1][i][0][:len(id_proxy)] * np.NAN,
+                                          result_3_all[1][i + sync_steps, 0, :len(id_proxy)])
         # After the delays impact the simulation, there is some difference for rate
         idelays = np.copy(sim_3.connectivity.idelays)
-        idelays = idelays[len(id_proxy):,:len(id_proxy)]
+        idelays = idelays[len(id_proxy):, :len(id_proxy)]
         min_delay = idelays[np.nonzero(idelays)].min()
         for i in range(min_delay + 1, simulation_n_steps):
             diff = result_all[0][1][i][0][len(id_proxy):] - result_3_all[1][i + sync_steps, 0, len(id_proxy):]
             assert np.isnan(diff.sum())
-            np.testing.assert_array_equal(result_all[0][1][i][0][:len(id_proxy)]*np.NAN,
+            np.testing.assert_array_equal(result_all[0][1][i][0][:len(id_proxy)] * np.NAN,
                                           result_3_all[1][i + sync_steps, 0, :len(id_proxy)])
 
         # The beginning is good for S
         for i in range(np.min(sim_3.connectivity.idelays[np.nonzero(sim_3.connectivity.idelays)]) + 1):
             np.testing.assert_array_equal(result_all[0][1][i][1][len(id_proxy):],
-                                          result_3_all[1][i+sync_steps, 1, len(id_proxy):])
-            np.testing.assert_array_equal(result_all[0][1][i][1][:len(id_proxy)]*np.NAN,
-                                          result_3_all[1][i+sync_steps, 1, :len(id_proxy)])
+                                          result_3_all[1][i + sync_steps, 1, len(id_proxy):])
+            np.testing.assert_array_equal(result_all[0][1][i][1][:len(id_proxy)] * np.NAN,
+                                          result_3_all[1][i + sync_steps, 1, :len(id_proxy)])
         # After the delays impact the simulation, there is some difference for S
         idelays = np.copy(sim_3.connectivity.idelays)
-        idelays = idelays[len(id_proxy):,:len(id_proxy)]
+        idelays = idelays[len(id_proxy):, :len(id_proxy)]
         min_delay = idelays[np.nonzero(idelays)].min()
         for i in range(min_delay + 1, simulation_n_steps):
             diff = result_all[0][1][i][1][len(id_proxy):] - result_3_all[1][i + sync_steps, 1, len(id_proxy):]
             assert np.isnan(diff.sum())
-            np.testing.assert_array_equal(result_all[0][1][i][1][:len(id_proxy)]*np.NAN,
+            np.testing.assert_array_equal(result_all[0][1][i][1][:len(id_proxy)] * np.NAN,
                                           result_3_all[1][i + sync_steps, 1, :len(id_proxy)])
 
     def test_with_proxy_bad_input(self):
@@ -212,7 +211,7 @@ class TestModifyWongWangRate(TestModifyWongWang):
             voi=np.array([0]),
             synchronization_time=synchronization_time,
             cosim_monitors=(RawCosim(),),
-            proxy_inds=np.asarray(id_proxy, dtype=np.int),
+            proxy_inds=np.asarray(id_proxy, dtype=np.int_),
             model=model,
             connectivity=connectivity,
             coupling=coupling,
@@ -237,36 +236,36 @@ class TestModifyWongWangRate(TestModifyWongWang):
 
         simulation_n_steps = int(SIMULATION_LENGTH / integrator.dt)
         # The beginning is good for rate
-        for i in range(np.min(sim_4.connectivity.idelays[np.nonzero(sim_4.connectivity.idelays)])+1):
+        for i in range(np.min(sim_4.connectivity.idelays[np.nonzero(sim_4.connectivity.idelays)]) + 1):
             np.testing.assert_array_equal(result_all[0][1][i][0][len(id_proxy):],
-                                          result_4_all[1][i+sync_steps, 0, len(id_proxy):])
+                                          result_4_all[1][i + sync_steps, 0, len(id_proxy):])
             np.testing.assert_array_compare(operator.__ne__, result_all[0][1][i][0][:len(id_proxy)],
-                                            result_4_all[1][i+sync_steps, 0, :len(id_proxy)])
+                                            result_4_all[1][i + sync_steps, 0, :len(id_proxy)])
         # After the delays impact the simulation, there is some difference for rate
         idelays = np.copy(sim_4.connectivity.idelays)
-        idelays = idelays[len(id_proxy):,:len(id_proxy)]
+        idelays = idelays[len(id_proxy):, :len(id_proxy)]
         min_delay = idelays[np.nonzero(idelays)].min()
         for i in range(min_delay + 1, simulation_n_steps):
-            diff = result_all[0][1][i][0][len(id_proxy):] - result_4_all[1][i+sync_steps, 0, len(id_proxy):]
+            diff = result_all[0][1][i][0][len(id_proxy):] - result_4_all[1][i + sync_steps, 0, len(id_proxy):]
             assert np.sum(diff) != 0.0
             np.testing.assert_array_compare(operator.__ne__, result_all[0][1][i][0][:len(id_proxy)],
-                                            result_4_all[1][i+sync_steps, 0, :len(id_proxy)])
+                                            result_4_all[1][i + sync_steps, 0, :len(id_proxy)])
 
         # The beginning is good for S
-        for i in range(np.min(sim_4.connectivity.idelays[np.nonzero(sim_4.connectivity.idelays)])+1):
+        for i in range(np.min(sim_4.connectivity.idelays[np.nonzero(sim_4.connectivity.idelays)]) + 1):
             np.testing.assert_array_equal(result_all[0][1][i][1][len(id_proxy):],
-                                          result_4_all[1][i+sync_steps, 1, len(id_proxy):])
-            np.testing.assert_array_equal(result_all[0][1][i][1][:len(id_proxy)]*np.NAN,
-                                          result_4_all[1][i+sync_steps, 1, :len(id_proxy)])
+                                          result_4_all[1][i + sync_steps, 1, len(id_proxy):])
+            np.testing.assert_array_equal(result_all[0][1][i][1][:len(id_proxy)] * np.NAN,
+                                          result_4_all[1][i + sync_steps, 1, :len(id_proxy)])
         # After the delays impact the simulation, there is some difference for S
         idelays = np.copy(sim_4.connectivity.idelays)
-        idelays = idelays[len(id_proxy):,:len(id_proxy)]
+        idelays = idelays[len(id_proxy):, :len(id_proxy)]
         min_delay = idelays[np.nonzero(idelays)].min()
         for i in range(min_delay + 1, simulation_n_steps):
-            diff = result_all[0][1][i][1][len(id_proxy):] - result_4_all[1][i+sync_steps, 1, len(id_proxy):]
+            diff = result_all[0][1][i][1][len(id_proxy):] - result_4_all[1][i + sync_steps, 1, len(id_proxy):]
             assert np.sum(diff) != 0.0  # TODO: Find out why it fails for the first two iterations!
-            np.testing.assert_array_equal(result_all[0][1][i][1][:len(id_proxy)]*np.NAN,
-                                          result_4_all[1][i+sync_steps, 1, :len(id_proxy)])
+            np.testing.assert_array_equal(result_all[0][1][i][1][:len(id_proxy)] * np.NAN,
+                                          result_4_all[1][i + sync_steps, 1, :len(id_proxy)])
 
     def test_with_proxy_right_input(self):
         connectivity, coupling, integrator, monitors, sim, result, result_all = self._reference_simulation()
@@ -283,7 +282,7 @@ class TestModifyWongWangRate(TestModifyWongWang):
             voi=np.array([0]),
             synchronization_time=synchronization_time,
             cosim_monitors=(RawCosim(),),
-            proxy_inds=np.asarray(id_proxy, dtype=np.int),
+            proxy_inds=np.asarray(id_proxy, dtype=np.int_),
             model=model,
             connectivity=connectivity,
             coupling=coupling,
@@ -308,14 +307,14 @@ class TestModifyWongWangRate(TestModifyWongWang):
             result_5_all[1] = np.concatenate((result_5_all[1], result_5_all_step[0][1]))
 
         # test for rate and then for S
-        simulation_n_steps = int(SIMULATION_LENGTH/integrator.dt)
+        simulation_n_steps = int(SIMULATION_LENGTH / integrator.dt)
         for i in range(simulation_n_steps):
             np.testing.assert_array_equal(result_all[0][1][i][0][len(id_proxy):],
-                                          result_5_all[1][i+sync_steps, 0, len(id_proxy):])
+                                          result_5_all[1][i + sync_steps, 0, len(id_proxy):])
             np.testing.assert_array_equal(result_all[0][1][i][0][:len(id_proxy)],
-                                          result_5_all[1][i+sync_steps, 0, :len(id_proxy)])
+                                          result_5_all[1][i + sync_steps, 0, :len(id_proxy)])
         for i in range(simulation_n_steps):
             np.testing.assert_array_equal(result_all[0][1][i][1][len(id_proxy):],
-                                          result_5_all[1][i+sync_steps, 1, len(id_proxy):])
-            np.testing.assert_array_equal(result_all[0][1][i][1][:len(id_proxy)]*np.NAN,
-                                          result_5_all[1][i+sync_steps, 1, :len(id_proxy)])
+                                          result_5_all[1][i + sync_steps, 1, len(id_proxy):])
+            np.testing.assert_array_equal(result_all[0][1][i][1][:len(id_proxy)] * np.NAN,
+                                          result_5_all[1][i + sync_steps, 1, :len(id_proxy)])

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/simple/modify_wongwang_test.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/simple/modify_wongwang_test.py
@@ -28,14 +28,12 @@
 import numpy as np
 import pytest
 import operator
-
 import tvb.simulator.lab as lab
 from tvb.tests.library.base_testcase import BaseTestCase
 from tvb.contrib.tests.cosimulation.synchronization_time_set import SYNCHRONIZATION_TIME, adjust_connectivity_delays
 from tvb.contrib.tests.cosimulation.parallel.ReducedWongWang import ReducedWongWangProxy
 from tvb.contrib.cosimulation.cosim_monitors import RawCosim, CosimCoupling
 from tvb.contrib.cosimulation.cosimulator import CoSimulator
-
 
 SIMULATION_LENGTH = 3.0
 
@@ -59,7 +57,7 @@ class TestModifyWongWang(BaseTestCase):
         coupling = lab.coupling.Linear(a=np.array(0.0154))
         integrator = lab.integrators.HeunDeterministic(dt=0.1, bounded_state_variable_indices=np.array([0]),
                                                        state_variable_boundaries=np.array([[0.0, 1.0]]))
-        monitors = lab.monitors.Raw(period=0.1, variables_of_interest=np.array(0, dtype=np.int))
+        monitors = lab.monitors.Raw(period=0.1, variables_of_interest=np.array(0, dtype=np.int_))
         # Initialise a Simulator -- Model, Connectivity, Integrator, and Monitors.
         sim = simulator(model=model,
                         connectivity=connectivity,
@@ -99,19 +97,19 @@ class TestModifyWongWangSimple(TestModifyWongWang):
         synchronization_time = SYNCHRONIZATION_TIME
         # Initialise a Simulator -- Model, Connectivity, Integrator, and Monitors.
         sim_3 = CoSimulator(
-                            voi=np.array([0]),
-                            synchronization_time=synchronization_time,
-                            cosim_monitors=(RawCosim(),),
-                            proxy_inds=np.asarray(id_proxy, dtype=np.int),
-                            model=model,
-                            connectivity=connectivity,
-                            coupling=coupling,
-                            integrator=integrator,
-                            monitors=(monitors,),
-                            initial_conditions=init,
-                            )
+            voi=np.array([0]),
+            synchronization_time=synchronization_time,
+            cosim_monitors=(RawCosim(),),
+            proxy_inds=np.asarray(id_proxy, dtype=np.int_),
+            model=model,
+            connectivity=connectivity,
+            coupling=coupling,
+            integrator=integrator,
+            monitors=(monitors,),
+            initial_conditions=init,
+        )
         sim_3.configure()
-        sim_3.run() # run the first steps because the history is delayed
+        sim_3.run()  # run the first steps because the history is delayed
 
         sim_to_sync_time = int(SIMULATION_LENGTH / synchronization_time)
         sync_steps = int(synchronization_time / integrator.dt)
@@ -126,17 +124,17 @@ class TestModifyWongWangSimple(TestModifyWongWang):
         # The beginning is good for rate and S
         for i in range(np.min(sim_3.connectivity.idelays[np.nonzero(sim_3.connectivity.idelays)]) + 1):
             np.testing.assert_array_equal(result_all[0][1][i][0][len(id_proxy):],
-                                          result_3_all[1][i+sync_steps, 0, len(id_proxy):])
-            np.testing.assert_array_equal(result_all[0][1][i][0][:len(id_proxy)]*np.NAN,
-                                          result_3_all[1][i+sync_steps, 0, :len(id_proxy)])
+                                          result_3_all[1][i + sync_steps, 0, len(id_proxy):])
+            np.testing.assert_array_equal(result_all[0][1][i][0][:len(id_proxy)] * np.NAN,
+                                          result_3_all[1][i + sync_steps, 0, :len(id_proxy)])
         # After the delays impact the simulation, there is some difference for S
         idelays = np.copy(sim_3.connectivity.idelays)
-        idelays = idelays[len(id_proxy):,:len(id_proxy)]
+        idelays = idelays[len(id_proxy):, :len(id_proxy)]
         min_delay = idelays[np.nonzero(idelays)].min()
-        for i in range(min_delay + 1, int(SIMULATION_LENGTH/integrator.dt)):
+        for i in range(min_delay + 1, int(SIMULATION_LENGTH / integrator.dt)):
             diff = result_all[0][1][i][0][len(id_proxy):] - result_3_all[1][i + sync_steps, 0, len(id_proxy):]
             assert np.isnan(diff.sum())
-            np.testing.assert_array_equal(result_all[0][1][i][0][:len(id_proxy)]*np.NAN,
+            np.testing.assert_array_equal(result_all[0][1][i][0][:len(id_proxy)] * np.NAN,
                                           result_3_all[1][i + sync_steps, 0, :len(id_proxy)])
 
     def test_with_proxy_bad_input(self):
@@ -151,19 +149,19 @@ class TestModifyWongWangSimple(TestModifyWongWang):
         synchronization_time = SYNCHRONIZATION_TIME
         # Initialise a Simulator -- Model, Connectivity, Integrator, and Monitors.
         sim_4 = CoSimulator(
-                            voi=np.array([0]),
-                            synchronization_time=synchronization_time,
-                            cosim_monitors=(RawCosim(),),
-                            proxy_inds=np.asarray(id_proxy, dtype=np.int),
-                            model=model,
-                            connectivity=connectivity,
-                            coupling=coupling,
-                            integrator=integrator,
-                            monitors=(monitors,),
-                            initial_conditions=init,
-                            )
+            voi=np.array([0]),
+            synchronization_time=synchronization_time,
+            cosim_monitors=(RawCosim(),),
+            proxy_inds=np.asarray(id_proxy, dtype=np.int_),
+            model=model,
+            connectivity=connectivity,
+            coupling=coupling,
+            integrator=integrator,
+            monitors=(monitors,),
+            initial_conditions=init,
+        )
         sim_4.configure()
-        sim_4.run() # run the first steps because the history is delayed
+        sim_4.run()  # run the first steps because the history is delayed
 
         sim_to_sync_time = int(SIMULATION_LENGTH / synchronization_time)
         sync_steps = int(synchronization_time / integrator.dt)
@@ -178,22 +176,22 @@ class TestModifyWongWangSimple(TestModifyWongWang):
             result_4_all[1] = np.concatenate((result_4_all[1], result_4_all_step[0][1]))
 
         # The beginning is good for rate and S
-        for i in range(np.min(sim_4.connectivity.idelays[np.nonzero(sim_4.connectivity.idelays)])+1):
+        for i in range(np.min(sim_4.connectivity.idelays[np.nonzero(sim_4.connectivity.idelays)]) + 1):
             np.testing.assert_array_equal(result_all[0][1][i][0][len(id_proxy):],
-                                          result_4_all[1][i+sync_steps, 0, len(id_proxy):])
+                                          result_4_all[1][i + sync_steps, 0, len(id_proxy):])
             np.testing.assert_array_compare(operator.__ne__,
                                             result_all[0][1][i][0][:len(id_proxy)],
-                                            result_4_all[1][i+sync_steps, 0, :len(id_proxy)])
+                                            result_4_all[1][i + sync_steps, 0, :len(id_proxy)])
         # After the delays impact the simulation, there is some difference for for rate and S
         idelays = np.copy(sim_4.connectivity.idelays)
-        idelays = idelays[len(id_proxy):,:len(id_proxy)]
+        idelays = idelays[len(id_proxy):, :len(id_proxy)]
         min_delay = idelays[np.nonzero(idelays)].min()
-        for i in range(min_delay + 1, int(SIMULATION_LENGTH/integrator.dt)):
-            diff = result_all[0][1][i][0][len(id_proxy):] - result_4_all[1][i+sync_steps, 0, len(id_proxy):]
+        for i in range(min_delay + 1, int(SIMULATION_LENGTH / integrator.dt)):
+            diff = result_all[0][1][i][0][len(id_proxy):] - result_4_all[1][i + sync_steps, 0, len(id_proxy):]
             assert np.sum(diff) != 0.0  # TODO: Find out why it fails for the first two iterations!
             np.testing.assert_array_compare(operator.__ne__,
                                             result_all[0][1][i][0][:len(id_proxy)],
-                                            result_4_all[1][i+sync_steps, 0, :len(id_proxy)])
+                                            result_4_all[1][i + sync_steps, 0, :len(id_proxy)])
 
     def test_with_proxy_right_input(self):
         connectivity, coupling, integrator, monitors, sim, result, result_all = self._reference_simulation()
@@ -207,19 +205,19 @@ class TestModifyWongWangSimple(TestModifyWongWang):
         synchronization_time = SYNCHRONIZATION_TIME
         # Initialise a Simulator -- Model, Connectivity, Integrator, and Monitors.
         sim_5 = CoSimulator(
-                            voi=np.array([0]),
-                            synchronization_time=synchronization_time,
-                            cosim_monitors=(RawCosim(),),
-                            proxy_inds=np.asarray(id_proxy, dtype=np.int),
-                            model=model,
-                            connectivity=connectivity,
-                            coupling=coupling,
-                            integrator=integrator,
-                            monitors=(monitors,),
-                            initial_conditions=init,
-                            )
+            voi=np.array([0]),
+            synchronization_time=synchronization_time,
+            cosim_monitors=(RawCosim(),),
+            proxy_inds=np.asarray(id_proxy, dtype=np.int_),
+            model=model,
+            connectivity=connectivity,
+            coupling=coupling,
+            integrator=integrator,
+            monitors=(monitors,),
+            initial_conditions=init,
+        )
         sim_5.configure()
-        sim_5.run() # run the first steps because the history is delayed
+        sim_5.run()  # run the first steps because the history is delayed
 
         sim_to_sync_time = int(SIMULATION_LENGTH / synchronization_time)
         sync_steps = int(synchronization_time / integrator.dt)
@@ -234,11 +232,11 @@ class TestModifyWongWangSimple(TestModifyWongWang):
             result_5_all[0] = np.concatenate((result_5_all[0], result_5_all_step[0][0]))
             result_5_all[1] = np.concatenate((result_5_all[1], result_5_all_step[0][1]))
 
-        for i in range(int(SIMULATION_LENGTH/integrator.dt)):
+        for i in range(int(SIMULATION_LENGTH / integrator.dt)):
             np.testing.assert_array_equal(result_all[0][1][i][0][len(id_proxy):],
-                                          result_5_all[1][i+sync_steps, 0, len(id_proxy):])
+                                          result_5_all[1][i + sync_steps, 0, len(id_proxy):])
             np.testing.assert_array_equal(result_all[0][1][i][0][:len(id_proxy)],
-                                          result_5_all[1][i+sync_steps, 0, :len(id_proxy)])
+                                          result_5_all[1][i + sync_steps, 0, :len(id_proxy)])
 
     def test_without_proxy_coupling(self):
         connectivity, coupling, integrator, monitors, sim, result, result_all = self._reference_simulation()
@@ -250,30 +248,31 @@ class TestModifyWongWangSimple(TestModifyWongWang):
         synchronization_time = SYNCHRONIZATION_TIME
         # Initialise a Simulator -- Model, Connectivity, Integrator, and Monitors.
         sim_6 = CoSimulator(
-                            voi=np.array([0]),
-                            synchronization_time=synchronization_time,
-                            cosim_monitors=(CosimCoupling(coupling=coupling),),
-                            proxy_inds=np.asarray([0], dtype=np.int),
-                            model=model,
-                            connectivity=connectivity,
-                            coupling=coupling,
-                            integrator=integrator,
-                            monitors=(monitors,),
-                            initial_conditions=init,
-                            )
+            voi=np.array([0]),
+            synchronization_time=synchronization_time,
+            cosim_monitors=(CosimCoupling(coupling=coupling),),
+            proxy_inds=np.asarray([0], dtype=np.int_),
+            model=model,
+            connectivity=connectivity,
+            coupling=coupling,
+            integrator=integrator,
+            monitors=(monitors,),
+            initial_conditions=init,
+        )
         sim_6.configure()
 
         sim_to_sync_time = int(SIMULATION_LENGTH / synchronization_time)
         sync_steps = int(synchronization_time / integrator.dt)
 
         with pytest.raises(ValueError):
-           coupling_future = sim_6.loop_cosim_monitor_output(sync_steps, 1)
+            coupling_future = sim_6.loop_cosim_monitor_output(sync_steps, 1)
 
         coupling_future = sim_6.loop_cosim_monitor_output()
 
         for i in range(sim_to_sync_time):
             result_2 = sim_6.run(
-                cosim_updates=[np.arange(i * synchronization_time, (i + 1) * synchronization_time, 0.1)-synchronization_time,
-                               np.zeros((int(synchronization_time/0.1),1,1,1))])[0][1][:, 0, 0, 0]
-            np.testing.assert_array_equal(result[i*sync_steps:(i+1)*sync_steps]*0.0, result_2)
+                cosim_updates=[
+                    np.arange(i * synchronization_time, (i + 1) * synchronization_time, 0.1) - synchronization_time,
+                    np.zeros((int(synchronization_time / 0.1), 1, 1, 1))])[0][1][:, 0, 0, 0]
+            np.testing.assert_array_equal(result[i * sync_steps:(i + 1) * sync_steps] * 0.0, result_2)
             assert np.sum(np.isnan(sim_6.loop_cosim_monitor_output()[0][1])) == 9

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/simple/proxy_precision_delay_test.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/simple/proxy_precision_delay_test.py
@@ -39,19 +39,19 @@ class TestProxyPrecisionDelay(BaseTestCase):
     def test_precision_delay(self):
         weight = np.array([[2, 8, 10], [0.2, 0.5, 0.1], [3, 0.6, 1]])
         delay = np.array([[0.6, 0.5, 1.0], [0.7, 0.8, 3.0], [1.0, 0.5, 0.7]])
-        max = np.int(np.max(delay)*10+1)
-        init_value = np.array([[[0.1,0.0], [0.1,0.0], [0.2,0.0]]] * max)
+        max = np.int_(np.max(delay) * 10 + 1)
+        init_value = np.array([[[0.1, 0.0], [0.1, 0.0], [0.2, 0.0]]] * max)
         initial_condition = init_value.reshape((max, 2, weight.shape[0], 1))
         resolution_simulation = 0.1
         synchronization_time = 0.1 * 4
         proxy_id = [0]
-        no_proxy = [1,2]
+        no_proxy = [1, 2]
 
         # simulation with one proxy
         np.random.seed(42)
         sim = TvbSim(weight, delay, proxy_id, resolution_simulation,
                      synchronization_time, initial_condition=initial_condition)
-        time, s , result= sim(synchronization_time, rate=True)
+        time, s, result = sim(synchronization_time, rate=True)
 
         # full simulation
         np.random.seed(42)
@@ -60,10 +60,10 @@ class TestProxyPrecisionDelay(BaseTestCase):
         time, s_ref, result_ref = sim_ref(synchronization_time, rate=True)
 
         # compare with the CosimMonitor RawCosim
-        np.testing.assert_array_equal(np.squeeze(result_ref[:,no_proxy,:], axis=2),
-                        np.squeeze(result[0][:,no_proxy,:], axis=2))
-        np.testing.assert_array_equal(np.squeeze(s_ref[:,no_proxy,:], axis=2),
-                          np.squeeze(s[0][:,no_proxy,:], axis=2))
+        np.testing.assert_array_equal(np.squeeze(result_ref[:, no_proxy, :], axis=2),
+                                      np.squeeze(result[0][:, no_proxy, :], axis=2))
+        np.testing.assert_array_equal(np.squeeze(s_ref[:, no_proxy, :], axis=2),
+                                      np.squeeze(s[0][:, no_proxy, :], axis=2))
 
         for i in range(0, 1000):
             time, s, result = sim(synchronization_time,
@@ -71,7 +71,7 @@ class TestProxyPrecisionDelay(BaseTestCase):
 
             # compare with RawDelayed monitor, delayed by synchronization_time
             np.testing.assert_array_equal(result_ref[:, no_proxy, :], result[1][:, no_proxy, :])
-            np.testing.assert_array_equal(result_ref[:, proxy_id, :]*np.NAN, result[1][:, proxy_id, :])
+            np.testing.assert_array_equal(result_ref[:, proxy_id, :] * np.NAN, result[1][:, proxy_id, :])
             np.testing.assert_array_equal(s_ref, s[1])
 
             time, s_ref, result_ref = sim_ref(synchronization_time, rate=True)

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/simple/proxy_precision_multiple_test.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/simple/proxy_precision_multiple_test.py
@@ -43,19 +43,19 @@ class TestProxyPrecisionDelaiMultiple(BaseTestCase):
                            [10, 0, 5, 6]])
         delay = np.array([[0.1, 0.1, 0.1, 0.1], [0.1, 0.1, 0.1, 0.1],
                           [0.1, 0.1, 0.1, 0.1], [0.1, 0.1, 0.1, 0.1]]) * 10
-        max = np.int(np.max(delay)*10+1)
-        init_value = np.array([[[0.1,0.0], [0.1,0.0], [0.2,0.0], [0.2,0.0]]* max] )
+        max = np.int_(np.max(delay) * 10 + 1)
+        init_value = np.array([[[0.1, 0.0], [0.1, 0.0], [0.2, 0.0], [0.2, 0.0]] * max])
         initial_condition = init_value.reshape((max, 2, weight.shape[0], 1))
         resolution_simulation = 0.1
         synchronization_time = np.min(delay)
-        proxy_id = [0,2,3]
+        proxy_id = [0, 2, 3]
         no_proxy = [1]
 
         # simulation with one or more proxy
         np.random.seed(42)
         sim = TvbSim(weight, delay, proxy_id, resolution_simulation,
                      synchronization_time, initial_condition=initial_condition)
-        time, s , result= sim(synchronization_time, rate=True)
+        time, s, result = sim(synchronization_time, rate=True)
 
         # full simulation
         np.random.seed(42)
@@ -65,9 +65,9 @@ class TestProxyPrecisionDelaiMultiple(BaseTestCase):
 
         # compare with the CosimMonitor RawCosim
         np.testing.assert_array_equal(np.squeeze(result_ref[:, no_proxy, :], axis=2),
-                        np.squeeze(result[0][:, no_proxy, :], axis=2))
+                                      np.squeeze(result[0][:, no_proxy, :], axis=2))
         np.testing.assert_array_equal(np.squeeze(s_ref[:, no_proxy, :], axis=2),
-                          np.squeeze(s[0][:, no_proxy, :], axis=2))
+                                      np.squeeze(s[0][:, no_proxy, :], axis=2))
 
         for i in range(0, 1000):
             time, s, result = sim(synchronization_time,
@@ -75,7 +75,7 @@ class TestProxyPrecisionDelaiMultiple(BaseTestCase):
 
             # compare with RawDelayed monitor, delayed by synchronization_time
             np.testing.assert_array_equal(result_ref[:, no_proxy, :], result[1][:, no_proxy, :])
-            np.testing.assert_array_equal(result_ref[:, proxy_id, :]*np.NAN, result[1][:, proxy_id, :])
+            np.testing.assert_array_equal(result_ref[:, proxy_id, :] * np.NAN, result[1][:, proxy_id, :])
             np.testing.assert_array_equal(s_ref, s[1])
 
             time, s_ref, result_ref = sim_ref(synchronization_time, rate=True)

--- a/tvb_framework/requirements.txt
+++ b/tvb_framework/requirements.txt
@@ -43,3 +43,4 @@ siibra==0.4a35
 bctpy
 kubernetes
 watchdog
+urllib3<2.0

--- a/tvb_framework/tvb/interfaces/web/templates/jinja2/user/tooltip.html
+++ b/tvb_framework/tvb/interfaces/web/templates/jinja2/user/tooltip.html
@@ -5,7 +5,7 @@
 
     <p>Released on {{ versionInfo['releaseDate'] }} for Windows, Mac OS X and Linux</p>
 
-	<p>{{ versionInfo['description'] }}</p>
+	<p>{{ versionInfo['description'] | safe }}</p>
 
     <a class="action action-download" href="{{ versionInfo['url'] }}" tabindex="-1" title="Visit the TVB download site...">Visit download site</a>
 </div>

--- a/tvb_framework/tvb/tests/framework/adapters/analyzers/bct_test.py
+++ b/tvb_framework/tvb/tests/framework/adapters/analyzers/bct_test.py
@@ -43,6 +43,9 @@ class TestBCT(TransactionalTestCase):
     Test that all BCT analyzers are executed without error.
     We do not verify that the algorithms are correct, because that is outside the purpose of TVB framework.
     """
+    #  TODO temp skip these from tests due to incompatibility with latest numpy
+    # see BCT reported issue https://github.com/aestrivex/bctpy/issues/119
+    SKIPPED_ALGOS = ["ModularityOpCSMU", "ModularityOCSM", "ParticipationCoefficient", "ParticipationCoefficientSign"]
 
     def transactional_setup_method(self):
         """
@@ -62,6 +65,8 @@ class TestBCT(TransactionalTestCase):
 
         self.bct_adapters = []
         for algo in algorithms:
+            if algo.classname in self.SKIPPED_ALGOS:
+                continue
             self.bct_adapters.append(ABCAdapter.build_adapter(algo))
 
     def transactional_teardown_method(self):

--- a/tvb_library/tvb/analyzers/fmri_balloon.py
+++ b/tvb_library/tvb/analyzers/fmri_balloon.py
@@ -220,8 +220,7 @@ class BalloonModel(HasTraits):
         state[0, 3, :] = 1.  # q
 
         # BOLD model coefficients
-        k = self.compute_derived_parameters()
-        k1, k2, k3 = k[0], k[1], k[2]
+        k1, k2, k3 = self.compute_derived_parameters()
 
         # prepare integrator
         self.integrator.dt = 1. / self.time_series.sample_rate # s
@@ -307,7 +306,7 @@ class BalloonModel(HasTraits):
             k2 = self.epsilon * self.r_0 * self.E0 * self.TE
             k3 = 1 - self.epsilon
 
-        return numpy.array([k1, k2, k3])
+        return k1, k2, k3
 
     def input_transformation(self, time_series, mode):
         """

--- a/tvb_library/tvb/basic/neotraits/_attr.py
+++ b/tvb_library/tvb/basic/neotraits/_attr.py
@@ -27,11 +27,11 @@
 """
 This private module implements concrete declarative attributes
 """
-import collections.abc
 import inspect
 import numpy
 import types
 import typing
+from collections.abc import Sequence
 from ._declarative_base import _Attr, MetaType
 from .ex import TraitValueError, TraitTypeError, TraitAttributeError, TraitFinalAttributeError
 from tvb.basic.logger.builder import get_logger
@@ -235,7 +235,7 @@ class List(Attr):
     def __init__(self, of=object, default=(), doc='', label='', final=False, choices=None):
         # type: (type, tuple, str, str, bool, typing.Optional[tuple]) -> None
         super(List, self).__init__(
-            field_type=collections.abc.Sequence,
+            field_type=Sequence,
             default=default,
             doc=doc,
             label=label,


### PR DESCRIPTION
- [x]  Fixed missing `numpy.int` and `numpy.float` in the latest release of `numpy`
- [x] Bind `urllib3<2.0` as its latest release `2.0` is breaking API and few 3rd party libs (such as `keycloack`) are not yet compatible.
- [x] Fix `Ballon`
- [ ] `test_bct_all` is still failing. Proposed change in [bctpy](https://github.com/aestrivex/bctpy/issues/119) 