### PR TITLE
TVB-3081 Make sure monitors are copied as different instances

### DIFF
--- a/tvb_library/tvb/basic/neotraits/_core.py
+++ b/tvb_library/tvb/basic/neotraits/_core.py
@@ -36,7 +36,6 @@ import typing
 from six import add_metaclass
 from numpy.random import RandomState
 from scipy.sparse import csc_matrix, spmatrix
-
 from ._attr import Attr
 from ._declarative_base import _Property, MetaType
 from .info import trait_object_str, trait_object_repr_html, narray_summary_info
@@ -193,7 +192,7 @@ class HasTraits(object):
 
     gid = Attr(field_type=uuid.UUID)
 
-    TYPES_TO_DEEPCOPY = (RandomState, csc_matrix, spmatrix)
+    TYPES_TO_DEEPCOPY = (RandomState, csc_matrix, spmatrix, list, tuple)
 
     def __init__(self, **kwargs):
         """

--- a/tvb_library/tvb/tests/library/basic/neotraits/neotraits_test.py
+++ b/tvb_library/tvb/tests/library/basic/neotraits/neotraits_test.py
@@ -984,6 +984,7 @@ def test_deepcopy():
     assert original.integrator.noise != clone.integrator.noise
     assert original.integrator.noise != integrators.IntegratorStochastic.noise.default
     assert original.model != clone.model
+    assert original.monitors[0] != clone.monitors[0]
     assert original.coupling != clone.coupling
     assert original.connectivity != clone.connectivity
     # even in the case of random generators


### PR DESCRIPTION
deepcopy on a simulator was keeping the same instances of the Monitors on the clone.
we need new instances for the Monitors as well