### PR TITLE
TVB-3089 Compatibility with latest numexpr

### DIFF
--- a/tvb_library/tvb/datatypes/equations.py
+++ b/tvb_library/tvb/datatypes/equations.py
@@ -423,8 +423,7 @@ class Gamma(HRFKernelEquation):
             product *= i + 1
 
         self.parameters["factorial"] = product
-        _pattern = RefBase.evaluate(self.equation,
-                                         global_dict=self.parameters)
+        _pattern = super().evaluate(var)
         _pattern /= max(_pattern)
         _pattern *= self.parameters["a"]
         return _pattern
@@ -472,7 +471,7 @@ class DoubleExponential(HRFKernelEquation):
         Generate a discrete representation of the equation for the space
         represented by ``var``.
         """
-        _pattern = RefBase.evaluate(self.equation, global_dict=self.parameters)
+        _pattern = super().evaluate(var)
         _pattern /= max(_pattern)
 
         _pattern *= self.parameters["a"]
@@ -588,4 +587,4 @@ class MixtureOfGammas(HRFKernelEquation):
         self.parameters["gamma_a_1"] = sp_gamma(self.parameters["a_1"])
         self.parameters["gamma_a_2"] = sp_gamma(self.parameters["a_2"])
 
-        return RefBase.evaluate(self.equation, global_dict=self.parameters)
+        return super().evaluate(var)


### PR DESCRIPTION
`numexpr.evaluate` implementation slightly changed in the latest release 2.8.5.
Here https://github.com/pydata/numexpr/blob/master/numexpr/necompiler.py#L985 is no longer considering the `global_dict` values, just the `local_dict` (2nd positional arg).
Code from the prev release 2.8.4 is here: https://github.com/pydata/numexpr/blob/ec5e90886b021558e51e35870735e7a64500c59e/numexpr/necompiler.py#L819

I propose to leave the call towards `RefBase.evaluate` only in the base `Equation.evaluate` implementation, if possible - like in this PR - for simplicity in fixing future similar API changes.