### PR TITLE
CoSimulator exclusive proxy nodes connectivity bug correction

### DIFF
--- a/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
+++ b/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
@@ -151,7 +151,7 @@ class CoSimulator(Simulator):
 
         # Reconfigure the connectivity for regions modelled by the other cosimulator exclusively:
         if self.exclusive:
-            self.connectivity.weights[np.ix_(self.proxy_inds, self.proxy_inds)] = 0.0
+            self.connectivity.weights[numpy.ix_(self.proxy_inds, self.proxy_inds)] = 0.0
             self.connectivity.configure()
 
         # Configure the cosimulator monitor

--- a/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
+++ b/tvb_contrib/tvb/contrib/cosimulation/cosimulator.py
@@ -151,7 +151,7 @@ class CoSimulator(Simulator):
 
         # Reconfigure the connectivity for regions modelled by the other cosimulator exclusively:
         if self.exclusive:
-            self.connectivity.weights[self.proxy_inds][:, self.proxy_inds] = 0.0
+            self.connectivity.weights[np.ix_(self.proxy_inds, self.proxy_inds)] = 0.0
             self.connectivity.configure()
 
         # Configure the cosimulator monitor


### PR DESCRIPTION
Corrected bug with setting the CoSimulator.connectivity.weights[proxy_inds][:, proxy_inds] = 0.0
when CoSimulator.exlusive = True (default behavior)
The above line was doing nothing...
The correct one uses np._ix