### PR TITLE
Make `model.nvar` a property

### DIFF
--- a/tvb_contrib/tvb/contrib/rateML/generatedModels/epileptor.py
+++ b/tvb_contrib/tvb/contrib/rateML/generatedModels/epileptor.py
@@ -145,7 +145,6 @@ class EpileptorT(ModelNumbaDfun):
 
     state_variables = ['x1', 'y1', 'z', 'x2', 'y2', 'g']
 
-    _nvar = 6
     cvar = numpy.array([0,1,2,3,4,5,], dtype = numpy.int32)
 
     def dfun(self, vw, c, local_coupling=0.0):

--- a/tvb_contrib/tvb/contrib/rateML/generatedModels/kuramoto.py
+++ b/tvb_contrib/tvb/contrib/rateML/generatedModels/kuramoto.py
@@ -33,7 +33,6 @@ class KuramotoT(ModelNumbaDfun):
 
     state_variables = ['V']
 
-    _nvar = 1
     cvar = numpy.array([0,], dtype = numpy.int32)
 
     def dfun(self, vw, c, local_coupling=0.0):

--- a/tvb_contrib/tvb/contrib/rateML/generatedModels/montbrio.py
+++ b/tvb_contrib/tvb/contrib/rateML/generatedModels/montbrio.py
@@ -85,7 +85,6 @@ class MontbrioT(ModelNumbaDfun):
 
     state_variables = ['r', 'V']
 
-    _nvar = 2
     cvar = numpy.array([0,1,], dtype = numpy.int32)
 
     def dfun(self, vw, c, local_coupling=0.0):

--- a/tvb_contrib/tvb/contrib/rateML/generatedModels/oscillator.py
+++ b/tvb_contrib/tvb/contrib/rateML/generatedModels/oscillator.py
@@ -101,7 +101,6 @@ class OscillatorT(ModelNumbaDfun):
 
     state_variables = ['V', 'W']
 
-    _nvar = 2
     cvar = numpy.array([0,1,], dtype = numpy.int32)
 
     def dfun(self, vw, c, local_coupling=0.0):

--- a/tvb_contrib/tvb/contrib/rateML/generatedModels/rwongwang.py
+++ b/tvb_contrib/tvb/contrib/rateML/generatedModels/rwongwang.py
@@ -163,7 +163,6 @@ class RwongwangT(ModelNumbaDfun):
 
     state_variables = ['V', 'W']
 
-    _nvar = 2
     cvar = numpy.array([0,1,], dtype = numpy.int32)
 
     def dfun(self, vw, c, local_coupling=0.0):

--- a/tvb_contrib/tvb/contrib/rateML/tmpl8_python.py
+++ b/tvb_contrib/tvb/contrib/rateML/tmpl8_python.py
@@ -87,7 +87,6 @@ class ${modelname}(ModelNumbaDfun):
 %endfor
 ]
 
-    _nvar = ${dynamics.state_variables.__len__()}
     cvar = numpy.array([\
     % for i, itemF in enumerate(dynamics.state_variables):
 ${i},\

--- a/tvb_contrib/tvb/contrib/scripts/models/linear_with_stimulus.py
+++ b/tvb_contrib/tvb/contrib/scripts/models/linear_with_stimulus.py
@@ -78,7 +78,6 @@ class Linear(Linear):
 
     state_variables = ('R', 'Rin')
     integration_variables = ('R',)
-    _nvar = 2
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def update_derived_parameters(self):

--- a/tvb_contrib/tvb/contrib/scripts/models/reduced_wong_wang_exc_io.py
+++ b/tvb_contrib/tvb/contrib/scripts/models/reduced_wong_wang_exc_io.py
@@ -197,7 +197,6 @@ class ReducedWongWangExcIO(TVBReducedWongWang):
 
     state_variables = ['S', 'Rint', 'R', 'Rin', 'I']
     non_integrated_variables = ['R', 'Rin', 'I']
-    _nvar = 5
     cvar = numpy.array([0], dtype=numpy.int32)
     _R = None
     _Rin = None

--- a/tvb_contrib/tvb/contrib/scripts/models/reduced_wong_wang_exc_io_inh_i.py
+++ b/tvb_contrib/tvb/contrib/scripts/models/reduced_wong_wang_exc_io_inh_i.py
@@ -169,7 +169,6 @@ class ReducedWongWangExcIOInhI(TVBReducedWongWangExcInh):
 
     state_variables = ['S_e', 'S_i', 'R_e', 'R_i', 'Rin_e', 'Rin_i', 'I_e', 'I_i']
     non_integrated_variables = ['Rin_e', 'Rin_i', 'I_e', 'I_i']
-    _nvar = 8
     cvar = numpy.array([0], dtype=numpy.int32)
     _Rin = None
     _stimulus = 0.0

--- a/tvb_contrib/tvb/contrib/scripts/models/spiking_wong_wang_exc_io_inh_i.py
+++ b/tvb_contrib/tvb/contrib/scripts/models/spiking_wong_wang_exc_io_inh_i.py
@@ -335,7 +335,6 @@ class SpikingWongWangExcIOInhI(Model):
     state_variables = ["s_AMPA", "x_NMDA", "s_NMDA", "s_GABA", "s_AMPA_ext",  "V_m", "t_ref",     # state variables
                        "spikes_ext", "spikes", "I_L", "I_AMPA", "I_NMDA", "I_GABA", "I_AMPA_ext"]  # non-state variables
     non_integrated_variables = ["spikes_ext", "spikes", "I_L", "I_AMPA", "I_NMDA", "I_GABA", "I_AMPA_ext"]
-    _nvar = 14
     cvar = numpy.array([0], dtype=numpy.int32)
     number_of_modes = 200  # assuming that 0...N_E-1 are excitatory and N_E ... number_of_modes-1 are inhibitory
     _stimulus = 0.0

--- a/tvb_contrib/tvb/contrib/scripts/models/wilson_cowan_constraint.py
+++ b/tvb_contrib/tvb/contrib/scripts/models/wilson_cowan_constraint.py
@@ -187,7 +187,6 @@ class WilsonCowan(TVBWilsonCowan):
         doc="""default state variables to be monitored""")
 
     state_variables = ['E', 'I', 'Ein', 'Iin']
-    _nvar = 4
 
     def update_derived_parameters(self):
         """

--- a/tvb_contrib/tvb/contrib/simulator/models/brunel_wang.py
+++ b/tvb_contrib/tvb/contrib/simulator/models/brunel_wang.py
@@ -341,7 +341,6 @@ class BrunelWang(models.Model):
             The corresponding state-variable units for this model are kHz.""")
 
     state_variables = ["E", "I"]
-    _nvar = 2
     cvar = numpy.array([0, 1], dtype=numpy.int32)
 
     def configure(self):

--- a/tvb_contrib/tvb/contrib/simulator/models/epileptor.py
+++ b/tvb_contrib/tvb/contrib/simulator/models/epileptor.py
@@ -153,7 +153,6 @@ class HMJEpileptor(models.Model):
         doc="""default state variables to be monitored""")
 
     state_variables = ["y%d" % i for i in range(6)]
-    _nvar = 6
     cvar = numpy.array([0, 3], dtype=numpy.int32)
 
     def dfun(self, state_variables, coupling, local_coupling=0.0,

--- a/tvb_contrib/tvb/contrib/simulator/models/generic_2d_oscillator.py
+++ b/tvb_contrib/tvb/contrib/simulator/models/generic_2d_oscillator.py
@@ -135,7 +135,6 @@ class Generic2dOscillator(models.Model):
             history, it is also provides the default range of phase-plane plots.""")
 
     state_variables = ["V", "W"]
-    _nvar = 2
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def dfun(self, state_variables, coupling, local_coupling=0.0):

--- a/tvb_contrib/tvb/contrib/simulator/models/hindmarsh_rose.py
+++ b/tvb_contrib/tvb/contrib/simulator/models/hindmarsh_rose.py
@@ -135,7 +135,6 @@ class HindmarshRose(models.Model):
         :math:`y = 1`,and :math:`z = 2`.""")
 
     state_variables = ["x", "y", "z"]
-    _nvar = 3
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def dfun(self, state_variables, coupling, local_coupling=0.0):

--- a/tvb_contrib/tvb/contrib/simulator/models/jansen_rit_david.py
+++ b/tvb_contrib/tvb/contrib/simulator/models/jansen_rit_david.py
@@ -142,7 +142,6 @@ class JansenRitDavid(models.Model):
                                     :math:`y5 = 5`""")
 
     state_variables = ["x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7"]
-    _nvar = 8
     cvar = numpy.array([1, 2], dtype=numpy.int32)
 
     def dfun(self, state_variables, coupling, local_coupling=0.0):

--- a/tvb_contrib/tvb/contrib/simulator/models/larter.py
+++ b/tvb_contrib/tvb/contrib/simulator/models/larter.py
@@ -215,7 +215,6 @@ class Larter(models.Model):
         :math:`W = 1`, and :math:`Z = 2`.""")
 
     state_variables = ["V", "W", "Z"]
-    _nvar = 3
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def dfun(self, state_variables, coupling, local_coupling=0.0):

--- a/tvb_contrib/tvb/contrib/simulator/models/larter_breakspear.py
+++ b/tvb_contrib/tvb/contrib/simulator/models/larter_breakspear.py
@@ -363,7 +363,6 @@ class LarterBreakspear(models.Model):
             history, it is also provides the default range of phase-plane plots.""")
 
     state_variables = ["V", "W", "Z"]
-    _nvar = 3
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def dfun(self, state_variables, coupling, local_coupling=0.0):

--- a/tvb_contrib/tvb/contrib/simulator/models/liley_steynross.py
+++ b/tvb_contrib/tvb/contrib/simulator/models/liley_steynross.py
@@ -293,7 +293,6 @@ class LileySteynRoss(models.Model):
                                     and :math:`I = 1`.""")
 
     state_variables = ["he", "hi"]
-    _nvar = 2
     cvar = numpy.array([0, 1], dtype=numpy.int32)
 
     def dfun(self, state_variables, coupling, local_coupling=0.0):

--- a/tvb_contrib/tvb/contrib/simulator/models/morris_lecar.py
+++ b/tvb_contrib/tvb/contrib/simulator/models/morris_lecar.py
@@ -161,7 +161,6 @@ class MorrisLecar(models.Model):
         and :math:`N = 1`.""")
 
     state_variables = ["V", "N"]
-    _nvar = 2
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def dfun(self, state_variables, coupling, local_coupling=0.0):

--- a/tvb_contrib/tvb/contrib/simulator/models/wong_wang.py
+++ b/tvb_contrib/tvb/contrib/simulator/models/wong_wang.py
@@ -201,7 +201,6 @@ class WongWang(models.Model):
         doc="""default state variables to be monitored""")
 
     state_variables = ["S1", "S2"]
-    _nvar = 2
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def configure(self):

--- a/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/ReducedWongWang.py
+++ b/tvb_contrib/tvb/contrib/tests/cosimulation/parallel/ReducedWongWang.py
@@ -53,7 +53,6 @@ class ReducedWongWangProxy(ReducedWongWang):
     modify class in order to take in count proxy firing rate and to monitor the firing rate
     """
     state_variables = 'S H'.split()
-    _nvar = 2
     state_variable_range = Final(
         label="State variable ranges [lo, hi]",
         default={"S": numpy.array([0.0, 1.0]),

--- a/tvb_documentation/dsl/tvb_dsl.rst
+++ b/tvb_documentation/dsl/tvb_dsl.rst
@@ -88,7 +88,6 @@ translates to:
     )
     state_variables = ('x1', 'y1', ...)
 
-    _nvar = 2
     cvar = numpy.array([0], dtype=numpy.int32)
 
 

--- a/tvb_library/tvb/simulator/models/base.py
+++ b/tvb_library/tvb/simulator/models/base.py
@@ -45,8 +45,6 @@ class Model(HasTraits):
     state_variables = ()  # type: typing.Tuple[str]
     non_integrated_variables = None  # type: typing.Tuple[str]
     variables_of_interest = ()
-    _nvar = None   # todo make this a prop len(state_variables)
-    _nintvar = _nvar
     number_of_modes = 1
     cvar = None
     stvar = None

--- a/tvb_library/tvb/simulator/models/base.py
+++ b/tvb_library/tvb/simulator/models/base.py
@@ -108,6 +108,7 @@ class Model(HasTraits):
     @property
     def nvar(self):
         """ The number of state variables in this model. """
+        self._nvar = len(self.state_variables)
         return self._nvar
 
     @property

--- a/tvb_library/tvb/simulator/models/epileptor.py
+++ b/tvb_library/tvb/simulator/models/epileptor.py
@@ -269,7 +269,6 @@ class Epileptor(ModelNumbaDfun):
 
     state_variables = ('x1', 'y1', 'z', 'x2', 'y2', 'g')
 
-    _nvar = 6
     cvar = numpy.array([0, 3], dtype=numpy.int32)  # should these not be constant Attr's?
     cvar.setflags(write=False)  # todo review this
 
@@ -475,7 +474,6 @@ class Epileptor2D(ModelNumbaDfun):
 
     state_variables = ('x1', 'z')
 
-    _nvar = 2
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def _numpy_dfun(self, state_variables, coupling, local_coupling=0.0,

--- a/tvb_library/tvb/simulator/models/epileptor_rs.py
+++ b/tvb_library/tvb/simulator/models/epileptor_rs.py
@@ -295,7 +295,6 @@ class EpileptorRestingState(ModelNumbaDfun):
 
     state_variables = ("x1", "y1", "z", "x2", "y2", "g", "x_rs", "y_rs")
 
-    _nvar = 8                                           # number of state-variables
     cvar = numpy.array([0, 3, 6], dtype=numpy.int32)    # coupling variables
 
     def _numpy_dfun(self, state_variables, coupling, local_coupling=0.0,

--- a/tvb_library/tvb/simulator/models/epileptorcodim3.py
+++ b/tvb_library/tvb/simulator/models/epileptorcodim3.py
@@ -161,7 +161,6 @@ class EpileptorCodim3(ModelNumbaDfun):
     state_variables = ('x', 'y', 'z')
 
     # number of state variables
-    _nvar = 3
     cvar = numpy.array([0], dtype=numpy.int32)
 
     # If there are derived parameters from the predefined parameters, then initialize them to None
@@ -486,7 +485,6 @@ class EpileptorCodim3SlowMod(ModelNumbaDfun):
     state_variables = ('x', 'y', 'z', 'uA', 'uB')
 
     # number of state variables
-    _nvar = 5
     cvar = numpy.array([0], dtype=numpy.int32)
 
     # If there are derived parameters from the predefined parameters, then initialize them to None

--- a/tvb_library/tvb/simulator/models/hopfield.py
+++ b/tvb_library/tvb/simulator/models/hopfield.py
@@ -132,7 +132,6 @@ class Hopfield(Model):
 
     state_variables = ('x', 'theta')
 
-    _nvar = 2
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def configure(self):
@@ -140,7 +139,6 @@ class Hopfield(Model):
         super(Hopfield, self).configure()
         if self.dynamic:
             self.dfun = self.dfunDyn
-            self._nvar = 2
             self.cvar = numpy.array([0, 1], dtype=numpy.int32)
             # self.variables_of_interest = ["x", "theta"]
 

--- a/tvb_library/tvb/simulator/models/infinite_theta.py
+++ b/tvb_library/tvb/simulator/models/infinite_theta.py
@@ -162,7 +162,6 @@ class MontbrioPazoRoxin(Model):
         default='tau Delta eta J I cr cv'.split())
 
     state_variables = ('r', 'V')
-    _nvar = 2
     # Cvar is the coupling variable. 
     cvar = numpy.array([0, 1], dtype=numpy.int32)
     # Stvar is the variable where stimulus is applied.
@@ -298,7 +297,6 @@ class CoombesByrne(Model):
     )
 
     state_variables = ('r', 'V', 'g', 'q')
-    _nvar = 4
     # Cvar is the coupling variable. 
     cvar = numpy.array([0, 1, 2, 3], dtype=numpy.int32)
 
@@ -410,7 +408,6 @@ class CoombesByrne2D(Model):
     )
 
     state_variables = ('r', 'V')
-    _nvar = 2
     # Cvar is the coupling variable. 
     cvar = numpy.array([0, 1], dtype=numpy.int32)
 
@@ -560,7 +557,6 @@ class GastSchmidtKnosche_SD(Model):
     )
 
     state_variables = ('r', 'V', 'A', 'B')
-    _nvar = 4
     # Cvar is the coupling variable. 
     cvar = numpy.array([0, 1, 2, 3], dtype=numpy.int32)
 
@@ -719,7 +715,6 @@ class GastSchmidtKnosche_SF(Model):
     )
 
     state_variables = ('r', 'V', 'A', 'B')
-    _nvar = 4
     # Cvar is the coupling variable. 
     cvar = numpy.array([0, 1, 2, 3], dtype=numpy.int32)
 
@@ -917,7 +912,6 @@ class DumontGutkin(Model):
     )
 
     state_variables = ('r_e', 'V_e', 's_ee', 's_ei', 'r_i', 'V_i', 's_ie', 's_ii')
-    _nvar = 8
     # Cvar is the coupling variable. 
     cvar = numpy.array([0, 1, 4, 5], dtype=numpy.int32)
 

--- a/tvb_library/tvb/simulator/models/jansen_rit.py
+++ b/tvb_library/tvb/simulator/models/jansen_rit.py
@@ -198,7 +198,6 @@ class JansenRit(ModelNumbaDfun):
                                     :math:`y5 = 5`""")
 
     state_variables = tuple('y0 y1 y2 y3 y4 y5'.split())
-    _nvar = 6
     cvar = numpy.array([1, 2], dtype=numpy.int32)
 
     def _numpy_dfun(self, state_variables, coupling, local_coupling=0.0):
@@ -467,7 +466,6 @@ class ZetterbergJansen(Model):
                                     :math:`v_5 = 5`""")
 
     state_variables = tuple('v1 y1 v2 y2 v3 y3 v4 y4 v5 y5 v6 v7'.split())
-    _nvar = 12
     cvar = numpy.array([10], dtype=numpy.int32)
     Heke = None  # self.He * self.ke
     Hiki = None  # self.Hi * self.ki

--- a/tvb_library/tvb/simulator/models/k_ion_exchange.py
+++ b/tvb_library/tvb/simulator/models/k_ion_exchange.py
@@ -202,7 +202,6 @@ class KIonEx(Model):
     )
 
     state_variables = ['x', 'V','n','DKi','Kg']
-    _nvar = 5
     # Cvar is the coupling variable. 
     cvar = numpy.array([0], dtype=numpy.int32)
     # Stvar is the variable where stimulus is applied.

--- a/tvb_library/tvb/simulator/models/larter_breakspear.py
+++ b/tvb_library/tvb/simulator/models/larter_breakspear.py
@@ -431,7 +431,6 @@ class LarterBreakspear(Model):
 
     state_variables = tuple('V W Z'.split())
     _state_variables = ("V", "W", "Z")
-    _nvar = 3
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def dfun(self, state_variables, coupling, local_coupling=0.0):

--- a/tvb_library/tvb/simulator/models/linear.py
+++ b/tvb_library/tvb/simulator/models/linear.py
@@ -71,7 +71,6 @@ class Linear(Model):
         default=tuple('gamma'.split()))
 
     state_variables = ('x',)
-    _nvar = 1
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def dfun(self, state, coupling, local_coupling=0.0):

--- a/tvb_library/tvb/simulator/models/oscillator.py
+++ b/tvb_library/tvb/simulator/models/oscillator.py
@@ -323,7 +323,6 @@ class Generic2dOscillator(ModelNumbaDfun):
         doc="The quantities of interest for monitoring for the generic 2D oscillator.")
 
     state_variables = ('V', 'W')
-    _nvar = 2
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def _numpy_dfun(self, state_variables, coupling, local_coupling=0.0):
@@ -452,7 +451,6 @@ class Kuramoto(Model):
                             is not necessary to change the default here.""")
 
     state_variables = ['theta']
-    _nvar = 1
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def dfun(self, state_variables, coupling, local_coupling=0.0,
@@ -538,16 +536,15 @@ class SupHopf(ModelNumbaDfun):
                conditions when the simulation isn't started from an explicit
                history, it is also provides the default range of phase-plane plots.""")
 
+    state_variables = 'x y'.split(' ')
+
     variables_of_interest = List(
         of=str,
         label="Variables watched by Monitors",
-        choices=("x", "y"),
+        choices=state_variables,
         default=("x",),
         doc="Quantities of supHopf available to monitor.")
 
-    state_variables = ["x", "y"]
-
-    _nvar = 2  # number of state-variables
     cvar = numpy.array([0, 1], dtype=numpy.int32)  # coupling variables
 
     def _numpy_dfun(self, state_variables, coupling, local_coupling=0.0,

--- a/tvb_library/tvb/simulator/models/stefanescu_jirsa.py
+++ b/tvb_library/tvb/simulator/models/stefanescu_jirsa.py
@@ -167,18 +167,18 @@ class ReducedSetFitzHughNagumo(ReducedSetBase):
         conditions when the simulation isn't started from an explicit history,
         it is also provides the default range of phase-plane plots.""")
 
+    state_variables = 'xi eta alpha beta'.split()
+
     variables_of_interest = List(
         of=str,
         label="Variables watched by Monitors",
-        choices=("xi", "eta", "alpha", "beta"),
+        choices=state_variables,
         default=("xi", "alpha"),
         doc=r"""This represents the default state-variables of this Model to be
                 monitored. It can be overridden for each Monitor if desired. The
                 corresponding state-variable indices for this model are :math:`\xi = 0`,
                 :math:`\eta = 1`, :math:`\alpha = 2`, and :math:`\beta= 3`.""")
 
-    state_variables = tuple('xi eta alpha beta'.split())
-    _nvar = 4
     cvar = numpy.array([0, 2], dtype=numpy.int32)
     # Derived parameters
     Aik = None
@@ -466,7 +466,6 @@ class ReducedSetHindmarshRose(ReducedSetBase):
                 :math:`\beta = 4`, and :math:`\gamma = 5`""")
 
     state_variables = 'xi eta tau alpha beta gamma'.split()
-    _nvar = 6
     cvar = numpy.array([0, 3], dtype=numpy.int32)
     # derived parameters
     A_ik = None

--- a/tvb_library/tvb/simulator/models/wilson_cowan.py
+++ b/tvb_library/tvb/simulator/models/wilson_cowan.py
@@ -371,7 +371,6 @@ class WilsonCowan(ModelNumbaDfun):
                and :math:`I = 1`.""")
 
     state_variables = 'E I'.split()
-    _nvar = 2
     cvar = numpy.array([0, 1], dtype=numpy.int32)
 
     def _numpy_dfun(self, state_variables, coupling, local_coupling=0.0):

--- a/tvb_library/tvb/simulator/models/wong_wang.py
+++ b/tvb_library/tvb/simulator/models/wong_wang.py
@@ -140,7 +140,6 @@ class ReducedWongWang(ModelNumbaDfun):
         doc="""default state variables to be monitored""")
 
     state_variables = ['S']
-    _nvar = 1
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def configure(self):

--- a/tvb_library/tvb/simulator/models/wong_wang_exc_inh.py
+++ b/tvb_library/tvb/simulator/models/wong_wang_exc_inh.py
@@ -227,7 +227,6 @@ class ReducedWongWangExcInh(ModelNumbaDfun):
         doc="""default state variables to be monitored""")
 
     state_variables = ['S_e', 'S_i']
-    _nvar = 2
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def configure(self):

--- a/tvb_library/tvb/simulator/models/zerlaut.py
+++ b/tvb_library/tvb/simulator/models/zerlaut.py
@@ -376,7 +376,6 @@ class ZerlautAdaptationFirstOrder(Model):
             the boundaries of the dynamic range of that state-variable. Set None for one-sided boundaries""")
 
     state_variables = 'E I W_e W_i ou_drift'.split()
-    _nvar = 5
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def dfun(self, state_variables, coupling, local_coupling=0.00):
@@ -677,7 +676,6 @@ class ZerlautAdaptationSecondOrder(ZerlautAdaptationFirstOrder):
                :math:`I = 1`, :math:`C_ee = 2`, :math:`C_ei = 3`, :math:`C_ii = 4` and :math:`W = 5`.""")
 
     state_variables = 'E I C_ee C_ei C_ii W_e W_i ou_drift'.split()
-    _nvar = 8
 
     def dfun(self, state_variables, coupling, local_coupling=0.00):
         r"""

--- a/tvb_library/tvb/tests/library/simulator/history_test.py
+++ b/tvb_library/tvb/tests/library/simulator/history_test.py
@@ -54,7 +54,6 @@ class IdCoupling(SparseCoupling):
 
 class Sum(Model):
     nvar = 1
-    _nvar = 1
     state_variable_range = {'x': [0, 100]}
     variables_of_interest = List(of=str, default=('x',), choices=('x',))
     state_variables = ('x',)

--- a/tvb_library/tvb/tests/library/simulator/models_test.py
+++ b/tvb_library/tvb/tests/library/simulator/models_test.py
@@ -66,7 +66,6 @@ class ModelTestBounds(Model):
             "x4": numpy.array([-1.0, 2.0]),
             "x5": numpy.array([-1.0, 2.0])
         })
-    _nvar = 5
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def dfun(self, state, node_coupling, local_coupling=0.0):
@@ -93,7 +92,6 @@ class ModelTestUpdateVariables(Model):
             "x4": numpy.array([-1.0, 2.0]),
             "x5": numpy.array([-1.0, 2.0])
         })
-    _nvar = 5
     cvar = numpy.array([0], dtype=numpy.int32)
 
     def dfun(self, integrated_variables, node_coupling, local_coupling=0.0):


### PR DESCRIPTION
This follows up on #550 as a minor maintenance PR to make `model.nvar` a property derived from `model.state_variables`, most changes are removing the hard coded property from models.