### PR TITLE
another take on hybrid models

### DIFF
--- a/tvb_library/tvb/simulator/hybrid.py
+++ b/tvb_library/tvb/simulator/hybrid.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+#
+#
+# TheVirtualBrain-Scientific Package. This package holds all simulators, and
+# analysers necessary to run brain-simulations. You can use it stand alone or
+# in conjunction with TheVirtualBrain-Framework Package. See content of the
+# documentation-folder for more details. See also http://www.thevirtualbrain.org
+#
+# (c) 2012-2024, Baycrest Centre for Geriatric Care ("Baycrest") and others
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this
+# program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+#   CITATION:
+# When using The Virtual Brain for scientific publications, please cite it as explained here:
+# https://www.thevirtualbrain.org/tvb/zwei/neuroscience-publications
+#
+#
+
+"""
+This modules defines a set of classes for hybrid-model simulation.
+
+.. moduleauthor:: Marmaduke Woodman <marmaduke.woodman@univ-amu.fr>
+
+"""
+
+import collections
+import numpy as np
+import tvb.basic.neotraits.api as t
+from tvb.datatypes.connectivity import Connectivity
+from tvb.simulator.models import Model
+
+
+class Subnetwork(t.HasTraits):
+    "Represents a subnetwork of a connectome."
+
+    conn: Connectivity = t.Attr(Connectivity, required=True)
+    mask: np.ndarray = t.NArray(dtype=np.bool_, required=True)
+    name: str = t.Attr(str)
+    model: Model = t.Attr(Model, required=True)
+
+    def zero_states(self) -> np.ndarray:
+        return np.zeros((self.model.nvar, self.mask.sum()))
+
+    def zero_cvars(self) -> np.ndarray:
+        return np.zeros((self.model.cvar.size, self.mask.sum()))
+
+
+class Projection(t.HasTraits):
+    """Represents a projection from a source subnetwork to a target
+    subnetwork, specifying indices of coupling variables."""
+
+    source: Subnetwork = t.Attr(Subnetwork, required=True)
+    target: Subnetwork = t.Attr(Subnetwork, required=True)
+    source_cvar: int = t.Int(required=True)
+    target_cvar: int = t.Int(required=True)
+    scale: float = t.Float(default=1.0)
+
+    # if not provided, default to source.conn
+    conn: Connectivity = t.Attr(Connectivity)
+
+    # cfun = t.Attr(tvb.coupling.Coupling)  # TODO
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        assert (self.source.mask * self.target.mask).sum() == 0, 'overlap'
+        assert self.source.conn.gid == self.target.conn.gid
+        try:
+            self.conn
+        except:
+            self.conn = self.source.conn
+        self._weights = self.conn.weights[self.target.mask][:, self.source.mask]
+        # TODO time delays
+
+    def apply(self, tgt, src):
+        tgt[self.target_cvar] += self.scale * src[self.source_cvar] @ self._weights.T
+
+
+class NetworkSet(t.HasTraits):
+    """Collects subnetworks & projections, with methods for evaluating
+    full network coupling and time stepping.
+    """
+    subnets: [Subnetwork] = t.List(of=Subnetwork)
+    projections: [Subnetwork] = t.List(of=Projection)
+
+    # NOTE dynamically generated namedtuple based on subnetworks
+    States: collections.namedtuple = None
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.States = collections.namedtuple(
+            'States',
+            ' '.join([_.name for _ in self.subnets]))
+        self.States.shape = property(lambda self: [_.shape for _ in self])
+
+    def zero_states(self) -> States:
+        return self.States(*[_.zero_states() for _ in self.subnets])
+
+    def zero_cvars(self) -> States:
+        return self.States(*[_.zero_cvars() for _ in self.subnets])
+
+    def cfun(self, eff: States) -> States:
+        "applies all projections to compute total coupling."
+        aff = self.zero_cvars()
+        for p in self.projections:
+            tgt = getattr(aff, p.target.name)
+            src = getattr(eff, p.source.name)
+            p.apply(tgt, src)
+        return aff
+
+    def step(self, scheme, xs: States) -> States:
+        cs = self.cfun(xs)
+        nxs = self.zero_states()
+        for sn, nx, x, c in zip(self.subnets, nxs, xs, cs):
+            nx[:] = scheme(x[..., None],
+                           sn.model.dfun,
+                           c[..., None], 0, 0)[:, :, 0]
+        return nxs
+

--- a/tvb_library/tvb/tests/library/simulator/hybrid_test.py
+++ b/tvb_library/tvb/tests/library/simulator/hybrid_test.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+#
+#
+#  TheVirtualBrain-Contributors Package. This package holds simulator extensions.
+#  See also http://www.thevirtualbrain.org
+#
+# (c) 2012-2025, Baycrest Centre for Geriatric Care ("Baycrest") and others
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this
+# program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+#   CITATION:
+# When using The Virtual Brain for scientific publications, please cite it as explained here:
+# https://www.thevirtualbrain.org/tvb/zwei/neuroscience-publications
+
+"""
+.. moduleauthor:: Marmaduke Woodman <marmaduke.woodman@univ-amu.fr>
+
+"""
+
+import numpy as np
+from tvb.simulator.hybrid import NetworkSet, Subnetwork, Projection
+from tvb.datatypes.connectivity import Connectivity
+from tvb.simulator.models import JansenRit, WilsonCowan
+from tvb.simulator.integrators import HeunDeterministic
+from tvb.tests.library.base_testcase import BaseTestCase
+
+
+class TestHybrid1(BaseTestCase):
+    
+    def setup(self):
+        conn = Connectivity.from_file()
+        conn.configure()
+        np.random.seed(42)
+
+        # XXX not sure what user api is warranted here
+        class AtlasPart:
+            CORTEX = 0
+            THALAMUS = 1
+
+        ix = np.random.randint(
+            low=0, high=2, size=conn.number_of_regions)
+
+        cortex = Subnetwork(
+            conn=conn,
+            mask=ix == AtlasPart.CORTEX,
+            name='cortex',
+            model=JansenRit()
+        )
+
+        thalamus = Subnetwork(
+            conn=conn,
+            mask=ix == AtlasPart.THALAMUS,
+            name='thalamus',
+            model=WilsonCowan()
+        )
+
+        return conn, ix, cortex, thalamus, AtlasPart
+
+    def test_subnetwork(self):
+        conn, ix, c, t, a = self.setup()
+        self.assert_equal((6, (ix == a.CORTEX).sum()), c.zero_states().shape)
+        self.assert_equal((2, (ix == a.CORTEX).sum()), c.zero_cvars().shape)
+        self.assert_equal((2, (ix == a.THALAMUS).sum()), t.zero_states().shape)
+
+    # TODO test_projection, but networkset tests projection
+
+    def test_networkset(self):
+        conn, ix, cortex, thalamus, a = self.setup()
+        nets = NetworkSet(
+            subnets=[cortex, thalamus],
+            projections=[
+                Projection(source=cortex, target=thalamus, source_cvar=0, target_cvar=1),
+                Projection(source=cortex, target=thalamus, source_cvar=5, target_cvar=0),
+                Projection(source=thalamus, target=cortex, source_cvar=0, target_cvar=1, scale=1e-2),
+            ]
+        )
+        nets.projections[1]._weights *= 0.5
+
+        x = nets.zero_states()
+        x.cortex[:] += 1
+        x.thalamus[0] += 1
+
+        c0 = nets.zero_cvars()
+        p: Projection = nets.projections[0]
+        c0.thalamus[1] += x.cortex[0] @ p._weights.T * p.scale
+        p: Projection = nets.projections[1]
+        c0.thalamus[0] += x.cortex[5] @ p._weights.T * p.scale
+        p: Projection = nets.projections[2]
+        c0.cortex[1] += x.thalamus[0] @ p._weights.T * p.scale
+
+        c1 = nets.cfun(x)
+
+        for c0_, c1_ in zip(c0, c1):
+            np.testing.assert_allclose(c0_, c1_)
+
+    def test_netset_step(self):
+        conn, ix, cortex, thalamus, a = self.setup()
+        nets = NetworkSet(
+            subnets=[cortex, thalamus],
+            projections=[
+                Projection(source=cortex, target=thalamus, source_cvar=0, target_cvar=1),
+                Projection(source=cortex, target=thalamus, source_cvar=5, target_cvar=0),
+                Projection(source=thalamus, target=cortex, source_cvar=0, target_cvar=1, scale=1e-2),
+            ]
+        )
+        x = nets.zero_states()
+        heun = HeunDeterministic(dt=1e-3)
+        nx = nets.step(heun.scheme, x)
+        self.assert_equal(
+            [(6, 37), (2, 39)], nx.shape
+        )
+        


### PR DESCRIPTION
This is a another take on hybrid models, where multiple models are used at once, which is a more array oriented than #739 and closer to TVB style with traits etc.  It introduces the following elements to the TVB datatypes (naming suggestions welcome)

- *subnetwork*: compromises a set of nodes by combining a connectivity with a mask
- *projection*: connects a cvar from a source subnet to a cvar in a target subnet
- *networkset*: collects subnetworks and projections into a coherent whole where we can
  - compute the coupling across all projections
  - compute all dfuns
  - apply an integration scheme to all dfuns to take a step in time

From there, it turns out that flexible state shapes creates surprise in many places, where it's assumed that the state variables are homogenous across nodes.  For instance, the integrator noise is set per state variable, however in different models, these need to be set with different values.

Other major nuances are related to monitors, but I think some straightforward compromises are available:  for "debug" monitors like raw or temporal average, the monitor will be applied per model to produce a per-subnetwork trace.  Monitors more "neuroimaging" like will choose a particular state variable and apply the forward model (gain matrix, BOLD equations) to it.

Stimulation is another open question, but I wonder if, deparating from the monolithic style, a stimulus cannot just be a "subnetwork" with a projection to the nodes being stimulated? Ideas welcome.

Performance is terrible w/ ~5-10k iter/s on default connectome w/ two models, but this is expected w/ the naive implementation and will improve dramatically after massaging for jax or a c++ impl.

@i-Zaak @ReyJ94 feedback welcome!