### PR TITLE
[ISSUE-544] improve speed of reduced set models

### DIFF
--- a/tvb_library/tvb/simulator/models/_dfun_stefanescu_jirsa.py
+++ b/tvb_library/tvb/simulator/models/_dfun_stefanescu_jirsa.py
@@ -1,0 +1,82 @@
+import numba as nb
+import numpy as np
+
+
+def dfun_fitzhughnaguma(state_variables, coupling, local_coupling, tau, e_i, K11, Aik, K12, Bik, IE_i, 
+               b, m_i, K21, Cik, II_i, f_i, n_i):
+    xi = state_variables[0, :]
+    eta = state_variables[1, :]
+    alpha = state_variables[2, :]
+    beta = state_variables[3, :]
+    derivative = np.empty_like(state_variables)
+
+    # Sum the activity from the modes
+    c_0 = coupling[0, :].sum(axis=1)[:, np.newaxis]
+
+    # Compute derivatives
+    derivative[0] = (
+        tau * (xi - e_i * xi ** 3 / 3.0 - eta)
+        + K11 * (np.dot(xi, Aik) - xi)
+        - K12 * (np.dot(alpha, Bik) - xi)
+        + tau * (IE_i + c_0 + local_coupling * xi)
+    )
+
+    derivative[1] = (xi - b * eta + m_i) / tau
+
+    derivative[2] = (
+        tau * (alpha - f_i * alpha ** 3 / 3.0 - beta)
+        + K21 * (np.dot(xi, Cik) - alpha)
+        + tau * (II_i + c_0 + local_coupling * xi)
+    )
+
+    derivative[3] = (alpha - b * beta + n_i) / tau
+
+    return derivative
+
+_dfun_fitzhughnaguma_numba = nb.njit(dfun_fitzhughnaguma)
+def dfun_fitzhughnaguma_numba(state_variables, coupling, local_coupling, tau, e_i, K11, Aik, K12, Bik, IE_i, 
+               b, m_i, K21, Cik, II_i, f_i, n_i):
+    return _dfun_fitzhughnaguma_numba(state_variables, coupling, local_coupling,
+                                      tau, e_i, K11, Aik, K12, Bik, IE_i, b,
+                                      m_i, K21, Cik, II_i, f_i, n_i)
+
+def dfun_hindmarshrose(state_variables, coupling, local_coupling, r, a_i, b_i, c_i, d_i, s, K11, A_ik, K12, B_ik, IE_i, m_i, K21, C_ik, II_i, e_i, f_i, h_i, p_i, n_i):
+    xi = state_variables[0, :]
+    eta = state_variables[1, :]
+    tau = state_variables[2, :]
+    alpha = state_variables[3, :]
+    beta = state_variables[4, :]
+    gamma = state_variables[5, :]
+    derivative = np.empty_like(state_variables)
+
+    c_0 = coupling[0, :].sum(axis=1)[:, np.newaxis]
+    # c_1 = coupling[1, :]
+
+    derivative[0] = (eta - a_i * xi ** 3 + b_i * xi ** 2 - tau +
+            K11 * (np.dot(xi, A_ik) - xi) -
+            K12 * (np.dot(alpha, B_ik) - xi) +
+            IE_i + c_0 + local_coupling * xi)
+
+    derivative[1] = c_i - d_i * xi ** 2 - eta
+
+    derivative[2] = r * s * xi - r * tau - m_i
+
+    derivative[3] = (beta - e_i * alpha ** 3 + f_i * alpha ** 2 - gamma +
+                K21 * (np.dot(xi, C_ik) - alpha) +
+                II_i + c_0 + local_coupling * xi)
+
+    derivative[4] = h_i - p_i * alpha ** 2 - beta
+
+    derivative[5] = r * s * alpha - r * gamma - n_i
+
+    return derivative
+
+_dfun_hindmarshrose_numba = nb.njit(dfun_hindmarshrose)
+@nb.njit
+def dfun_hindmarshrose_numba(state_variables, coupling, local_coupling, r, a_i, b_i, c_i, d_i, s, K11, A_ik, K12, B_ik, IE_i, m_i, K21, C_ik, II_i, e_i, f_i, h_i, p_i, n_i):
+    return _dfun_hindmarshrose_numba(state_variables, coupling, local_coupling,
+                                      r, a_i, b_i, c_i, d_i, s, K11, A_ik,
+                                      K12, B_ik, IE_i, m_i, K21, C_ik, II_i,
+                                      e_i, f_i, h_i, p_i, n_i)
+
+

--- a/tvb_library/tvb/tests/library/simulator/models_benchmark.py
+++ b/tvb_library/tvb/tests/library/simulator/models_benchmark.py
@@ -1,0 +1,78 @@
+import numpy as np
+import time
+from tvb.tests.library.base_testcase import BaseTestCase
+from tvb.simulator.models.stefanescu_jirsa import ReducedSetFitzHughNagumo
+from tvb.simulator.models.stefanescu_jirsa import ReducedSetHindmarshRose
+from tvb.simulator.models.base import Model
+
+
+class TestBenchmarkModels(BaseTestCase):
+    """Test cases that benchmark the performance of models' implementation
+    """
+
+    def randn_state_for_model(self, model: Model, n_node):
+        shape = (model.nvar, n_node, model.number_of_modes)
+        state = np.random.randn(*shape)
+        return state
+
+
+    def zero_coupling_for_model(self, model: Model, n_node):
+        n_cvar = len(model.cvar)
+        shape = (n_cvar, n_node, model.number_of_modes)
+        coupling = np.zeros(shape)
+        return coupling
+
+    def eps_for_model(self, model: Model, n_node, time_limit=0.5, state=None, coupling=None):
+        model.configure()
+        if state is None:
+            state = self.randn_state_for_model(model, n_node)
+        if coupling is None:
+            coupling = self.zero_coupling_for_model(model, n_node)
+        # throw one away in case of initialization
+        model.dfun(state, coupling)
+        # start timing
+        tic = time.time()
+        n_eval = 0
+        while (time.time() - tic) < time_limit:
+            model.dfun(state, coupling)
+            n_eval += 1
+        toc = time.time()
+        return n_eval / (toc - tic)
+
+    def test_reduced_set_fitz_hugh_nagumo_when_using_numba_improve_performance(self):
+        #  create, & initialize numba & no-numba models
+        rs_fhn_model = ReducedSetFitzHughNagumo()
+        n_node = 10
+        state = self.randn_state_for_model(rs_fhn_model, n_node)
+        coupling = self.zero_coupling_for_model(rs_fhn_model, n_node)
+
+        rs_fhn_model.use_numba = False
+        no_numba_performance = self.eps_for_model(rs_fhn_model, 10, state=state, coupling=coupling)
+        no_numba_dfun_derivative = rs_fhn_model.dfun(state, coupling)
+        rs_fhn_model.use_numba = True
+        numba_performance = self.eps_for_model(rs_fhn_model, 10, state=state, coupling=coupling)
+        numba_dfun_derivative = rs_fhn_model.dfun(state, coupling)
+        speedup = numba_performance / no_numba_performance
+        print(f"speedup: {speedup}")
+        print(f"no_numba_performance: {no_numba_performance}, numba_performance: {numba_performance}")
+        assert speedup > 1
+        assert np.allclose(no_numba_dfun_derivative, numba_dfun_derivative)
+
+    def test_reduced_set_hindmarsh_rose_when_using_numba_improve_performance(self):
+        #  create, & initialize numba & no-numba models
+        rs_hr_model = ReducedSetHindmarshRose()
+        n_node = 10
+        state = self.randn_state_for_model(rs_hr_model, n_node)
+        coupling = self.zero_coupling_for_model(rs_hr_model, n_node)
+
+        rs_hr_model.use_numba = False
+        no_numba_performance = self.eps_for_model(rs_hr_model, 10, state=state, coupling=coupling)
+        no_numba_dfun_derivative = rs_hr_model.dfun(state, coupling)
+        rs_hr_model.use_numba = True
+        numba_performance = self.eps_for_model(rs_hr_model, 10, state=state, coupling=coupling)
+        numba_dfun_derivative = rs_hr_model.dfun(state, coupling)
+        speedup = numba_performance / no_numba_performance
+        print(f"speedup: {speedup}")
+        print(f"no_numba_performance: {no_numba_performance}, numba_performance: {numba_performance}")
+        assert speedup > 1
+        assert np.allclose(no_numba_dfun_derivative, numba_dfun_derivative)


### PR DESCRIPTION
Reduced Set models don't use numba for enhanced performance. This uses numba njit wrapper to compile the deriviative functions during runtime, and provide considerable performance gain.

Since numba currently doesn't fully support jit-ed classes, derivative functions have to move outside the class scope. To improved readability, they were moved to a new file: _dfun_stefanescu_jirsa.py.

To test the changes a new unit test module was added: models_benchmark.py. Here, we compute the derivative multiple times within a time window with/without numba and compare the throughput. Around 5x performance gains were observed. We also verify that numba doesn't change derivative values.