### PR TITLE
VT-123. Add newest Julich Parcellation (3.1) to Siibra Connectivity page

### DIFF
--- a/tvb_framework/tvb/adapters/creators/siibra_base.py
+++ b/tvb_framework/tvb/adapters/creators/siibra_base.py
@@ -54,9 +54,9 @@ HUMAN_ATLAS = 'Multilevel Human Atlas'  # DEFAULT, only this atlas has Struct. C
 
 # parcellations
 JULICH_3 = get_last_version('Julich-Brain Cytoarchitectonic Atlas')  # DEFAULT
-JULICH_3_0_3 = 'Julich-Brain Cytoarchitectonic Atlas (v3.0.3)'  # DEFAULT
+JULICH_3_0_3 = 'Julich-Brain Cytoarchitectonic Atlas (v3.0.3)'
 JULICH_2_9 = 'Julich-Brain Cytoarchitectonic Atlas (v2.9)'
-parcellations = [JULICH_3, JULICH_2_9]
+parcellations = [JULICH_3, JULICH_3_0_3, JULICH_2_9]
 
 # cohorts
 HCP_COHORT = 'HCP'  # DEFAULT
@@ -255,7 +255,7 @@ def get_connectivity_matrix(parcellation, cohort, subjects, component):
             break
 
     if conn_for_cohort is None:
-        raise AttributeError(f"NO {modality} was found for cohort {cohort}")
+        raise AttributeError(f"No {modality} was found for cohort {cohort}")
 
     # for 1000BRAINS cohort, if the user did not specify a suffix (_1, _2), get all the possible ids for that subject
     if cohort == THOUSAND_BRAINS_COHORT and subjects is not None:
@@ -264,7 +264,12 @@ def get_connectivity_matrix(parcellation, cohort, subjects, component):
 
     # get the conn. matrices for each specified subject
     for s in subjects:
-        conn = [c for c in conn_for_cohort if c.subject == s][0]
+        conn = [c for c in conn_for_cohort if c.subject == s]
+        print(conn)
+        if not conn:
+            raise ValueError(f"No subject with ID {s} were found for cohort {cohort} and parcellation {parcellation}")
+        else:
+            conn = conn[0]
         matrix = conn.data
         conn_matrices[s] = matrix
         LOGGER.info(f'{component.name} for subject {s} retrieved successfully.')

--- a/tvb_framework/tvb/adapters/creators/siibra_base.py
+++ b/tvb_framework/tvb/adapters/creators/siibra_base.py
@@ -265,9 +265,8 @@ def get_connectivity_matrix(parcellation, cohort, subjects, component):
     # get the conn. matrices for each specified subject
     for s in subjects:
         conn = [c for c in conn_for_cohort if c.subject == s]
-        print(conn)
         if not conn:
-            raise ValueError(f"No subject with ID {s} were found for cohort {cohort} and parcellation {parcellation}")
+            raise ValueError(f"No subject with ID {s} was found for cohort {cohort} and parcellation {parcellation}")
         else:
             conn = conn[0]
         matrix = conn.data

--- a/tvb_framework/tvb/adapters/creators/siibra_creator.py
+++ b/tvb_framework/tvb/adapters/creators/siibra_creator.py
@@ -51,7 +51,7 @@ def init_siibra_options():
     future.
     """
     atlases = [siibra_base.HUMAN_ATLAS]
-    parcellations = [siibra_base.JULICH_3_0_3 , siibra_base.JULICH_2_9]
+    parcellations = [siibra_base.JULICH_3, siibra_base.JULICH_3_0_3 , siibra_base.JULICH_2_9]
     cohorts = [siibra_base.HCP_COHORT, siibra_base.THOUSAND_BRAINS_COHORT]
 
     # create dicts needed for TVB Enums
@@ -82,7 +82,7 @@ class SiibraModel(ViewModel):
 
     parcellation = EnumAttr(
         field_type=PARCELLATION_OPTS,
-        default=PARCELLATION_OPTS[siibra_base.JULICH_3_0_3],
+        default=PARCELLATION_OPTS[siibra_base.JULICH_3],
         label='Parcellation',
         required=True,
         doc='Parcellation to be used'
@@ -99,11 +99,12 @@ class SiibraModel(ViewModel):
     subject_ids = Str(
         label='Subjects',
         required=True,
-        default='000',
+        default='101309',
         doc="""The list of all subject IDs for which the structural and optionally functional connectivities are 
         computed. Depending on the selected cohort, you can specify the IDs in the following ways: <br/>
-        a) For the "HCP" cohort, the subject IDs are: 000,001,002, etc. Each subject has exactly one 
-        subject ID associated to them. Thus, there are 3 ways to specify the IDs:<br/>
+        a) For the "HCP" cohort, the subject IDs are: 000,001,002, etc. (Julich 2.9 & 3.0.3), 
+        101309, 102008, etc. (Julich 3.1). Each subject has exactly one subject ID associated to them. 
+        Thus, there are 3 ways to specify the IDs:<br/>
         1. individually, delimited by a semicolon symbol: 000;001;002. <br/>
         2. As a range, specifying the first and last IDs: 000-050 will retrieve all the subjects starting with 
         subject 000 until subject 050 (51 subjects). <br/>

--- a/tvb_framework/tvb/tests/framework/adapters/creators/siibra_base_test.py
+++ b/tvb_framework/tvb/tests/framework/adapters/creators/siibra_base_test.py
@@ -38,7 +38,7 @@ HUMAN_ATLAS = 'Multilevel Human Atlas'
 MONKEY_ATLAS = 'Monkey Atlas'
 JULICH_PARCELLATION_3_0 = 'Julich 3.0'
 MONKEY_PARCELLATION = 'MEBRAINS population-based monkey parcellation'
-DEFAULT_HCP_SUBJECT = ['000']
+DEFAULT_HCP_SUBJECT = ['101309']
 DEFAULT_1000BRAINS_SUBJECT = ['0001_1']
 
 
@@ -193,20 +193,20 @@ class TestSiibraBase(BaseTestCase):
         """
         Test the retrieval of structural connectivities (weights and tracts) and functional connectivities
         """
-        weights = sb.get_connectivity_matrix(self.julich_parcellation_3_0, sb.HCP_COHORT, DEFAULT_HCP_SUBJECT,
+        weights = sb.get_connectivity_matrix(self.julich_parcellation_3_1, sb.HCP_COHORT, DEFAULT_HCP_SUBJECT,
                                              sb.Component2Modality.WEIGHTS)
         assert len(weights) > 0
         assert DEFAULT_HCP_SUBJECT[0] in weights
         assert isinstance(weights[DEFAULT_HCP_SUBJECT[0]], pandas.core.frame.DataFrame)
 
-        tracts = sb.get_connectivity_matrix(self.julich_parcellation_3_0, sb.HCP_COHORT, DEFAULT_HCP_SUBJECT,
+        tracts = sb.get_connectivity_matrix(self.julich_parcellation_3_1, sb.HCP_COHORT, DEFAULT_HCP_SUBJECT,
                                             sb.Component2Modality.TRACTS)
         assert len(tracts) > 0
         assert DEFAULT_HCP_SUBJECT[0] in tracts
         assert isinstance(tracts[DEFAULT_HCP_SUBJECT[0]], pandas.core.frame.DataFrame)
 
     def test_get_functional_connectivity_matrix(self, create_test_atlases_and_parcellations):
-        fcs, fcs_names = sb.get_functional_connectivity_matrix(self.julich_parcellation_3_0, sb.HCP_COHORT,
+        fcs, fcs_names = sb.get_functional_connectivity_matrix(self.julich_parcellation_3_1, sb.HCP_COHORT,
                                                                DEFAULT_HCP_SUBJECT[0])
         assert len(fcs) > 0
         assert len(fcs_names) > 0
@@ -219,7 +219,7 @@ class TestSiibraBase(BaseTestCase):
         assert hemi == [1, 0, 0]
 
     def test_get_regions_positions(self, create_test_atlases_and_parcellations):
-        region = self.julich_parcellation_3_0.get_region('v1')
+        region = self.julich_parcellation_3_1.get_region('v1')
         assert region.name == 'Area hOc1 (V1, 17, CalcS)'
         reg_coord = sb.get_regions_positions([region])[0]
         assert len(reg_coord) == 3
@@ -296,27 +296,27 @@ class TestSiibraBase(BaseTestCase):
         """
         Test retrieval of just structural connectivities
         """
-        scs, fcs = sb.get_connectivities_from_kg(self.human_atlas, self.julich_parcellation_3_0, sb.HCP_COHORT, '001')
+        scs, fcs = sb.get_connectivities_from_kg(self.human_atlas, self.julich_parcellation_3_1, sb.HCP_COHORT, '102311')
 
         assert len(scs) == 1
         assert not fcs
 
-        assert (list(scs.keys()) == ['001'])
-        assert isinstance(scs['001'], connectivity.Connectivity)
+        assert (list(scs.keys()) == ['102311'])
+        assert isinstance(scs['102311'], connectivity.Connectivity)
 
     def test_get_connectivities_from_kg_with_fc(self, create_test_atlases_and_parcellations):
         """
         Test retrieval of both structural and functional connectivities
         """
-        scs, fcs = sb.get_connectivities_from_kg(self.human_atlas, self.julich_parcellation_3_0, sb.HCP_COHORT, '001',
+        scs, fcs = sb.get_connectivities_from_kg(self.human_atlas, self.julich_parcellation_3_1, sb.HCP_COHORT, '102311',
                                                  True)
 
         assert len(scs) == 1
         assert len(fcs) == 1
-        assert len(fcs['001']) == 5
+        assert len(fcs['102311']) == 5
 
-        assert (list(scs.keys()) == ['001'])
-        assert isinstance(scs['001'], connectivity.Connectivity)
+        assert (list(scs.keys()) == ['102311'])
+        assert isinstance(scs['102311'], connectivity.Connectivity)
 
-        assert (list(fcs.keys()) == ['001'])
-        assert isinstance(fcs['001'][4], graph.ConnectivityMeasure)
+        assert (list(fcs.keys()) == ['102311'])
+        assert isinstance(fcs['102311'][4], graph.ConnectivityMeasure)

--- a/tvb_framework/tvb/tests/framework/adapters/creators/siibra_creator_test.py
+++ b/tvb_framework/tvb/tests/framework/adapters/creators/siibra_creator_test.py
@@ -38,7 +38,7 @@ class TestSiibraCreator(TransactionalTestCase):
 
     def test_happy_flow_launch(self, operation_factory):
         view_model = SiibraModel()
-        view_model.subject_ids = '010'
+        view_model.subject_ids = '106319'  # random pick from available subject in Julich 3.1
 
         operation = operation_factory(test_user=self.test_user, test_project=self.test_project)
         self.siibra_creator.extract_operation_data(operation)
@@ -51,11 +51,11 @@ class TestSiibraCreator(TransactionalTestCase):
 
         # connectivities
         assert conn_index.has_hemispheres_mask
-        assert conn_index.number_of_regions == 314
-        assert conn_index.subject == '010'
+        assert conn_index.number_of_regions == 414
+        assert conn_index.subject == '106319'
 
         # connectivity measures
         for conn_measure in conn_measure_indices:
-            assert conn_measure.parsed_shape == (314, 314)
-            assert conn_measure.subject == '010'
+            assert conn_measure.parsed_shape == (414, 414)
+            assert conn_measure.subject == '106319'
             assert conn_measure.fk_connectivity_gid == conn_index.gid


### PR DESCRIPTION
Tested with latest siibra version: [v1.0.1-alpha.8](https://github.com/FZJ-INM1-BDA/siibra-python/releases/tag/v1.0.1-alpha.8)

Added a new Parcellation in the parcellation list and updated defaults and help text accordingly.
Also updated the tests to use the newest Parcellation.