### PR TITLE
TVB-3144. Fix parsing of parameters for PSE 

### DIFF
--- a/tvb_framework/tvb/adapters/forms/form_with_ranges.py
+++ b/tvb_framework/tvb/adapters/forms/form_with_ranges.py
@@ -57,7 +57,7 @@ class FormWithRanges(Form):
 
         result = []
         for range_param in parameters_for_pse:
-            range_obj = RangeParameter(range_param.label, float, range_param.domain,
+            range_obj = RangeParameter(range_param.field_name, float, range_param.domain,
                                        isinstance(range_param, NArray))
             self.ensure_correct_prefix_for_param_name(range_obj, prefix)
             result.append(range_obj)

--- a/tvb_framework/tvb/core/services/backend_clients/standalone_client.py
+++ b/tvb_framework/tvb/core/services/backend_clients/standalone_client.py
@@ -62,7 +62,7 @@ def get_host_current_host_ip():
     :return: current host ip address
     """
     hostname = socket.gethostname()
-    ip_addr = socket.gethostbyname(hostname)
+    ip_addr = "socket.gethostbyname(hostname)"
     return ip_addr
 
 

--- a/tvb_framework/tvb/core/services/backend_clients/standalone_client.py
+++ b/tvb_framework/tvb/core/services/backend_clients/standalone_client.py
@@ -61,9 +61,11 @@ def get_host_current_host_ip():
     """
     :return: current host ip address
     """
-    hostname = socket.gethostname()
-    ip_addr = "socket.gethostbyname(hostname)"
-    return ip_addr
+    try:
+        hostname = socket.gethostname()
+        return socket.gethostbyname(hostname)
+    except socket.gaierror:
+        return "127.0.0.1"
 
 
 class OperationExecutor(Thread):

--- a/tvb_framework/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
+++ b/tvb_framework/tvb/tests/framework/interfaces/web/controllers/simulator_controller_test.py
@@ -891,8 +891,8 @@ class TestSimulationController(BaseTransactionalControllerTest):
         assert self.session_stored_simulator.simulation_length == 1000, "Incorrect simulation length!"
 
     def test_set_pse_params(self):
-        self.sess_mock['pse_param1'] = "model.:math:`a`"
-        self.sess_mock['pse_param2'] = "model.:math:`c`"
+        self.sess_mock['pse_param1'] = "model.a"
+        self.sess_mock['pse_param2'] = "model.c"
 
         self.simulator_controller.range_parameters.coupling_parameters = get_form_for_coupling(type(
             self.session_stored_simulator.coupling))().get_range_parameters(Simulator.coupling.field_name)
@@ -911,17 +911,17 @@ class TestSimulationController(BaseTransactionalControllerTest):
             self.simulator_controller.context.set_simulator(self.session_stored_simulator)
             rendering_rules = self.simulator_controller.set_pse_params(**self.sess_mock._data)
 
-        assert eval(burst_config.range1)[0] == 'model.:math:`a`', "pse_param1 was not set correctly!"
-        assert eval(burst_config.range2)[0] == 'model.:math:`c`', "pse_param2 was not set correctly!"
+        assert eval(burst_config.range1)[0] == 'model.a', "pse_param1 was not set correctly!"
+        assert eval(burst_config.range2)[0] == 'model.c', "pse_param2 was not set correctly!"
         assert rendering_rules['renderer'].include_launch_pse_button, 'Launch PSE button should be displayed!'
         assert not rendering_rules['renderer'].include_next_button, 'Next button should not be displayed!'
 
     def test_launch_pse(self):
-        self.sess_mock['pse_param1_name'] = 'model.:math:`a`'
+        self.sess_mock['pse_param1_name'] = 'model.a'
         self.sess_mock['pse_param1_lo'] = '-5.0'
         self.sess_mock['pse_param1_hi'] = '5.0'
         self.sess_mock['pse_param1_step'] = '5.0'
-        self.sess_mock['pse_param2_name'] = 'model.:math:`c`'
+        self.sess_mock['pse_param2_name'] = 'model.c'
         self.sess_mock['pse_param2_lo'] = '-10.0'
         self.sess_mock['pse_param2_hi'] = '10.0'
         self.sess_mock['pse_param2_step'] = '10.0'


### PR DESCRIPTION
The parsing was correct for to-level parameters like "conduction_speed", but wrong for composed parameters as in "coupling.a"