### PR TITLE
Changed nvar property to return count of state variables

### DIFF
--- a/tvb_library/tvb/simulator/models/base.py
+++ b/tvb_library/tvb/simulator/models/base.py
@@ -108,7 +108,7 @@ class Model(HasTraits):
     @property
     def nvar(self):
         """ The number of state variables in this model. """
-        return self._nvar
+        return len(self.state_variables)
 
     @property
     def nintvar(self):


### PR DESCRIPTION
Addresses Issue #549 on the-virtual-brain/tvb-root.

Previously, models could manually specify an `_nvar` inconsistent with their `state_variables`. `nvar` is now automatically derived from `len(state_variables)`, so these two can never mismatch.

The now redundant `_nvar` class attributes in subclasses are intentionally left untouched for a possible followup.

I also noticed `nintvar` may have a similar pattern so I am happy to open another PR for that if the team and Core Contributors would like that. Thank you! :D